### PR TITLE
Fetch only active versions of published package

### DIFF
--- a/src/services/package-manager/package-service.ts
+++ b/src/services/package-manager/package-service.ts
@@ -47,7 +47,12 @@ class PackageService {
                 return !packagesKeyWithActionFlows.includes(node.rootNodeKey);
             })
 
-            nodesListToExport = await this.getNodesWithActiveVersion(nodesListToExport);
+            const unPublishedNodes = nodesListToExport.filter(node => !node.activatedDraftId);
+            let publishedNodes = nodesListToExport.filter(node => node.activatedDraftId);
+
+            publishedNodes = await this.getNodesWithActiveVersion(publishedNodes);
+
+            nodesListToExport = [...publishedNodes, ...unPublishedNodes];
 
             const dataModelAssignments = await dataModelService.getDatamodelsForNodes(nodesListToExport);
             nodesListToExport.forEach(node => {


### PR DESCRIPTION
#### Description

When fetching the active version of pacakges we tried to fetch the active version of unpublished packages. This would result in an error to be thrown and failing the command. 
So we need to filter only the published packages and fetch only their version.

#### Checklist

- [x] I have self-reviewed this PR
- [x] I have tested the change and proved that it works in different scenarios
- [x] I have updated docs if needed
