### PR TITLE
Make service and version static in datadog push sourcemap command to allow pushing sourcemaps to the same datadog RUM application

### DIFF
--- a/src/content/manager/widget-sourcemaps.manager.ts
+++ b/src/content/manager/widget-sourcemaps.manager.ts
@@ -22,10 +22,10 @@ export class WidgetSourcemapsManager extends BaseManager {
 
             const datadogCiPath = require.resolve("@datadog/datadog-ci/dist/cli.js");
             const commandLines = [
-                `node ${datadogCiPath} sourcemaps upload ${this.distPath}/${distPathPostfix}`,
-                `--service=${this.service}`,
-                `--release-version=${this.releaseVersion}`,
-                `--minified-path-prefix=/package-manager/${sourcemapsPath}`,
+                `node ${datadogCiPath} sourcemaps upload .`,
+                `--service=package-manager`,
+                `--release-version=1.0.0`,
+                `--minified-path-prefix=/package-manager/`,
             ];
 
             exec(commandLines.join(" "), (error, stdout) => {


### PR DESCRIPTION
#### Description

Datadog RUM requires a service and version that is defined in datadogRum.init the same as the one in push sourcemap command thats why we made it static as a workaround.

#### Checklist

- [x] I have self-reviewed this PR
- [x] I have tested the change and proved that it works in different scenarios
- [ ] I have updated docs if needed
