### PR TITLE
chore TN-1777 bump patch version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celonis/content-cli",
-  "version": "0.0.40",
+  "version": "0.0.41",
   "description": "CLI Tools for Celonis Content",
   "main": "content-cli.js",
   "bin": {


### PR DESCRIPTION
because package failed to publish https://github.com/celonis/content-cli/actions/runs/493185691