### PR TITLE
docs - Add docs for application key on profiles and better instructions for CLI installation

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -56,21 +56,31 @@ content-cli pull package -h
 ### Using profiles
 
 As mentioned above, **Content CLI** allows creating profiles for
-different environments. A profile consists of a name, an URL to your EMS
-team and an API-KEY. Each of the above mentioned commands include
+different environments. A profile consists of a name, URL to your EMS
+team and an API token. Each of the above mentioned commands include
 a ***--profile*** flag which allows you selecting a profile by its name.
 
 Creating a profile is done by using the ***content-cli profile create***
-command. The CLI will ask for a name, an URL and an API key. If the
+command. The CLI will ask for a name, a URL and an API token. If the
 provided information is correct, it will create a profile with the
-provided data.
+provided data. After successfully creating a profile, you can view 
+your profiles by running the ***content-cli profile list*** command.
 
 | Note: Please do not use blanks in profile names |
 |-------------------------------------------------|
 
-An API Key can be created in the 'Edit Profile' section of your EMS 
-user account. By using ***content-cli profile list**, *you can see
-all of your ready-to-use profiles.
+#### API Token
+
+You can choose between two different options when asked for an API token. 
+The first option is to use an API key, which identifies the user that created 
+the key. You can generate an API key in the `Edit Profile` section of your EMS 
+user account, under `API-Keys`. The second options is to use an Application Key,
+which is treated as a new user with separate configurable permissions. You can 
+generate an Application key in the `Team Settings` section of your EMS account, 
+under `Applications`. After creating an Application, you can assign it different
+permissions based on how much power you want to give to the key owner.
+
+#### When to create profiles
 
 So let's say you have a Studio package in [https://my-team.eu-1.celonis.cloud]() 
 and you want to push the same one to [http://my-other-team.eu-1.celonis.cloud]().

--- a/README.md
+++ b/README.md
@@ -1,53 +1,88 @@
 # Content CLI
 
-Content CLI is a tool to help manage content in Celonis EMS. It provides various commands to help extract content like analyses, packages, assets and others from your Celonis EMS team to your local machine, which you can then push to other teams. This process can be easily achieved by creating profiles for your different teams and execute commands in a profile's context.
+Content CLI is a tool to help manage content in Celonis EMS. It provides various commands to help extract 
+content like analyses, packages, assets and others from your Celonis EMS team to your local machine, which 
+you can then push to other teams. This process can be easily achieved by creating profiles for your different 
+teams and execute commands in a profile's context.
 
 ## Table of Contents
 
-1. [About the Project](#about-the-project)
-2. [Getting Started](#getting-started)
-3. [Release Process](#release-process)
-4. [Contributing](#contributing)
-5. [License](#license)
+1. [Getting Started](#getting-started)
+2. [About the Project](#about-the-project)
+3. [Building the Project](#building-the-project)
+4. [Release Process](#release-process)
+5. [Contributing](#contributing)
+6. [License](#license)
+
+## Getting Started
+
+To get started with using Content CLI, you will need to have `node` installed in your local machine. Please download 
+the LTS version that is recommended for most users from the `node` web page [here](https://nodejs.org/en/). After 
+installing `node` you can run the following command in the terminal (cmd for Windows users) to install Content CLI. 
+Note that the same command is used for updating Content CLI too.
+
+```
+npm install -g @celonis/content-cli
+```
+
+You can verify that the installation was successful by running the following command in the terminal, which prints 
+the installed version of Content CLI:
+
+```
+content-cli -V
+```
 
 ## About the Project
 
 Content CLI has three core functionalities:
 
-**Profile:** The CLI connects to the EMS environments through profiles. For each of the commands you can specify which profile you want to use. This makes it powerful in the sense that you can pull something from let's say team1.cluser1 and push it directly to team2.cluster2 easily. You can create a profile using the following command:
+**Profile:** The CLI connects to the EMS environments through profiles. For each of the commands you can specify 
+which profile you want to use. This makes it powerful in the sense that you can pull something from let's say 
+team1.cluser1 and push it directly to team2.cluster2 easily. You can create a profile using the following command:
 
 ```
 content-cli profile create
 ```
 
-**Pull:** This feature allows you to download content from the EMS to your local machine. Let's take Studio package as an example. These can be exported in the EMS as ZIP files that contain all package assets. By using the following command using the package key and profile you have created, you will pull the ZIP file.
+**Pull:** This feature allows you to download content from the EMS to your local machine. Let's take Studio package 
+as an example. These can be exported in the EMS as ZIP files that contain all package assets. By using the following 
+command using the package key and profile you have created, you will pull the ZIP file.
 
 ```
 content-cli pull package -p team1.cluster1 --key my-package
 ```
 
-**Push:** This feature allows you to push a content file to a team in the EMS. To continue the last example, you can use the following command to push he previously pulled package in another team.
+**Push:** This feature allows you to push a content file to a team in the EMS. To continue the last example, 
+you can use the following command to push he previously pulled package in another team.
 
 ```
 content-cli push package -p team2.cluster2 --spaceKey my-space -f package_my-package.zip
 ```
 
-A more comprehensive list of Content CLI capabilities can be found on the following [documentation](https://github.com/celonis/content-cli/blob/master/DOCUMENTATION.md). 
+A more comprehensive list of Content CLI capabilities can be found on the following 
+[documentation](https://github.com/celonis/content-cli/blob/master/DOCUMENTATION.md). 
 
-You can still explore the full capabilities of Content CLI and the list of options for the different commands by using the `-h` option in your command.
+You can still explore the full capabilities of Content CLI and the list of options for the different commands 
+by using the `-h` option in your command.
 
 ```
 content-cli -h
 content-cli pull package -h
 ```
 
-## Getting Started
+## Building the Project
 
-This tool is tightly connected with the Celonis EMS and all capabilities require to have access to a Celonis EMS Team. After cloning the project, the next step is to install the project dependencies. We use `yarn` as our package manager, so running `yarn install` on the project root folder should install all the necessary dependencies. After installing the project dependencies, you can run `yarn build` to build the project artifact. To use the built artifact, you can run `node content-cli.js` in the generated `dist` folder.
+This tool is tightly connected with the Celonis EMS and all capabilities require to have access to a Celonis EMS Team. 
+After cloning the project, the next step is to install the project dependencies. We use `yarn` as our package manager, 
+so running `yarn install` on the project root folder should install all the necessary dependencies. After installing 
+the project dependencies, you can run `yarn build` to build the project artifact. To use the built artifact, you can 
+run `node content-cli.js` in the generated `dist` folder.
 
 ## Release Process
 
-We manage releases using Github Actions with the `Build and Publish Workflow`. This action runs after merging to the master branch, which builds the project and publishes the package to the Github registry. You can install a published version of the Content CLI using the following command:
+We manage releases using Github Actions with the `Build and Publish Workflow`. This action runs after merging to 
+the master branch, which builds the project and publishes the package to the Github registry. You can install 
+a published version of the Content CLI using the following command:
 
 ```
 npm i -g @celonis/content-cli
@@ -55,10 +90,13 @@ npm i -g @celonis/content-cli
 
 ## Contributing
 
-We encourage public contributions! Please review [CONTRIBUTING.md](https://github.com/celonis/content-cli/blob/master/CONTRIBUTING.md) for details on our code of conduct and development process.
+We encourage public contributions! Please review 
+[CONTRIBUTING.md](https://github.com/celonis/content-cli/blob/master/CONTRIBUTING.md) for details on our 
+code of conduct and development process.
 
 ## License
 
 Copyright (c) 2021 Celonis SE
 
-This project is licensed under the MIT License - see [LICENSE](https://github.com/celonis/content-cli/blob/master/LICENSE) file for details.
+This project is licensed under the MIT License - 
+see [LICENSE](https://github.com/celonis/content-cli/blob/master/LICENSE) file for details.


### PR DESCRIPTION
#### Description

Revamped `Getting Started` section for new users with more detailed instructions on how to get started with using Content CLI.
Updated docs for creating profiles to include recent support of application key authentication.

#### Checklist

- [x] I have self-reviewed this PR
- [x] I have tested the change and proved that it works in different scenarios
- [x] I have updated docs if needed
