### PR TITLE
Bugfix/TN-1196 Update command not working

### DIFF
--- a/src/content/manager/metadata.manager.ts
+++ b/src/content/manager/metadata.manager.ts
@@ -4,7 +4,6 @@ import { ManagerConfig } from "../../interfaces/manager-config.interface";
 export class MetadataManager extends BaseManager {
     private static BASE_URL = "/semantic-layer/api/yaml-metadata";
     private static MODEL_BASE_URL = "/semantic-layer/api/layer";
-    private static MODEL_UPDATE_URL = "/semantic-layer/api/metadata";
     private _id: string;
     private _content: string;
 
@@ -28,10 +27,10 @@ export class MetadataManager extends BaseManager {
         return {
             pushUrl: this.profile.team.replace(/\/?$/, `${MetadataManager.BASE_URL}`),
             pullUrl: this.profile.team.replace(/\/?$/, `${MetadataManager.MODEL_BASE_URL}/${this.id}`),
-            updateUrl: this.profile.team.replace(/\/?$/, `${MetadataManager.MODEL_UPDATE_URL}/${this.id}`),
+            updateUrl: this.profile.team.replace(/\/?$/, `${MetadataManager.BASE_URL}/${this.id}`),
             exportFileName: "metadata_" + this.id + ".yaml",
             onPushSuccessMessage: (data: any): string => {
-                return "Metadata was pushed successfully. New ID: " + data.id;
+                return "Metadata was pushed successfully. New ID: " + data.metadataId;
             },
             onUpdateSuccessMessage: (): string => {
                 return "Metadata was updated successfully!";


### PR DESCRIPTION
- fix TN-1196 change endpoint called when updating a semantic model

- fix TN-1196 show metadataId on push success because it was showing undefined