### PR TITLE
Studio manager migration

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celonis/content-cli",
-  "version": "0.0.49",
+  "version": "0.1.3",
   "description": "CLI Tool to help manage content in Celonis EMS",
   "main": "content-cli.js",
   "bin": {

--- a/src/commands/widget.command.ts
+++ b/src/commands/widget.command.ts
@@ -5,10 +5,15 @@ export class WidgetCommand {
     private contentService = new ContentService();
     private widgetManagerFactory = new WidgetManagerFactory();
 
-    public async pushWidget(profile: string, tenantIndependent: boolean, userSpecific: boolean): Promise<void> {
+    public async pushWidget(
+        profile: string,
+        tenantIndependent: boolean,
+        userSpecific: boolean,
+        activate: boolean
+    ): Promise<void> {
         await this.contentService.push(
             profile,
-            this.widgetManagerFactory.createManager(tenantIndependent, userSpecific)
+            this.widgetManagerFactory.createManager(tenantIndependent, userSpecific, activate)
         );
     }
 }

--- a/src/content-cli-push.ts
+++ b/src/content-cli-push.ts
@@ -70,9 +70,15 @@ class Push {
             .option("-p, --profile <profile>", "Profile which you want to use to push the widget")
             .option("--tenantIndependent", "Upload widget tenant independently")
             .option("--userSpecific", "Upload widget only for the user in the provided api token")
+            .option("--activate", "Activate widget on upload")
             .option("--packageManager", "Upload widget to package manager (deprecated)") // Deprecated
             .action(async cmd => {
-                await new WidgetCommand().pushWidget(cmd.profile, !!cmd.tenantIndependent, !!cmd.userSpecific);
+                await new WidgetCommand().pushWidget(
+                    cmd.profile,
+                    !!cmd.tenantIndependent,
+                    !!cmd.userSpecific,
+                    !!cmd.activate
+                );
                 process.exit();
             });
 

--- a/src/content/factory/widget-manager.factory.ts
+++ b/src/content/factory/widget-manager.factory.ts
@@ -10,6 +10,7 @@ interface Manifest {
     name: string;
     bundle: string;
     externalResource: string;
+    version: string;
     widgets: ManifestWidget[];
 }
 
@@ -19,11 +20,16 @@ interface ManifestWidget {
 }
 
 export class WidgetManagerFactory {
-    public createManager(tenantIndependent: boolean = false, userSpecific: boolean = false): WidgetManager {
+    public createManager(
+        tenantIndependent: boolean = false,
+        userSpecific: boolean = false,
+        activate: boolean = false
+    ): WidgetManager {
         const widgetManager = new WidgetManager();
         widgetManager.content = this.readContent();
         widgetManager.tenantIndependent = tenantIndependent;
         widgetManager.userSpecific = userSpecific;
+        widgetManager.activate = activate;
         return widgetManager;
     }
 
@@ -86,6 +92,10 @@ export class WidgetManagerFactory {
 
         if (!fs.existsSync(manifest.bundle)) {
             logger.error(new FatalError("Missing bundle."));
+        }
+
+        if (!manifest.version) {
+            logger.error(new FatalError("Missing version."));
         }
 
         if (

--- a/src/content/manager/widget.manager.ts
+++ b/src/content/manager/widget.manager.ts
@@ -9,6 +9,7 @@ export class WidgetManager extends BaseManager {
     private _content: any;
     private _tenantIndependent = false;
     private _userSpecific = false;
+    private _activate = false;
 
     public get content(): any {
         return this._content;
@@ -34,6 +35,14 @@ export class WidgetManager extends BaseManager {
         this._userSpecific = value;
     }
 
+    public get activate(): any {
+        return this._activate;
+    }
+
+    public set activate(value: any) {
+        this._activate = value;
+    }
+
     public getConfig(): ManagerConfig {
         const baseUrl = WidgetManager.STUDIO_MANAGER_BASE_URL;
         const widgetUrl = this.userSpecific
@@ -53,6 +62,7 @@ export class WidgetManager extends BaseManager {
         return {
             formData: {
                 file: this.content,
+                activate: String(this.activate),
             },
         };
     }

--- a/src/content/manager/widget.manager.ts
+++ b/src/content/manager/widget.manager.ts
@@ -2,7 +2,7 @@ import { BaseManager } from "./base.manager";
 import { ManagerConfig } from "../../interfaces/manager-config.interface";
 
 export class WidgetManager extends BaseManager {
-    private static PACKAGE_MANAGER_BASE_URL = "/package-manager";
+    private static STUDIO_MANAGER_BASE_URL = "/studio-manager";
     private static WIDGET_API = "/api/widgets/upload";
     private static WIDGET_TENANT_INDEPENDENT_API = "/api/widgets/upload-tenant-independently";
     private static WIDGET_USER_SPECIFIC_API = "/api/widgets/upload-user";
@@ -35,7 +35,7 @@ export class WidgetManager extends BaseManager {
     }
 
     public getConfig(): ManagerConfig {
-        const baseUrl = WidgetManager.PACKAGE_MANAGER_BASE_URL;
+        const baseUrl = WidgetManager.STUDIO_MANAGER_BASE_URL;
         const widgetUrl = this.userSpecific
             ? WidgetManager.WIDGET_USER_SPECIFIC_API
             : this.tenantIndependent


### PR DESCRIPTION
#### Description

In preparation for using studio manager for widget administration, widget should be pushed to studio manager instead of the package manager. 

Extra flag is added for activation.

#### Checklist

- [ ] I have self-reviewed this PR
- [ ] I have tested the change and proved that it works in different scenarios
- [ ] I have updated docs if needed
