### PR TITLE
exception handler on batch package import 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celonis/content-cli",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "CLI Tool to help manage content in Celonis EMS",
   "main": "content-cli.js",
   "bin": {

--- a/src/api/space-api.ts
+++ b/src/api/space-api.ts
@@ -1,8 +1,3 @@
-import {
-    ContentNodeTransport,
-    PackageHistoryTransport,
-    PackageWithVariableAssignments
-} from "../interfaces/package-manager.interfaces";
 import {httpClientV2} from "../services/http-client-service.v2";
 import {FatalError} from "../util/logger";
 import {SpaceTransport} from "../interfaces/save-space.interface";
@@ -12,19 +7,19 @@ class SpaceApi {
 
     public async findOne(spaceId: string): Promise<SpaceTransport> {
         return httpClientV2.get(`/package-manager/api/spaces/${spaceId}`).catch(e => {
-            throw new FatalError(`Problem getting packages: ${e}`);
+            throw new FatalError(`Problem getting space: ${spaceId} ${e}`);
         });
     }
 
     public async findAllSpaces(): Promise<SpaceTransport[]> {
         return httpClientV2.get("/package-manager/api/spaces").catch(e => {
-            throw new FatalError(`Problem getting packages: ${e}`);
+            throw new FatalError(`Problem getting spaces: ${e}`);
         });
     }
 
     public async createSpace(space: SpaceTransport): Promise<SpaceTransport> {
         return httpClientV2.post("/package-manager/api/spaces", space).catch(e => {
-            throw new FatalError(`Problem getting packages: ${e}`);
+            throw new FatalError(`Problem space creation: ${e}`);
         });
     }
 

--- a/src/services/package-manager/package-service.ts
+++ b/src/services/package-manager/package-service.ts
@@ -1,4 +1,4 @@
-import {FatalError, logger} from "../../util/logger";
+import {logger} from "../../util/logger";
 import {packageApi} from "../../api/package-api";
 import {v4 as uuidv4} from "uuid";
 import {FileService, fileService} from "../file-service";

--- a/src/services/package-manager/package-service.ts
+++ b/src/services/package-manager/package-service.ts
@@ -1,4 +1,4 @@
-import {logger} from "../../util/logger";
+import {FatalError, logger} from "../../util/logger";
 import {packageApi} from "../../api/package-api";
 import {v4 as uuidv4} from "uuid";
 import {FileService, fileService} from "../file-service";
@@ -123,7 +123,11 @@ class PackageService {
         const versionsOfPackage = [...packageToImport.dependenciesByVersion.keys()].sort((k1, k2) => this.compareVersions(k1, k2)).filter(version => !importedPackageVersion.includes(version));
 
         for (const version of versionsOfPackage) {
-            await this.importPackageVersion(packageToImport, manifestNodes, sourceToTargetVersionsByNodeKey, spaceMappings, importedVersionsByNodeKey, draftIdsByPackageKeyAndVersion, importedFilePath, version);
+            try {
+                await this.importPackageVersion(packageToImport, manifestNodes, sourceToTargetVersionsByNodeKey, spaceMappings, importedVersionsByNodeKey, draftIdsByPackageKeyAndVersion, importedFilePath, version);
+            } catch (e) {
+                logger.error(`Problem import package with key: ${packageToImport.packageKey} ${version} ${e}`);
+            }
         }
     }
 


### PR DESCRIPTION
#### Description

Since any exception on any package import causes the failure of the whole process and causes the skipping of upcoming imports, an exception handler is added for each package import.  Otherwise (in the current stage), it applies the before exception imports but skips the upcoming ones

Before handler;
![image](https://github.com/celonis/content-cli/assets/93587193/3e44ad85-6da6-4d6f-ba1d-59a4604c2ad8)
After handler;
![image](https://github.com/celonis/content-cli/assets/93587193/3b33aced-cae5-489e-b1c5-829d6da967c2)


#### Checklist

- [x] I have self-reviewed this PR
- [x] I have tested the change and proved that it works in different scenarios
- [x] I have updated docs if needed
