### PR TITLE
CPMBR-2980 Add extra params to ctp push command

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celonis/content-cli",
-  "version": "0.0.51",
+  "version": "0.0.52",
   "description": "CLI Tool to help manage content in Celonis EMS",
   "main": "content-cli.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celonis/content-cli",
-  "version": "0.0.52",
+  "version": "0.0.53",
   "description": "CLI Tool to help manage content in Celonis EMS",
   "main": "content-cli.js",
   "bin": {

--- a/src/commands/ctp.command.ts
+++ b/src/commands/ctp.command.ts
@@ -12,7 +12,6 @@ export class CTPCommand {
         password: string,
         pushAnalysis: boolean,
         pushDataModels: boolean,
-        isGlobalPool: boolean,
         existingPoolId: string,
         globalPoolName: string
     ): Promise<void> {
@@ -24,23 +23,21 @@ export class CTPCommand {
         }
 
         if (pushDataModels) {
-            this.validateParamsForDataModelPush(isGlobalPool, globalPoolName);
+            this.validateParamsForDataModelPush(existingPoolId, globalPoolName);
             await this.contentService.push(
                 profile,
-                this.ctpManagerFactory.createCtpDataModelManager(
-                    filename,
-                    password,
-                    isGlobalPool,
-                    existingPoolId,
-                    globalPoolName
-                )
+                this.ctpManagerFactory.createCtpDataModelManager(filename, password, existingPoolId, globalPoolName)
             );
         }
     }
 
-    private validateParamsForDataModelPush(isGlobalPool: boolean, globalPoolName: string): void {
-        if (isGlobalPool && globalPoolName == null) {
-            logger.error(new FatalError("You should specify the pool name along with --globalPool option"));
+    private validateParamsForDataModelPush(existingPoolId: string, globalPoolName: string): void {
+        if (existingPoolId != null && globalPoolName != null) {
+            logger.error(
+                new FatalError(
+                    "You should specify only one of those options --globalPoolName, --existingPoolId, they are mutual exclusive"
+                )
+            );
         }
     }
 }

--- a/src/commands/ctp.command.ts
+++ b/src/commands/ctp.command.ts
@@ -1,5 +1,6 @@
 import { ContentService } from "../services/content.service";
 import { CTPManagerFactory } from "../content/factory/ctp-manager.factory";
+import { FatalError, logger } from "../util/logger";
 
 export class CTPCommand {
     private contentService = new ContentService();
@@ -10,7 +11,10 @@ export class CTPCommand {
         filename: string,
         password: string,
         pushAnalysis: boolean,
-        pushDataModels: boolean
+        pushDataModels: boolean,
+        isGlobalPool: boolean,
+        existingPoolId: string,
+        globalPoolName: string
     ): Promise<void> {
         if (pushAnalysis) {
             await this.contentService.push(
@@ -20,10 +24,23 @@ export class CTPCommand {
         }
 
         if (pushDataModels) {
+            this.validateParamsForDataModelPush(isGlobalPool, globalPoolName);
             await this.contentService.push(
                 profile,
-                this.ctpManagerFactory.createCtpDataModelManager(filename, password)
+                this.ctpManagerFactory.createCtpDataModelManager(
+                    filename,
+                    password,
+                    isGlobalPool,
+                    existingPoolId,
+                    globalPoolName
+                )
             );
+        }
+    }
+
+    private validateParamsForDataModelPush(isGlobalPool: boolean, globalPoolName: string): void {
+        if (isGlobalPool && globalPoolName == null) {
+            logger.error(new FatalError("You should specify the pool name along with --globalPool option"));
         }
     }
 }

--- a/src/content-cli-push.ts
+++ b/src/content-cli-push.ts
@@ -32,9 +32,21 @@ class Push {
             .option("-p, --profile <profile>", "Profile which you want to use to push the analysis")
             .option("-a, --pushAnalysis", "Specify this option if you want to push analysis from the CTP file")
             .option("-d, --pushDataModels", "Specify this option if you want to push data models from the CTP file")
-            .option("--globalPool", "", false)
-            .option("--globalPoolName <globalPoolName>", "", null)
-            .option("--existingPoolId <existingPoolId>", "", null)
+            .option(
+                "--globalPool",
+                "Specify this option along with --globalPoolName if you want to push all Data models into one newly created pool",
+                false
+            )
+            .option(
+                "--globalPoolName <globalPoolName>",
+                "Specify this option along with --globalPool to set the name of the pool to be created",
+                null
+            )
+            .option(
+                "--existingPoolId <existingPoolId>",
+                "Specify this option if you want to push all Data models into one already existing pool with provided ID",
+                null
+            )
             .requiredOption("-f, --file <file>", "The .ctp file you want to push")
             .requiredOption("--password <password>", "The password used for extracting the .ctp file")
             .action(async cmd => {

--- a/src/content-cli-push.ts
+++ b/src/content-cli-push.ts
@@ -33,13 +33,8 @@ class Push {
             .option("-a, --pushAnalysis", "Specify this option if you want to push analysis from the CTP file")
             .option("-d, --pushDataModels", "Specify this option if you want to push data models from the CTP file")
             .option(
-                "--globalPool",
-                "Specify this option along with --globalPoolName if you want to push all Data models into one newly created pool",
-                false
-            )
-            .option(
                 "--globalPoolName <globalPoolName>",
-                "Specify this option along with --globalPool to set the name of the pool to be created",
+                "Specify this option if you want to push all Data models into one newly created pool along with value to set the name of the pool to be created",
                 null
             )
             .option(
@@ -56,7 +51,6 @@ class Push {
                     cmd.password,
                     cmd.pushAnalysis,
                     cmd.pushDataModels,
-                    cmd.globalPool,
                     cmd.existingPoolId,
                     cmd.globalPoolName
                 );

--- a/src/content-cli-push.ts
+++ b/src/content-cli-push.ts
@@ -32,6 +32,9 @@ class Push {
             .option("-p, --profile <profile>", "Profile which you want to use to push the analysis")
             .option("-a, --pushAnalysis", "Specify this option if you want to push analysis from the CTP file")
             .option("-d, --pushDataModels", "Specify this option if you want to push data models from the CTP file")
+            .option("--globalPool", "", false)
+            .option("--globalPoolName <globalPoolName>", "", null)
+            .option("--existingPoolId <existingPoolId>", "", null)
             .requiredOption("-f, --file <file>", "The .ctp file you want to push")
             .requiredOption("--password <password>", "The password used for extracting the .ctp file")
             .action(async cmd => {
@@ -40,7 +43,10 @@ class Push {
                     cmd.file,
                     cmd.password,
                     cmd.pushAnalysis,
-                    cmd.pushDataModels
+                    cmd.pushDataModels,
+                    cmd.globalPool,
+                    cmd.existingPoolId,
+                    cmd.globalPoolName
                 );
                 process.exit();
             });

--- a/src/content/factory/ctp-manager.factory.ts
+++ b/src/content/factory/ctp-manager.factory.ts
@@ -15,11 +15,10 @@ export class CTPManagerFactory {
     public createCtpDataModelManager(
         filename: string,
         password: string,
-        isGlobalPool: boolean,
         existingPoolId: string,
         globalPoolName: string
     ): CtpManager {
-        const ctpManager = new CtpDataModelManager(existingPoolId, isGlobalPool, globalPoolName);
+        const ctpManager = new CtpDataModelManager(existingPoolId, globalPoolName);
         return this.initManager(ctpManager, filename, password);
     }
 

--- a/src/content/factory/ctp-manager.factory.ts
+++ b/src/content/factory/ctp-manager.factory.ts
@@ -12,8 +12,14 @@ export class CTPManagerFactory {
         return this.initManager(ctpManager, filename, password);
     }
 
-    public createCtpDataModelManager(filename: string, password: string): CtpManager {
-        const ctpManager = new CtpDataModelManager();
+    public createCtpDataModelManager(
+        filename: string,
+        password: string,
+        isGlobalPool: boolean,
+        existingPoolId: string,
+        globalPoolName: string
+    ): CtpManager {
+        const ctpManager = new CtpDataModelManager(existingPoolId, isGlobalPool, globalPoolName);
         return this.initManager(ctpManager, filename, password);
     }
 

--- a/src/content/manager/ctp.analysis.manager.ts
+++ b/src/content/manager/ctp.analysis.manager.ts
@@ -6,4 +6,13 @@ export class CtpAnalysisManager extends CtpManager {
     protected getUrl(): string {
         return CtpAnalysisManager.BASE_URL;
     }
+
+    public getBody(): any {
+        return {
+            formData: {
+                file: this.content,
+                password: this.password,
+            },
+        };
+    }
 }

--- a/src/content/manager/ctp.datamodel.manager.ts
+++ b/src/content/manager/ctp.datamodel.manager.ts
@@ -2,8 +2,33 @@ import { CtpManager } from "./ctp.manager";
 
 export class CtpDataModelManager extends CtpManager {
     private static BASE_URL = "/cpm-ems-migrator/migration/api/ctp";
+    private readonly existingPoolId: string;
+    private readonly isGlobalPool: boolean;
+    private readonly globalPoolName: string;
+
+    constructor(existingPoolId: string, isGlobalPool: boolean, globalPoolName: string) {
+        super();
+        this.existingPoolId = existingPoolId;
+        this.isGlobalPool = isGlobalPool;
+        this.globalPoolName = globalPoolName;
+    }
 
     protected getUrl(): string {
         return CtpDataModelManager.BASE_URL;
+    }
+
+    protected getBody(): object {
+        return {
+            formData: {
+                file: this.content,
+                transport: JSON.stringify({
+                    password: this.password,
+                    dataSourceId: null,
+                    dataPoolId: this.existingPoolId,
+                    isGlobalPool: this.existingPoolId != null ? true : this.isGlobalPool,
+                    globalPoolName: this.globalPoolName,
+                }),
+            },
+        };
     }
 }

--- a/src/content/manager/ctp.datamodel.manager.ts
+++ b/src/content/manager/ctp.datamodel.manager.ts
@@ -3,13 +3,11 @@ import { CtpManager } from "./ctp.manager";
 export class CtpDataModelManager extends CtpManager {
     private static BASE_URL = "/cpm-ems-migrator/migration/api/ctp";
     private readonly existingPoolId: string;
-    private readonly isGlobalPool: boolean;
     private readonly globalPoolName: string;
 
-    constructor(existingPoolId: string, isGlobalPool: boolean, globalPoolName: string) {
+    constructor(existingPoolId: string, globalPoolName: string) {
         super();
         this.existingPoolId = existingPoolId;
-        this.isGlobalPool = isGlobalPool;
         this.globalPoolName = globalPoolName;
     }
 
@@ -23,9 +21,7 @@ export class CtpDataModelManager extends CtpManager {
                 file: this.content,
                 transport: JSON.stringify({
                     password: this.password,
-                    dataSourceId: null,
-                    dataPoolId: this.existingPoolId,
-                    isGlobalPool: this.existingPoolId != null ? true : this.isGlobalPool,
+                    existingPoolId: this.existingPoolId,
                     globalPoolName: this.globalPoolName,
                 }),
             },

--- a/src/content/manager/ctp.manager.ts
+++ b/src/content/manager/ctp.manager.ts
@@ -31,15 +31,6 @@ export abstract class CtpManager extends BaseManager {
         };
     }
 
-    public getBody(): any {
-        return {
-            formData: {
-                file: this.content,
-                password: this.password,
-            },
-        };
-    }
-
     protected getSerializedFileContent(data: any): string {
         return JSON.stringify(data);
     }


### PR DESCRIPTION
#### Description

##### Motivation

According to the new business requirements regarding the CPM to EMS migration we decided to add a possibility to control whether user wants to import all data models into several different pools or into one. 

##### Actual changes

Added following `push ctp` command options:
1. `--globalPoolName <name>` indicates whether user wants to import all data models from CTP file **inside one newly created data pool**
2. `--existingPoolId <ID>` indicates whether user wants to import all data models from CTP file **inside one already existing data pool**

#### Checklist

- [x] I have self-reviewed this PR
- [x] I have tested the change and proved that it works in different scenarios
- [x] I have updated docs if needed
