### PR TITLE
fix TN Publish compiled package to npmjs

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Publish to Npm Registry
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npm publish --access public
+        run: cd dist/ && npm publish --access public
 
       - uses: actions/checkout@master
         name: Checkout Master

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ content-cli pull package -p team1.cluster1 --key my-package
 content-cli push package -p team2.cluster2 --file package_my-package.zip
 ```
 
-A more comprehensive list of Content CLI capabilities can be found on the following [documentation](DOCUMENTATION.md). 
+A more comprehensive list of Content CLI capabilities can be found on the following [documentation](https://github.com/celonis/content-cli/blob/master/DOCUMENTATION.md). 
 
 You can still explore the full capabilities of Content CLI and the list of options for the different commands by using the `-h` option in your command.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celonis/content-cli",
-  "version": "0.0.50",
+  "version": "0.0.51",
   "description": "CLI Tool to help manage content in Celonis EMS",
   "main": "content-cli.js",
   "bin": {


### PR DESCRIPTION
#### Description

Updated publish to action to change directory to build folder before publishing to npmjs.
Updated documentation link in README file

#### Checklist

- [ ] I have self-reviewed this PR
- [ ] I have tested the change and proved that it works in different scenarios
- [ ] I have updated docs if needed
