### PR TITLE
TN-4316: Export versioned packages.

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -261,7 +261,7 @@ You can use the export packages command to export multiple packages at once from
 
 ```
 //Exporting multiple packages at once
-content-cli export packages -p <your-chosen-profile> --packageKeys <packageKeysYouWantToExport>
+content-cli export packages -p <your-chosen-profile> --packageKeys <package1> <package2>
 ```
 
 Example usage would be:
@@ -270,6 +270,11 @@ content-cli export packages -p dev --packageKeys package-1 package-2
 ```
 
 You can use the --includeDependencies flag to also export the dependencies of the specified packages.
+
+```
+//Exporting multiple packages at once with dependencies
+content-cli export packages -p <your-chosen-profile> --packageKeys <package1> <package2> --includeDependencies
+```
 
 ### List all spaces in Studio
 With this command you can retrieve a list of all spaces within a team.

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -255,6 +255,22 @@ When you use overwrite the following is to be taken into consideration:
 content-cli push package -p my-profile-name --spaceKey my-space -f <path-to-my-local-package> --overwrite
 ```
 
+### Export multiple packages at once from Studio
+
+You can use the export packages command to export multiple packages at once from studio.
+
+```
+//Exporting multiple packages at once
+content-cli export packages -p <your-chosen-profile> --packageKeys <packageKeysYouWantToExport>
+```
+
+Example usage would be:
+```
+content-cli export packages -p dev --packageKeys package-1 package-2
+```
+
+You can use the --includeDependencies flag to also export the dependencies of the specified packages.
+
 ### List all spaces in Studio
 With this command you can retrieve a list of all spaces within a team.
 The command takes your permissions into consideration and only lists the

--- a/src/api/package-api.ts
+++ b/src/api/package-api.ts
@@ -1,7 +1,7 @@
 import {httpClientV2} from "../services/http-client-service.v2";
 import {
     ActivatePackageTransport,
-    ContentNodeTransport, PackageDependencyTransport, PackageHistoryTransport, PackageWithVariableAssignments
+    ContentNodeTransport, PackageHistoryTransport, PackageWithVariableAssignments
 } from "../interfaces/package-manager.interfaces";
 import {FatalError} from "../util/logger";
 
@@ -16,7 +16,11 @@ class PackageApi {
     }
 
     public async exportPackage(rootPackageKey: string, version?: string): Promise<Buffer> {
-        return await httpClientV2.downloadFile(`/package-manager/api/packages/${rootPackageKey}/export?newKey=${rootPackageKey}${version ? `&version=${version}` : ""}`);
+        const queryParams = new URLSearchParams();
+        queryParams.set("newKey", rootPackageKey);
+        queryParams.set("version", version ?? "");
+
+        return await httpClientV2.downloadFile(`/package-manager/api/packages/${rootPackageKey}/export?${queryParams.toString()}`);
     }
 
     public async findAllPackagesWithVariableAssignments(): Promise<PackageWithVariableAssignments[]> {

--- a/src/api/package-api.ts
+++ b/src/api/package-api.ts
@@ -20,7 +20,9 @@ class PackageApi {
         queryParams.set("newKey", rootPackageKey);
         queryParams.set("version", version ?? "");
 
-        return await httpClientV2.downloadFile(`/package-manager/api/packages/${rootPackageKey}/export?${queryParams.toString()}`);
+        return await httpClientV2.downloadFile(`/package-manager/api/packages/${rootPackageKey}/export?${queryParams.toString()}`).catch(e => {
+            throw new FatalError(`Pacakge ${rootPackageKey}_${version} failed to export.`)
+        });
     }
 
     public async findAllPackagesWithVariableAssignments(): Promise<PackageWithVariableAssignments[]> {

--- a/src/api/package-api.ts
+++ b/src/api/package-api.ts
@@ -15,8 +15,8 @@ class PackageApi {
         });
     }
 
