### PR TITLE
feat: [DV-2894] add a new command to import CTP files

### DIFF
--- a/src/commands/ctp.command.ts
+++ b/src/commands/ctp.command.ts
@@ -1,0 +1,11 @@
+import { ContentService } from "../services/content.service";
+import { CTPManagerFactory } from "../content/factory/ctp-manager.factory";
+
+export class CTPCommand {
+    private contentService = new ContentService();
+    private cTPManagerFactory = new CTPManagerFactory();
+
+    public async pushCTPFile(profile: string, filename: string, password: string) {
+        await this.contentService.push(profile, this.cTPManagerFactory.createManager(filename, password));
+    }
+}

--- a/src/commands/ctp.command.ts
+++ b/src/commands/ctp.command.ts
@@ -3,9 +3,9 @@ import { CTPManagerFactory } from "../content/factory/ctp-manager.factory";
 
 export class CTPCommand {
     private contentService = new ContentService();
-    private cTPManagerFactory = new CTPManagerFactory();
+    private ctpManagerFactory = new CTPManagerFactory();
 
     public async pushCTPFile(profile: string, filename: string, password: string) {
-        await this.contentService.push(profile, this.cTPManagerFactory.createManager(filename, password));
+        await this.contentService.push(profile, this.ctpManagerFactory.createManager(filename, password));
     }
 }

--- a/src/content-cli-push.ts
+++ b/src/content-cli-push.ts
@@ -5,6 +5,7 @@ import { WorkflowCommand } from "./commands/workflow.command";
 import { DataPoolCommand } from "./commands/data-pool.command";
 import { AssetCommand } from "./commands/asset.command";
 import { PackageCommand } from "./commands/package.command";
+import { CTPCommand } from "./commands/ctp.command";
 
 var program = require("commander");
 
@@ -18,6 +19,21 @@ class Push {
             .requiredOption("-f, --file <file>", "The file you want to push")
             .action(async cmd => {
                 await new AnalysisCommand().pushAnalysis(cmd.profile, cmd.workspaceId, cmd.file);
+                process.exit();
+            });
+
+        return program;
+    }
+    
+    public static ctp(program) {
+        program
+            .command("ctp")
+            .description("Command to push a .ctp (Celonis 4 transport file) to create a package")
+            .option("-p, --profile <profile>", "Profile which you want to use to push the analysis")
+            .requiredOption("-f, --file <file>", "The .ctp file you want to push")
+            .requiredOption("--password <password>", "The password used for extracting the .ctp file")
+            .action(async cmd => {
+                await new CTPCommand().pushCTPFile(cmd.profile, cmd.file, cmd.password);
                 process.exit();
             });
 
@@ -166,6 +182,7 @@ class Push {
 }
 
 Push.analysis(program);
+Push.ctp(program);
 Push.skill(program);
 Push.widget(program);
 Push.workflow(program);

--- a/src/content/factory/ctp-manager.factory.ts
+++ b/src/content/factory/ctp-manager.factory.ts
@@ -1,0 +1,23 @@
+import * as fs from "fs";
+import * as path from "path";
+import { FatalError, logger } from "../../util/logger";
+import { Stream } from "stream";
+import { CTPManager } from "../manager/ctp.manager";
+
+export class CTPManagerFactory {
+    public createManager(filename: string, password: string): CTPManager {
+        const ctpManager = new CTPManager();
+        ctpManager.password = password;
+        if (filename !== null) {
+            ctpManager.content = this.readFile(filename);
+        }
+        return ctpManager;
+    }
+
+    private readFile(filename: string): Stream {
+        if (!fs.existsSync(path.resolve(process.cwd(), filename))) {
+            logger.error(new FatalError("The provided file does not exit"));
+        }
+        return fs.createReadStream(path.resolve(process.cwd(), filename));
+    }
+}

--- a/src/content/manager/ctp.manager.ts
+++ b/src/content/manager/ctp.manager.ts
@@ -1,0 +1,46 @@
+import { BaseManager } from "./base.manager";
+import { ManagerConfig } from "../../interfaces/manager-config.interface";
+
+export class CTPManager extends BaseManager {
+    private static BASE_URL = "/process-analytics/import/ctp";
+    private _content: any;
+    private _password: string;
+
+    public get content(): any {
+        return this._content;
+    }
+
+    public set content(value: any) {
+        this._content = value;
+    }   
+    
+    public get password(): string {
+        return this._password;
+    }
+
+    public set password(value: string) {
+        this._password = value;
+    }
+    public getConfig(): ManagerConfig {
+            const baseUrl = CTPManager.BASE_URL;            
+            return {
+                pushUrl: this.profile.team.replace(/\/?$/, `${baseUrl}`),
+                onPushSuccessMessage: (): string => {
+                    return "CTP File was pushed successfully";
+                },
+            };
+    }    
+
+    public getBody(): any {
+        return {
+            formData: {
+                file: this.content,
+                password: this.password
+            },
+        };
+    }
+
+    protected getSerializedFileContent(data: any): string {
+        return JSON.stringify(data);
+    }
+}


### PR DESCRIPTION
The new command is used for importing .ctp file (celonis 4 zipped files). The new command sends the ctp file and the password to process-analytics where the file will be extracted and used to generate a new package with analysis assets 