### PR TITLE
Fix publish action authentication issue

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -20,7 +20,6 @@ jobs:
           node-version: '10.17.0'
           registry-url: https://npm.pkg.github.com/celonis
           scope: '@celonis'
-          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Yarn Install
         run: yarn install
@@ -35,6 +34,8 @@ jobs:
           cp LICENSE dist/LICENSE
 
       - name: Publish to Github Registry
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: cd dist/ && npm publish
 
       - name: Setup publish to Npm Registry
@@ -43,9 +44,10 @@ jobs:
           node-version: '10.17.0'
           registry-url: https://registry.npmjs.org/
           scope: '@celonis'
-          token: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish to Npm Registry
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npm publish --access public
 
       - uses: actions/checkout@master

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 npm-debug.log
 /.scannerwork
 
+
 *.scss.ngstyle.ts
 *.scss.shim.ngstyle.ts
 *.ngsummary.json

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celonis/content-cli",
-  "version": "0.0.49",
+  "version": "0.0.50",
   "description": "CLI Tool to help manage content in Celonis EMS",
   "main": "content-cli.js",
   "bin": {


### PR DESCRIPTION
#### Description

Moved registry authentication with NODE_AUTH_TOKEN environment variable. This way was also documented on the setup-node action README [here](https://github.com/actions/setup-node/tree/v2.1.5#usage)

#### Checklist

- [x] I have self-reviewed this PR
- [ ] I have tested the change and proved that it works in different scenarios
- [ ] I have updated docs if needed