-    public async exportPackage(rootPackageKey: string): Promise<Buffer> {
-        return await httpClientV2.downloadFile(`/package-manager/api/packages/${rootPackageKey}/export?newKey=${rootPackageKey}`);
+    public async exportPackage(rootPackageKey: string, version?: string): Promise<Buffer> {
+        return await httpClientV2.downloadFile(`/package-manager/api/packages/${rootPackageKey}/export?newKey=${rootPackageKey}${version ? `&version=${version}` : ""}`);
     }
 
     public async findAllPackagesWithVariableAssignments(): Promise<PackageWithVariableAssignments[]> {

--- a/src/api/package-dependencies-api.ts
+++ b/src/api/package-dependencies-api.ts
@@ -1,6 +1,6 @@
 import {PackageDependencyTransport} from "../interfaces/package-manager.interfaces";
 import {httpClientV2} from "../services/http-client-service.v2";
-import {FatalError, logger} from "../util/logger";
+import {FatalError} from "../util/logger";
 
 class PackageDependenciesApi {
     public static readonly INSTANCE = new PackageDependenciesApi();

--- a/src/commands/package.command.ts
+++ b/src/commands/package.command.ts
@@ -38,7 +38,7 @@ export class PackageCommand {
 
     public async listPackages(jsonResponse: boolean, includeDependencies: boolean): Promise<void> {
         if (jsonResponse) {
-            await packageService.findAndExportAllPackages(includeDependencies);
+            await packageService.findAndExportListOfAllPackages(includeDependencies);
         } else {
             await packageService.listPackages();
         }

--- a/src/commands/package.command.ts
+++ b/src/commands/package.command.ts
@@ -48,7 +48,7 @@ export class PackageCommand {
         await packageService.batchExportPackages(packageKeys, includeDependencies);
     }
 
-    public async batchImportPackages(spaceMappings: string[], exportedDatapoolsFile: string, exportedPackagesFile: string): Promise<void> {
-        await packageService.batchImportPackages(spaceMappings ?? [], exportedDatapoolsFile, exportedPackagesFile);
+    public async batchImportPackages(spaceMappings: string[], dataModelMapping: string, exportedPackagesFile: string): Promise<void> {
+        await packageService.batchImportPackages(spaceMappings ?? [], dataModelMapping, exportedPackagesFile);
     }
 }

--- a/src/content-cli-export.ts
+++ b/src/content-cli-export.ts
@@ -2,11 +2,9 @@ import {CommanderStatic} from "commander";
 import {PackageCommand} from "./commands/package.command";
 import {logger} from "./util/logger";
 import {contextService} from "./services/context.service";
-import {List} from "./content-cli-list";
 import * as commander from "commander";
 
 export class Export {
-
     public static packages(program: CommanderStatic): CommanderStatic {
         program
             .command("packages")

--- a/src/content-cli-export.ts
+++ b/src/content-cli-export.ts
@@ -24,7 +24,7 @@ export class Export {
 }
 
 const options = commander.parseOptions(process.argv)
-const indexOfProfileOption = options.unknown.indexOf('-p') ?? options.unknown.indexOf('--profile');
+const indexOfProfileOption = options.unknown.indexOf('-p') !== -1 ? options.unknown.indexOf('-p') : options.unknown.indexOf('--profile');
 
 process.on("unhandledRejection", (e, promise) => {
     logger.error(e.toString());

--- a/src/content-cli-import.ts
+++ b/src/content-cli-import.ts
@@ -12,10 +12,10 @@ export class Import {
             .description("Command to import all given packages")
             .option("-p, --profile <profile>", "Profile which you want to use to list packages")
             .option("--spaceMappings <spaceMappings...>", "List of mappings for importing packages to different target spaces. Mappings should follow format 'packageKey:targetSpaceKey'")
-            .option("--exportedDatapoolsFile <exportedDatapoolsFile>", "Exported datapool file (relative path)", "")
+            .option("--dataModelMapping <dataModelMapping>", "Data model mappings file (relative path)", "")
             .requiredOption("--exportedPackagesFile <exportedPackagesFile>", "Exported packages file (relative path)")
             .action(async cmd => {
-                await new PackageCommand().batchImportPackages(cmd.spaceMappings, cmd.exportedDatapoolsFile, cmd.exportedPackagesFile)
+                await new PackageCommand().batchImportPackages(cmd.spaceMappings, cmd.dataModelMapping, cmd.exportedPackagesFile)
                 process.exit();
             });
 

--- a/src/content-cli-list.ts
+++ b/src/content-cli-list.ts
@@ -70,28 +70,23 @@ export class List {
 
 
 const options = commander.parseOptions(process.argv)
-const indexOfProfileOption = options.unknown.indexOf('-p') !== -1 ? options.unknown.indexOf('-p') : options.unknown.indexOf('--profile');
+const indexOfProfileOption = options.unknown.indexOf('-p') ?? options.unknown.indexOf('--profile');
 
 process.on("unhandledRejection", (e, promise) => {
     logger.error(e.toString());
 })
 
 contextService.resolveProfile(options.unknown[indexOfProfileOption + 1]).then(() => {
-    getAllCommands();
-}, ()=> {
-    getAllCommands();
-}).catch(e => {
-    console.log(e)
-});
-
-function getAllCommands() {
     List.packages(commander);
     List.spaces(commander);
     List.dataPools(commander);
     List.assets(commander);
 
     commander.parse(process.argv);
-}
+}).catch(e => {
+    console.log(e)
+});
+
 if (!process.argv.slice(2).length) {
     commander.outputHelp();
     process.exit(1);

--- a/src/content-cli-list.ts
+++ b/src/content-cli-list.ts
@@ -68,9 +68,8 @@ export class List {
     }
 }
 
-
-const options = commander.parseOptions(process.argv)
-const indexOfProfileOption = options.unknown.indexOf('-p') ?? options.unknown.indexOf('--profile');
+const options = commander.parseOptions(process.argv);
+const indexOfProfileOption = options.unknown.indexOf('-p') !== -1 ? options.unknown.indexOf('-p') : options.unknown.indexOf('--profile');
 
 process.on("unhandledRejection", (e, promise) => {
     logger.error(e.toString());

--- a/src/interfaces/manifest-transport.ts
+++ b/src/interfaces/manifest-transport.ts
@@ -6,6 +6,7 @@ export interface ManifestNodeTransport {
     packageVersion: string;
     variables: ManifestVariable[],
     space: ManifestSpace,
+    usedVersions: string[];
     dependencies: ManifestDependency[]
 }
 

--- a/src/interfaces/manifest-transport.ts
+++ b/src/interfaces/manifest-transport.ts
@@ -1,13 +1,12 @@
 import {VariablesAssignments} from "./package-manager.interfaces";
 
 export interface ManifestNodeTransport {
+    packageKeyAndVersion: string;
     packageKey: string;
     packageId: string,
-    packageVersion: string;
     variables: ManifestVariable[],
     space: ManifestSpace,
-    usedVersions: string[];
-    dependencies: ManifestDependency[]
+    dependenciesByVersion: Map<string, ManifestDependency[]>;
 }
 
 export interface ManifestVariable extends VariablesAssignments {

--- a/src/services/package-manager/package-service.ts
+++ b/src/services/package-manager/package-service.ts
@@ -140,70 +140,73 @@ class PackageService {
     }
 
     private async importPackage(packageToImport: ManifestNodeTransport, manifestNodes: ManifestNodeTransport[], spaceMappings: string[], allSpaces: SpaceTransport[], importedKeys: string[], importedFilePath: string) {
-        if (importedKeys.includes(packageToImport.packageKey)) {
-            return;
-        }
-        let targetSpaceId;
-        if (packageToImport.dependencies.length > 0) {
-            for (const dependency of packageToImport.dependencies) {
-                if (!dependency.external) {
-                    const dependentPackage = manifestNodes.find((node) => node.packageKey === dependency.key);
-                    await this.importPackage(dependentPackage, manifestNodes, spaceMappings, allSpaces, importedKeys, importedFilePath)
-                }
-            }
-        }
-
-        let targetSpace = allSpaces.find(space => space.name === packageToImport.space.spaceName)
-        const customSpacesMap: Map<string, string> = new Map();
-        spaceMappings.forEach(spaceMap => {
-            const packageAndSpaceid = spaceMap.split(":");
-            customSpacesMap.set(packageAndSpaceid[0], packageAndSpaceid[1])
-        })
-        const customSpaceId = customSpacesMap.get(packageToImport.packageKey);
-        if (customSpaceId) {
-            const customSpace = allSpaces.find(space => space.id === customSpaceId)
-            if (!customSpace) {
-                throw Error("Provided space id does not exist");
-            }
-            targetSpaceId = customSpace.id;
-        } else {
-            if (!targetSpace) {
-                targetSpace = await spaceApi.createSpace({
-                    id: uuidv4(),
-                    name: packageToImport.space.spaceName,
-                    iconReference: packageToImport.space.spaceIcon
-                });
-            }
-            targetSpaceId = targetSpace.id;
-        }
-
-        const packageZip = {
-            formData: {
-                package: await fs.createReadStream(path.resolve(importedFilePath, packageToImport.packageKey + ".zip"), {encoding: null})
-            },
-        };
-        importedKeys.push(packageToImport.packageKey);
-        const nodeInTargetTeam = await nodeApi.findOneByKeyAndRootNodeKey(packageToImport.packageKey, packageToImport.packageKey);
-        await packageApi.importPackage(packageZip, targetSpaceId, !!nodeInTargetTeam);
-        if (nodeInTargetTeam) {
-            await packageApi.movePackageToSpace(nodeInTargetTeam.id, targetSpaceId)
-        }
-        await this.updateDependencyVersions(packageToImport);
-        await this.publishPackage(packageToImport);
-        logger.info(`Imported package with key: ${packageToImport.packageKey} successfully`)
+      // TODO [TN-4317](https://celonis.atlassian.net/browse/TN-4317)
+        // if (importedKeys.includes(packageToImport.packageKey)) {
+        //     return;
+        // }
+        // let targetSpaceId;
+        // if (packageToImport.dependencies.length > 0) {
+        //     for (const dependency of packageToImport.dependencies) {
+        //         if (!dependency.external) {
+        //             const dependentPackage = manifestNodes.find((node) => node.packageKey === dependency.key);
+        //             await this.importPackage(dependentPackage, manifestNodes, spaceMappings, allSpaces, importedKeys, importedFilePath)
+        //         }
+        //     }
+        // }
+        //
+        // let targetSpace = allSpaces.find(space => space.name === packageToImport.space.spaceName)
+        // const customSpacesMap: Map<string, string> = new Map();
+        // spaceMappings.forEach(spaceMap => {
+        //     const packageAndSpaceid = spaceMap.split(":");
+        //     customSpacesMap.set(packageAndSpaceid[0], packageAndSpaceid[1])
+        // })
+        // const customSpaceId = customSpacesMap.get(packageToImport.packageKey);
+        // if (customSpaceId) {
+        //     const customSpace = allSpaces.find(space => space.id === customSpaceId)
+        //     if (!customSpace) {
+        //         throw Error("Provided space id does not exist");
+        //     }
+        //     targetSpaceId = customSpace.id;
+        // } else {
+        //     if (!targetSpace) {
+        //         targetSpace = await spaceApi.createSpace({
+        //             id: uuidv4(),
+        //             name: packageToImport.space.spaceName,
+        //             iconReference: packageToImport.space.spaceIcon
+        //         });
+        //     }
+        //     targetSpaceId = targetSpace.id;
+        // }
+        //
+        // const packageZip = {
+        //     formData: {
+        //         package: await fs.createReadStream(path.resolve(importedFilePath, packageToImport.packageKey + ".zip"), {encoding: null})
+        //     },
+        // };
+        // importedKeys.push(packageToImport.packageKey);
+        // const nodeInTargetTeam = await nodeApi.findOneByKeyAndRootNodeKey(packageToImport.packageKey, packageToImport.packageKey);
+        // await packageApi.importPackage(packageZip, targetSpaceId, !!nodeInTargetTeam);
+        // if (nodeInTargetTeam) {
+        //     await packageApi.movePackageToSpace(nodeInTargetTeam.id, targetSpaceId)
+        // }
+        // await this.updateDependencyVersions(packageToImport);
+        // await this.publishPackage(packageToImport);
+        // logger.info(`Imported package with key: ${packageToImport.packageKey} successfully`)
     }
 
     private async updateDependencyVersions(node: ManifestNodeTransport): Promise<void> {
-        const createdNode = await nodeApi.findOneByKeyAndRootNodeKey(node.packageKey, node.packageKey);
-        for (const dependency of node.dependencies) {
-            const nodeInTargetTeam = await nodeApi.findOneByKeyAndRootNodeKey(dependency.key, dependency.key);
-            const nextVersion = await packageApi.findActiveVersionById(nodeInTargetTeam.id);
-            dependency.version = nextVersion.version;
-            dependency.updateAvailable = false;
-            dependency.id = nodeInTargetTeam.rootNodeId;
-            dependency.rootNodeId = nodeInTargetTeam.rootNodeId;
-            await packageDependenciesApi.updatePackageDependency(createdNode.id, dependency);
-        }
+        // TODO [TN-4317](https://celonis.atlassian.net/browse/TN-4317)
+
+        // const createdNode = await nodeApi.findOneByKeyAndRootNodeKey(node.packageKey, node.packageKey);
+        // for (const dependency of node.dependencies) {
+        //     const nodeInTargetTeam = await nodeApi.findOneByKeyAndRootNodeKey(dependency.key, dependency.key);
+        //     const nextVersion = await packageApi.findActiveVersionById(nodeInTargetTeam.id);
+        //     dependency.version = nextVersion.version;
+        //     dependency.updateAvailable = false;
+        //     dependency.id = nodeInTargetTeam.rootNodeId;
+        //     dependency.rootNodeId = nodeInTargetTeam.rootNodeId;
+        //     await packageDependenciesApi.updatePackageDependency(createdNode.id, dependency);
+        // }
     }
 
     private async getDependencyPackages(nodesToResolve: BatchExportNodeTransport[], dependencyPackages: BatchExportNodeTransport[], allPackages: ContentNodeTransport[], actionFlowPackageKeys: string[], resolvedDependencies: string[], versionsByNodeKey: Map<string, string[]>): Promise<BatchExportNodeTransport[]> {
@@ -291,12 +294,12 @@ class PackageService {
     }
 
     private exportManifestOfPackages(nodes: BatchExportNodeTransport[], dependencyVersionsByNodeKey: Map<string, string[]>): ManifestNodeTransport[] {
-        const manifestNodes: ManifestNodeTransport[] = [];
+        const manifestNodesByPackageKey = new Map<string, ManifestNodeTransport>();
+
         nodes.forEach((node) => {
-            const manifestNode = {} as ManifestNodeTransport;
+            const manifestNode = manifestNodesByPackageKey.get(node.key) ?? {} as ManifestNodeTransport;
             manifestNode.packageKey = node.key;
             manifestNode.packageId = node.id;
-            manifestNode.packageVersion = node?.version?.version;
             manifestNode.space = {
                 spaceName: node.space.name,
                 spaceIcon: node.space.iconReference
@@ -315,12 +318,12 @@ class PackageService {
                 }
                 return variable;
             });
-            manifestNode.dependencies = node.dependencies as ManifestDependency[];
-            manifestNode.usedVersions = dependencyVersionsByNodeKey.get(node.key) ?? [];
-            manifestNodes.push(manifestNode);
+            manifestNode.dependenciesByVersion = manifestNode.dependenciesByVersion ?? new Map<string, ManifestDependency[]>();
+            manifestNode.dependenciesByVersion.set(node.version.version, node.dependencies);
+            manifestNodesByPackageKey.set(node.key, manifestNode);
         })
 
-        return manifestNodes;
+        return [...manifestNodesByPackageKey.values()];
     }
 }
 

--- a/src/services/package-manager/package-service.ts
+++ b/src/services/package-manager/package-service.ts
@@ -227,7 +227,7 @@ class PackageService {
 
         const fileName = "export_" + uuidv4() + ".zip";
         zip.writeZip(fileName);
-        logger.info("Successfully exported package to: " + fileName);
+        logger.info(this.fileDownloadedMessage + fileName);
     }
 
     private exportManifestOfPackages(nodes: BatchExportNodeTransport[], dependencyVersionsByNodeKey: Map<string, string[]>): ManifestNodeTransport[] {

--- a/src/services/package-manager/package-service.ts
+++ b/src/services/package-manager/package-service.ts
@@ -256,7 +256,7 @@ class PackageService {
                 return variable;
             });
             manifestNode.dependenciesByVersion = manifestNode.dependenciesByVersion ?? new Map<string, ManifestDependency[]>();
-            manifestNode.dependenciesByVersion.set(node.version.version, node.dependencies);
+            manifestNode.dependenciesByVersion.set(node.version.version, node.dependencies ?? []);
             manifestNodesByPackageKey.set(node.key, manifestNode);
         })
 

--- a/src/services/package-manager/package-service.ts
+++ b/src/services/package-manager/package-service.ts
@@ -61,7 +61,7 @@ class PackageService {
         this.exportListOfPackages(nodesListToExport, fieldsToInclude);
     }
 
-    public async batchImportPackages(spaceMappings: string[], exportedDatapoolsFile: string, exportedPackagesFile: string): Promise<void> {
+    public async batchImportPackages(spaceMappings: string[], dataModelMapping: string, exportedPackagesFile: string): Promise<void> {
         exportedPackagesFile = exportedPackagesFile + (exportedPackagesFile.includes(".zip") ? "" : ".zip");
         const zip = new AdmZip(exportedPackagesFile);
         const importedFilePath = path.resolve(tmpdir(), "export_" + uuidv4());
@@ -69,7 +69,8 @@ class PackageService {
         await zip.extractAllTo(importedFilePath);
 
         const manifestNodes = await fileService.readManifestFile(importedFilePath);
-        //TO-DO Import data-pools and data models based on the package variables
+
+        //TO-DO [DS-1462](https://celonis.atlassian.net/browse/DP-1462) Use mapping to set new datamodelIds.
         const allSpaces = await spaceApi.findAllSpaces();
         const importedKeys = [];
         for (const node of manifestNodes) {

--- a/src/services/package-manager/package-service.ts
+++ b/src/services/package-manager/package-service.ts
@@ -141,72 +141,10 @@ class PackageService {
 
     private async importPackage(packageToImport: ManifestNodeTransport, manifestNodes: ManifestNodeTransport[], spaceMappings: string[], allSpaces: SpaceTransport[], importedKeys: string[], importedFilePath: string) {
       // TODO [TN-4317](https://celonis.atlassian.net/browse/TN-4317)
-        // if (importedKeys.includes(packageToImport.packageKey)) {
-        //     return;
-        // }
-        // let targetSpaceId;
-        // if (packageToImport.dependencies.length > 0) {
-        //     for (const dependency of packageToImport.dependencies) {
-        //         if (!dependency.external) {
-        //             const dependentPackage = manifestNodes.find((node) => node.packageKey === dependency.key);
-        //             await this.importPackage(dependentPackage, manifestNodes, spaceMappings, allSpaces, importedKeys, importedFilePath)
-        //         }
-        //     }
-        // }
-        //
-        // let targetSpace = allSpaces.find(space => space.name === packageToImport.space.spaceName)
-        // const customSpacesMap: Map<string, string> = new Map();
-        // spaceMappings.forEach(spaceMap => {
-        //     const packageAndSpaceid = spaceMap.split(":");
-        //     customSpacesMap.set(packageAndSpaceid[0], packageAndSpaceid[1])
-        // })
-        // const customSpaceId = customSpacesMap.get(packageToImport.packageKey);
-        // if (customSpaceId) {
-        //     const customSpace = allSpaces.find(space => space.id === customSpaceId)
-        //     if (!customSpace) {
-        //         throw Error("Provided space id does not exist");
-        //     }
-        //     targetSpaceId = customSpace.id;
-        // } else {
-        //     if (!targetSpace) {
-        //         targetSpace = await spaceApi.createSpace({
-        //             id: uuidv4(),
-        //             name: packageToImport.space.spaceName,
-        //             iconReference: packageToImport.space.spaceIcon
-        //         });
-        //     }
-        //     targetSpaceId = targetSpace.id;
-        // }
-        //
-        // const packageZip = {
-        //     formData: {
-        //         package: await fs.createReadStream(path.resolve(importedFilePath, packageToImport.packageKey + ".zip"), {encoding: null})
-        //     },
-        // };
-        // importedKeys.push(packageToImport.packageKey);
-        // const nodeInTargetTeam = await nodeApi.findOneByKeyAndRootNodeKey(packageToImport.packageKey, packageToImport.packageKey);
-        // await packageApi.importPackage(packageZip, targetSpaceId, !!nodeInTargetTeam);
-        // if (nodeInTargetTeam) {
-        //     await packageApi.movePackageToSpace(nodeInTargetTeam.id, targetSpaceId)
-        // }
-        // await this.updateDependencyVersions(packageToImport);
-        // await this.publishPackage(packageToImport);
-        // logger.info(`Imported package with key: ${packageToImport.packageKey} successfully`)
     }
 
     private async updateDependencyVersions(node: ManifestNodeTransport): Promise<void> {
         // TODO [TN-4317](https://celonis.atlassian.net/browse/TN-4317)
-
-        // const createdNode = await nodeApi.findOneByKeyAndRootNodeKey(node.packageKey, node.packageKey);
-        // for (const dependency of node.dependencies) {
-        //     const nodeInTargetTeam = await nodeApi.findOneByKeyAndRootNodeKey(dependency.key, dependency.key);
-        //     const nextVersion = await packageApi.findActiveVersionById(nodeInTargetTeam.id);
-        //     dependency.version = nextVersion.version;
-        //     dependency.updateAvailable = false;
-        //     dependency.id = nodeInTargetTeam.rootNodeId;
-        //     dependency.rootNodeId = nodeInTargetTeam.rootNodeId;
-        //     await packageDependenciesApi.updatePackageDependency(createdNode.id, dependency);
-        // }
     }
 
     private async getDependencyPackages(nodesToResolve: BatchExportNodeTransport[], dependencyPackages: BatchExportNodeTransport[], allPackages: ContentNodeTransport[], actionFlowPackageKeys: string[], resolvedDependencies: string[], versionsByNodeKey: Map<string, string[]>): Promise<BatchExportNodeTransport[]> {
@@ -263,11 +201,10 @@ class PackageService {
         logger.info(FileService.fileDownloadedMessage + filename);
     }
 
-    private async exportPackagesAndAssets(nodes: BatchExportNodeTransport[], versionsByNodeKey: Map<string, string[]>): Promise<any[]> {
+    private async exportPackagesAndAssets(nodes: BatchExportNodeTransport[]): Promise<any[]> {
         const zips = [];
         for (const rootPackage of nodes) {
-            let exportedPackage;
-            exportedPackage = await packageApi.exportPackage(rootPackage.key, rootPackage.version.version)
+            const exportedPackage = await packageApi.exportPackage(rootPackage.key, rootPackage.version.version)
             zips.push({
                 data: exportedPackage,
                 packageKey: rootPackage.key,
@@ -279,7 +216,7 @@ class PackageService {
 
     private async exportToZip(nodes: BatchExportNodeTransport[], versionsByNodeKey: Map<string, string[]>): Promise<void> {
         const manifestNodes = this.exportManifestOfPackages(nodes, versionsByNodeKey);
-        const packageZips = await this.exportPackagesAndAssets(nodes, versionsByNodeKey);
+        const packageZips = await this.exportPackagesAndAssets(nodes);
 
         const zip = new AdmZip();
 

--- a/src/services/package-manager/package-service.ts
+++ b/src/services/package-manager/package-service.ts
@@ -86,6 +86,15 @@ class PackageService {
 
         const versionsByNodeKey = new Map<string, string[]>();
 
+        const allPackageKeys = allPackages.map(p => p.key);
+
+        for(const packageKey of packageKeys) {
+            if (!allPackageKeys.includes(packageKey)) {
+                throw  new Error(`Package ${packageKey} does not exist.`);
+            }
+        }
+
+
         nodesListToExport = await this.getNodesWithActiveVersion(nodesListToExport);
         if (includeDependencies) {
             const dependencyPackages = await this.getDependencyPackages(nodesListToExport, [], allPackages, actionFlowsPackageKeys, [], versionsByNodeKey);


### PR DESCRIPTION
#### Description

When exporting packages and their dependencies, currently we only export the latest version of each package instead of the required version that some package along the chain depends on. 
This pr makes it so we export the used version of each package and also sets the field in the usedVersion field in the manifest for each package.

#### Checklist

- [x] I have self-reviewed this PR
- [x] I have tested the change and proved that it works in different scenarios
- [x] I have updated docs if needed
