### PR TITLE
Remove thrown error when datamodels aren't found

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celonis/content-cli",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "CLI Tool to help manage content in Celonis EMS",
   "main": "content-cli.js",
   "bin": {

--- a/src/api/compute-pool-api.ts
+++ b/src/api/compute-pool-api.ts
@@ -7,8 +7,8 @@ class ComputePoolApi {
 
     public async findAssignedDatamodels(packageKey: string): Promise<StudioDataModelTransport[]> {
         return httpClientV2.get(`/package-manager/api/compute-pools/data-models/assigned?packageKey=${packageKey}`)
-            .catch(e=> {
-                throw new FatalError(`Problem getting datamodels of package: ${e}`);
+            .catch(e => {
+                return null;
             });
     }
 }


### PR DESCRIPTION
#### Description

There are some cases where datamodels fail to be fetched. We don't want to fail the command if a datamodel load  fails. 

#### Checklist

- [x] I have self-reviewed this PR
- [x] I have tested the change and proved that it works in different scenarios
- [x] I have updated docs if needed
