### PR TITLE
implement authentication by application key

### DIFF
--- a/src/commands/profile.command.ts
+++ b/src/commands/profile.command.ts
@@ -12,7 +12,7 @@ export class ProfileCommand {
         profile.name = await QuestionService.ask("Name of the profile: ");
         profile.team = await QuestionService.ask("Your team (please provide the full url): ");
         profile.apiToken = await QuestionService.ask("Your api token: ");
-        await ProfileValidator.validateProfile(profile);
+        profile.authenticationType = await ProfileValidator.validateProfile(profile);
         this.profileService.storeProfile(profile);
         if (setAsDefault) {
             await this.makeDefaultProfile(profile.name);

--- a/src/content/manager/base.manager.ts
+++ b/src/content/manager/base.manager.ts
@@ -21,7 +21,7 @@ export abstract class BaseManager {
     public async pull(): Promise<any> {
         return new Promise<any>((resolve, reject) => {
             this.httpClientService
-                .authenticate(this._profile)
+                .buildRequestHeadersWithAuthentication(this._profile)
                 .then(headers => {
                     return this.httpClientService.pullData(this.getConfig().pullUrl, headers);
                 })
@@ -45,7 +45,7 @@ export abstract class BaseManager {
     public async pullFile(): Promise<any> {
         return new Promise<any>((resolve, reject) => {
             this.httpClientService
-                .authenticate(this._profile)
+                .buildRequestHeadersWithAuthentication(this._profile)
                 .then(headers => {
                     return this.httpClientService.pullFileData(this.getConfig().pullUrl, headers);
                 })
@@ -64,7 +64,7 @@ export abstract class BaseManager {
     public async push(): Promise<any> {
         return new Promise<any>((resolve, reject) => {
             this.httpClientService
-                .authenticate(this._profile)
+                .buildRequestHeadersWithAuthentication(this._profile)
                 .then(headers => {
                     return this.httpClientService.pushData(this.getConfig().pushUrl, headers, this.getBody());
                 })
@@ -82,7 +82,7 @@ export abstract class BaseManager {
     public async update(): Promise<any> {
         return new Promise<any>((resolve, reject) => {
             this.httpClientService
-                .authenticate(this._profile)
+                .buildRequestHeadersWithAuthentication(this._profile)
                 .then(headers => {
                     return this.httpClientService.updateData(this.getConfig().updateUrl, headers, this.getBody());
                 })
@@ -100,7 +100,7 @@ export abstract class BaseManager {
     public async findAll(): Promise<any> {
         return new Promise<any>((resolve, reject) => {
             this.httpClientService
-                .authenticate(this._profile)
+                .buildRequestHeadersWithAuthentication(this._profile)
                 .then(headers => {
                     return this.httpClientService.findAll(this.getConfig().findAllUrl, headers);
                 })

--- a/src/content/manager/base.manager.ts
+++ b/src/content/manager/base.manager.ts
@@ -21,7 +21,10 @@ export abstract class BaseManager {
     public async pull(): Promise<any> {
         return new Promise<any>((resolve, reject) => {
             this.httpClientService
-                .pullData(this.getConfig().pullUrl, this._profile)
+                .authenticate(this._profile)
+                .then(headers => {
+                    return this.httpClientService.pullData(this.getConfig().pullUrl, headers);
+                })
                 .then(data => {
                     try {
                         const filename = this.writeToFile(data);
@@ -42,7 +45,10 @@ export abstract class BaseManager {
     public async pullFile(): Promise<any> {
         return new Promise<any>((resolve, reject) => {
             this.httpClientService
-                .pullFileData(this.getConfig().pullUrl, this._profile)
+                .authenticate(this._profile)
+                .then(headers => {
+                    return this.httpClientService.pullFileData(this.getConfig().pullUrl, headers);
+                })
                 .then(data => {
                     const filename = this.writeStreamToFile(data);
                     logger.info("File downloaded successfully. New filename: " + filename);
@@ -58,7 +64,10 @@ export abstract class BaseManager {
     public async push(): Promise<any> {
         return new Promise<any>((resolve, reject) => {
             this.httpClientService
-                .pushData(this.getConfig().pushUrl, this._profile, this.getBody())
+                .authenticate(this._profile)
+                .then(headers => {
+                    return this.httpClientService.pushData(this.getConfig().pushUrl, headers, this.getBody());
+                })
                 .then(data => {
                     logger.info(this.getConfig().onPushSuccessMessage(data));
                     resolve(data);
@@ -73,7 +82,10 @@ export abstract class BaseManager {
     public async update(): Promise<any> {
         return new Promise<any>((resolve, reject) => {
             this.httpClientService
-                .updateData(this.getConfig().updateUrl, this._profile, this.getBody())
+                .authenticate(this._profile)
+                .then(headers => {
+                    return this.httpClientService.updateData(this.getConfig().updateUrl, headers, this.getBody());
+                })
                 .then(data => {
                     logger.info(this.getConfig().onUpdateSuccessMessage());
                     resolve(data);
@@ -88,7 +100,10 @@ export abstract class BaseManager {
     public async findAll(): Promise<any> {
         return new Promise<any>((resolve, reject) => {
             this.httpClientService
-                .findAll(this.getConfig().findAllUrl, this._profile)
+                .authenticate(this._profile)
+                .then(headers => {
+                    return this.httpClientService.findAll(this.getConfig().findAllUrl, headers);
+                })
                 .then(data => {
                     this.getConfig().onFindAll(data);
                     resolve(data);

--- a/src/content/manager/base.manager.ts
+++ b/src/content/manager/base.manager.ts
@@ -21,10 +21,7 @@ export abstract class BaseManager {
     public async pull(): Promise<any> {
         return new Promise<any>((resolve, reject) => {
             this.httpClientService
-                .buildRequestHeadersWithAuthentication(this._profile)
-                .then(headers => {
-                    return this.httpClientService.pullData(this.getConfig().pullUrl, headers);
-                })
+                .pullData(this.getConfig().pullUrl, this._profile)
                 .then(data => {
                     try {
                         const filename = this.writeToFile(data);
@@ -45,10 +42,7 @@ export abstract class BaseManager {
     public async pullFile(): Promise<any> {
         return new Promise<any>((resolve, reject) => {
             this.httpClientService
-                .buildRequestHeadersWithAuthentication(this._profile)
-                .then(headers => {
-                    return this.httpClientService.pullFileData(this.getConfig().pullUrl, headers);
-                })
+                .pullFileData(this.getConfig().pullUrl, this._profile)
                 .then(data => {
                     const filename = this.writeStreamToFile(data);
                     logger.info("File downloaded successfully. New filename: " + filename);
@@ -64,10 +58,7 @@ export abstract class BaseManager {
     public async push(): Promise<any> {
         return new Promise<any>((resolve, reject) => {
             this.httpClientService
-                .buildRequestHeadersWithAuthentication(this._profile)
-                .then(headers => {
-                    return this.httpClientService.pushData(this.getConfig().pushUrl, headers, this.getBody());
-                })
+                .pushData(this.getConfig().pushUrl, this._profile, this.getBody())
                 .then(data => {
                     logger.info(this.getConfig().onPushSuccessMessage(data));
                     resolve(data);
@@ -82,10 +73,7 @@ export abstract class BaseManager {
     public async update(): Promise<any> {
         return new Promise<any>((resolve, reject) => {
             this.httpClientService
-                .buildRequestHeadersWithAuthentication(this._profile)
-                .then(headers => {
-                    return this.httpClientService.updateData(this.getConfig().updateUrl, headers, this.getBody());
-                })
+                .updateData(this.getConfig().updateUrl, this._profile, this.getBody())
                 .then(data => {
                     logger.info(this.getConfig().onUpdateSuccessMessage());
                     resolve(data);
@@ -100,10 +88,7 @@ export abstract class BaseManager {
     public async findAll(): Promise<any> {
         return new Promise<any>((resolve, reject) => {
             this.httpClientService
-                .buildRequestHeadersWithAuthentication(this._profile)
-                .then(headers => {
-                    return this.httpClientService.findAll(this.getConfig().findAllUrl, headers);
-                })
+                .findAll(this.getConfig().findAllUrl, this._profile)
                 .then(data => {
                     this.getConfig().onFindAll(data);
                     resolve(data);

--- a/src/interfaces/profile.interface.ts
+++ b/src/interfaces/profile.interface.ts
@@ -2,7 +2,7 @@ export interface Profile {
     name: string;
     team: string;
     apiToken: string;
-    authenticationType: string;
+    authenticationType: AuthenticationType;
 }
 
 export type AuthenticationType = "Bearer" | "AppKey";

--- a/src/interfaces/profile.interface.ts
+++ b/src/interfaces/profile.interface.ts
@@ -2,4 +2,5 @@ export interface Profile {
     name: string;
     team: string;
     apiToken: string;
+    authenticationType: string;
 }

--- a/src/interfaces/profile.interface.ts
+++ b/src/interfaces/profile.interface.ts
@@ -4,3 +4,10 @@ export interface Profile {
     apiToken: string;
     authenticationType: string;
 }
+
+export type AuthenticationType = "Bearer" | "AppKey";
+// tslint:disable-next-line:variable-name
+export const AuthenticationType: { [key: string]: AuthenticationType } = {
+    BEARER: "Bearer",
+    APPKEY: "AppKey",
+};

--- a/src/services/http-client.service.ts
+++ b/src/services/http-client.service.ts
@@ -1,30 +1,30 @@
-import { Profile } from "../interfaces/profile.interface";
+import { AuthenticationType, Profile } from "../interfaces/profile.interface";
 import { logger } from "../util/logger";
 import { CoreOptions, Headers, Response } from "request";
 
 import request = require("request");
 
 export class HttpClientService {
-    public async pushData(url: string, headers: Headers, body: object): Promise<any> {
+    public async pushData(url: string, profile: Profile, body: object): Promise<any> {
         return new Promise<any>((resolve, reject) => {
-            request.post(url, this.makeOptions(headers, body), (err, res) => {
+            request.post(url, this.makeOptions(profile, body), (err, res) => {
                 this.handleResponse(res, resolve, reject);
             });
         });
     }
 
-    public async pullData(url: string, headers: Headers): Promise<any> {
+    public async pullData(url: string, profile: Profile): Promise<any> {
         return new Promise<any>((resolve, reject) => {
-            request.get(url, this.makeOptions(headers, null), (err, res) => {
+            request.get(url, this.makeOptions(profile, null), (err, res) => {
                 this.handleResponse(res, resolve, reject);
             });
         });
     }
 
-    public async pullFileData(url: string, headers: Headers): Promise<any> {
+    public async pullFileData(url: string, profile: Profile): Promise<any> {
         return new Promise<any>((resolve, reject) => {
             request
-                .post(url, this.makeFileDownloadOptions(headers))
+                .post(url, this.makeFileDownloadOptions(profile))
                 .on("response", (response: Response) => {
                     const data: Buffer[] = [];
                     response.on("data", (chunk: Buffer) => {
@@ -42,72 +42,42 @@ export class HttpClientService {
         });
     }
 
-    public async updateData(url: string, headers: Headers, body: object): Promise<any> {
+    public async updateData(url: string, profile: Profile, body: object): Promise<any> {
         return new Promise<any>((resolve, reject) => {
-            request.put(url, this.makeOptions(headers, body), (err, res) => {
+            request.put(url, this.makeOptions(profile, body), (err, res) => {
                 this.handleResponse(res, resolve, reject);
             });
         });
     }
 
-    public async findAll(url: string, headers: Headers): Promise<any> {
+    public async findAll(url: string, profile: Profile): Promise<any> {
         return new Promise<any>((resolve, reject) => {
-            request.get(url, this.makeOptions(headers, null), (err, res) => {
+            request.get(url, this.makeOptions(profile, null), (err, res) => {
                 this.handleResponse(res, resolve, reject);
             });
         });
     }
 
-    public async buildRequestHeadersWithAuthentication(profile: Profile): Promise<any> {
-        return new Promise<any>(resolve => {
-            const url = profile.team.replace(/\/?$/, "/api/cloud");
-            let headers = {
-                authorization: null,
-                "content-type": "application/json",
-            };
-            if (profile.authenticationType != null) {
-                headers.authorization = `${profile.authenticationType} ${profile.apiToken}`;
-                resolve(headers);
-            } else {
-                headers.authorization = `Bearer ${profile.apiToken}`;
-            }
-            this.authenticate(url, headers)
-                .then(() => {
-                    resolve(headers);
-                })
-                .catch(() => {
-                    headers.authorization = `AppKey ${profile.apiToken}`;
-                    this.authenticate(url, headers)
-                        .then(() => {
-                            resolve(headers);
-                        })
-                        .catch(() => {
-                            resolve(headers);
-                        });
-                });
-        });
-    }
-
-    private async authenticate(url: string, headers: Headers): Promise<any> {
-        return new Promise<any>((resolve, reject) => {
-            request.get(url, this.makeOptions(headers, null), (err, res) => {
-                this.handleResponse(res, resolve, reject);
-            });
-        });
-    }
-
-    private makeOptions(headers: Headers, body: object = {}): CoreOptions {
+    private makeOptions(profile: Profile, body: object = {}): CoreOptions {
         const options = {
-            headers: headers,
+            headers: this.buildAuthorizationHeaders(profile),
         };
 
         return Object.assign(options, body);
     }
 
-    private makeFileDownloadOptions(headers: Headers): object {
+    private makeFileDownloadOptions(profile: Profile): object {
         return {
-            headers: headers,
+            headers: this.buildAuthorizationHeaders(profile),
             responseType: "binary",
+        };
+    }
+
+    private buildAuthorizationHeaders(profile: Profile): Headers {
+        const authenticationType = profile.authenticationType || AuthenticationType.BEARER;
+        return {
+            authorization: `${authenticationType} ${profile.apiToken}`,
+            "content-type": "application/json",
         };
     }
 

--- a/src/services/profile.service.ts
+++ b/src/services/profile.service.ts
@@ -74,6 +74,7 @@ export class ProfileService {
                 name: profileVariables.teamUrl,
                 team: profileVariables.teamUrl,
                 apiToken: profileVariables.apiToken,
+                authenticationType: null,
             });
         });
     }

--- a/src/services/profile.service.ts
+++ b/src/services/profile.service.ts
@@ -1,4 +1,5 @@
-import { Profile } from "../interfaces/profile.interface";
+import { AuthenticationType, Profile } from "../interfaces/profile.interface";
+import { ProfileValidator } from "../validators/profile.validator";
 import * as path from "path";
 import * as fs from "fs";
 import { FatalError, logger } from "../util/logger";
@@ -67,16 +68,16 @@ export class ProfileService {
         });
     }
 
-    private buildProfileFromEnvVariables(): Promise<Profile> {
+    private async buildProfileFromEnvVariables(): Promise<Profile> {
         const profileVariables = this.getProfileEnvVariables();
-        return new Promise<Profile>(resolve => {
-            resolve({
-                name: profileVariables.teamUrl,
-                team: profileVariables.teamUrl,
-                apiToken: profileVariables.apiToken,
-                authenticationType: null,
-            });
-        });
+        const profile: Profile = {
+            name: profileVariables.teamUrl,
+            team: profileVariables.teamUrl,
+            apiToken: profileVariables.apiToken,
+            authenticationType: AuthenticationType.BEARER,
+        };
+        profile.authenticationType = await ProfileValidator.validateProfile(profile);
+        return profile;
     }
 
     private storeConfig(config: Config): void {

--- a/src/validators/profile.validator.ts
+++ b/src/validators/profile.validator.ts
@@ -1,4 +1,4 @@
-import { Profile } from "../interfaces/profile.interface";
+import { AuthenticationType, Profile } from "../interfaces/profile.interface";
 import { FatalError, logger } from "../util/logger";
 import validUrl = require("valid-url");
 import request = require("request");
@@ -20,7 +20,7 @@ export class ProfileValidator {
             }
             let options = {
                 headers: {
-                    authorization: `Bearer ${profile.apiToken}`,
+                    authorization: `${AuthenticationType.BEARER} ${profile.apiToken}`,
                 },
             };
             const url = profile.team.replace(/\/?$/, "/api/cloud");
@@ -34,17 +34,17 @@ export class ProfileValidator {
                     reject();
                 }
                 if (res.statusCode >= 400 || body.teamDomain == null) {
-                    options.headers.authorization = `AppKey ${profile.apiToken}`;
+                    options.headers.authorization = `${AuthenticationType.APPKEY} ${profile.apiToken}`;
                     request.get(url, options, (err, res) => {
                         if (res.statusCode === 200) {
-                            resolve("AppKey");
+                            resolve(AuthenticationType.APPKEY);
                         } else {
                             logger.error(new FatalError("The provided team or api key is wrong."));
                             reject();
                         }
                     });
                 } else {
-                    resolve("Bearer");
+                    resolve(AuthenticationType.BEARER);
                 }
             });
         });

--- a/src/validators/profile.validator.ts
+++ b/src/validators/profile.validator.ts
@@ -4,8 +4,8 @@ import validUrl = require("valid-url");
 import request = require("request");
 
 export class ProfileValidator {
-    public static async validateProfile(profile: Profile): Promise<void> {
-        return new Promise<void>((resolve, reject) => {
+    public static async validateProfile(profile: Profile): Promise<any> {
+        return new Promise<any>((resolve, reject) => {
             if (profile.name == null) {
                 logger.error(new FatalError("The name can not be empty"));
             }
@@ -37,14 +37,14 @@ export class ProfileValidator {
                     options.headers.authorization = `AppKey ${profile.apiToken}`;
                     request.get(url, options, (err, res) => {
                         if (res.statusCode === 200) {
-                            resolve();
+                            resolve("AppKey");
                         } else {
                             logger.error(new FatalError("The provided team or api key is wrong."));
                             reject();
                         }
                     });
                 } else {
-                    resolve();
+                    resolve("Bearer");
                 }
             });
         });

--- a/src/validators/profile.validator.ts
+++ b/src/validators/profile.validator.ts
@@ -18,12 +18,11 @@ export class ProfileValidator {
             if (!validUrl.isUri(profile.team)) {
                 logger.error(new FatalError("The provided url is not a valid url."));
             }
-            const options = {
+            let options = {
                 headers: {
                     authorization: `Bearer ${profile.apiToken}`,
                 },
             };
-
             const url = profile.team.replace(/\/?$/, "/api/cloud");
 
             request.get(url, options, (err, res) => {
@@ -35,8 +34,15 @@ export class ProfileValidator {
                     reject();
                 }
                 if (res.statusCode >= 400 || body.teamDomain == null) {
-                    logger.error(new FatalError("The provided team or api key is wrong."));
-                    reject();
+                    options.headers.authorization = `AppKey ${profile.apiToken}`;
+                    request.get(url, options, (err, res) => {
+                        if (res.statusCode === 200) {
+                            resolve();
+                        } else {
+                            logger.error(new FatalError("The provided team or api key is wrong."));
+                            reject();
+                        }
+                    });
                 } else {
                     resolve();
                 }


### PR DESCRIPTION
#### Description
I made changes to utilize both user API key and Application key regarding https://github.com/celonis/content-cli/issues/68
.

#### Checklist

- [x] I have self-reviewed this PR
- [x] I have tested the change and proved that it works in different scenarios
  - [x] profile create command by user API key
  - [x] profile create command by Application key
  - [x] list package command with profile contains user API key
  - [x] list package command with profile contains Application key
  - [x] list package command with environment variable of user API key
  - [x] list package command with environment variable of Application key
  - [x] pull package command with profile contains Application key
  - [x] push package command with profile contains Application key
- [ ] I have updated docs if needed
