### PR TITLE
fix: Add spaceKey when pushing CTP file using content-cli.

### DIFF
--- a/src/commands/ctp.command.ts
+++ b/src/commands/ctp.command.ts
@@ -13,12 +13,13 @@ export class CTPCommand {
         pushAnalysis: boolean,
         pushDataModels: boolean,
         existingPoolId: string,
-        globalPoolName: string
+        globalPoolName: string,
+        spaceKey: string
     ): Promise<void> {
         if (pushAnalysis) {
             await this.contentService.push(
                 profile,
-                this.ctpManagerFactory.createCtpAnalysisManager(filename, password)
+                this.ctpManagerFactory.createCtpAnalysisManager(filename, password, spaceKey)
             );
         }
 

--- a/src/content-cli-push.ts
+++ b/src/content-cli-push.ts
@@ -42,6 +42,11 @@ class Push {
                 "Specify this option if you want to push all Data models into one already existing pool with provided ID",
                 null
             )
+            .option(
+                "-s, --spaceKey <spaceKey>",
+                "The key of the destination space where the analyses from .ctp file will be created.",
+                ""
+            )
             .requiredOption("-f, --file <file>", "The .ctp file you want to push")
             .requiredOption("--password <password>", "The password used for extracting the .ctp file")
             .action(async cmd => {
@@ -52,7 +57,8 @@ class Push {
                     cmd.pushAnalysis,
                     cmd.pushDataModels,
                     cmd.existingPoolId,
-                    cmd.globalPoolName
+                    cmd.globalPoolName,
+                    cmd.spaceKey
                 );
                 process.exit();
             });

--- a/src/content/factory/ctp-manager.factory.ts
+++ b/src/content/factory/ctp-manager.factory.ts
@@ -7,9 +7,9 @@ import { CtpManager } from "../manager/ctp.manager";
 import { CtpDataModelManager } from "../manager/ctp.datamodel.manager";
 
 export class CTPManagerFactory {
-    public createCtpAnalysisManager(filename: string, password: string): CtpManager {
+    public createCtpAnalysisManager(filename: string, password: string, spaceKey: string): CtpManager {
         const ctpManager = new CtpAnalysisManager();
-        return this.initManager(ctpManager, filename, password);
+        return this.initManager(ctpManager, filename, password, spaceKey);
     }
 
     public createCtpDataModelManager(
@@ -22,8 +22,9 @@ export class CTPManagerFactory {
         return this.initManager(ctpManager, filename, password);
     }
 
-    private initManager(ctpManager: CtpManager, filename: string, password: string): CtpManager {
+    private initManager(ctpManager: CtpManager, filename: string, password: string, spaceKey?: string): CtpManager {
         ctpManager.password = password;
+        ctpManager.spaceKey = spaceKey;
         if (filename !== null) {
             ctpManager.content = this.readFile(filename);
         }

--- a/src/content/manager/ctp.analysis.manager.ts
+++ b/src/content/manager/ctp.analysis.manager.ts
@@ -12,6 +12,7 @@ export class CtpAnalysisManager extends CtpManager {
             formData: {
                 file: this.content,
                 password: this.password,
+                spaceId: this.spaceKey,
             },
         };
     }

--- a/src/content/manager/ctp.manager.ts
+++ b/src/content/manager/ctp.manager.ts
@@ -4,6 +4,7 @@ import { ManagerConfig } from "../../interfaces/manager-config.interface";
 export abstract class CtpManager extends BaseManager {
     protected _content: any;
     protected _password: string;
+    protected _spaceKey?: string;
 
     public get content(): any {
         return this._content;
@@ -19,6 +20,14 @@ export abstract class CtpManager extends BaseManager {
 
     public set password(value: string) {
         this._password = value;
+    }
+
+    public get spaceKey(): string {
+        return this._spaceKey;
+    }
+
+    public set spaceKey(value: string) {
+        this._spaceKey = value;
     }
 
     public getConfig(): ManagerConfig {


### PR DESCRIPTION
#### Description

The PR includes the changes to include optional spaceKey while pushing CTP file to Studio. So, here it is an optional field, to provide the spaceKey in the content-cli push ctp command, if you pass spaceKey it pushes the CTP file to that space, else if you don't provide the spaceKey it pushes the CTP file to default space.

#### Checklist

- [x] I have self-reviewed this PR
- [x] I have tested the change and proved that it works in different scenarios
- [x] I have updated docs if needed
