### PR TITLE
[BUGFIX] Use local datadog-ci included in content-cli instead of forcing installing it everywhere

### DIFF
--- a/src/content/manager/widget-sourcemaps.manager.ts
+++ b/src/content/manager/widget-sourcemaps.manager.ts
@@ -20,10 +20,9 @@ export class WidgetSourcemapsManager extends BaseManager {
                 logger.error(new GracefulError("Missing DATADOG_API_KEY"));
             }
 
+            const datadogCiPath = require.resolve("@datadog/datadog-ci/dist/cli.js");
             const commandLines = [
-                `node ${require.resolve("@datadog/datadog-ci/dist/cli.js")} sourcemaps upload ${
-                    this.distPath
-                }/${distPathPostfix}`,
+                `node ${datadogCiPath} sourcemaps upload ${this.distPath}/${distPathPostfix}`,
                 `--service=${this.service}`,
                 `--release-version=${this.releaseVersion}`,
                 `--minified-path-prefix=/package-manager/${sourcemapsPath}`,

--- a/src/content/manager/widget-sourcemaps.manager.ts
+++ b/src/content/manager/widget-sourcemaps.manager.ts
@@ -21,7 +21,9 @@ export class WidgetSourcemapsManager extends BaseManager {
             }
 
             const commandLines = [
-                `datadog-ci sourcemaps upload ${this.distPath}/${distPathPostfix}`,
+                `node ${require.resolve("@datadog/datadog-ci/dist/cli.js")} sourcemaps upload ${
+                    this.distPath
+                }/${distPathPostfix}`,
                 `--service=${this.service}`,
                 `--release-version=${this.releaseVersion}`,
                 `--minified-path-prefix=/package-manager/${sourcemapsPath}`,


### PR DESCRIPTION
#### Description

[BUGFIX] Use local datadog-ci included in content-cli instead of forcing installing it everywhere

#### Checklist

- [x] I have self-reviewed this PR
- [x] I have tested the change and proved that it works in different scenarios
- [ ] I have updated docs if needed
