### PR TITLE
PAD-2091: Datapools success message refactors

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celonis/content-cli",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "CLI Tool to help manage content in Celonis EMS",
   "main": "content-cli.js",
   "bin": {

--- a/src/services/data-pool/data-pool-service.ts
+++ b/src/services/data-pool/data-pool-service.ts
@@ -13,7 +13,7 @@ class DataPoolService {
         if (outputToJsonFile) {
             const reportFileName = "batch_import_report_" + uuidv4() + ".json";
             fileService.writeToFileWithGivenName(importReportString, reportFileName);
-            logger.info(FileService.fileDownloadedMessage + reportFileName);
+            logger.info("Batch import report file: " + reportFileName);
         } else {
             logger.info("Batch import report: \n" + importReportString);
         }

--- a/src/services/data-pool/data-pool-service.ts
+++ b/src/services/data-pool/data-pool-service.ts
@@ -10,11 +10,10 @@ class DataPoolService {
         const importReport = await dataPoolApi.executeDataPoolsBatchImport(requestFileContent);
         const importReportString = JSON.stringify(importReport, null, 4);
 
-        logger.info("Data Pools batch import succeeded!");
         if (outputToJsonFile) {
             const reportFileName = "batch_import_report_" + uuidv4() + ".json";
             fileService.writeToFileWithGivenName(importReportString, reportFileName);
-            logger.info("Batch import report file: " + reportFileName);
+            logger.info(FileService.fileDownloadedMessage + reportFileName);
         } else {
             logger.info("Batch import report: \n" + importReportString);
         }
@@ -24,11 +23,10 @@ class DataPoolService {
         const exportedDataPool = await dataPoolApi.exportDataPool(poolId);
         const exportedDataPoolString = JSON.stringify(exportedDataPool, null, 4);
 
-        logger.info("Data Pools export succeeded!");
         if (outputToJsonFile) {
-            const reportFileName = "data_pool_" + poolId + ".json";
+            const reportFileName = uuidv4() + "data_pool_" + poolId + ".json";
             fileService.writeToFileWithGivenName(exportedDataPoolString, reportFileName);
-            logger.info("Export file: " + reportFileName);
+            logger.info(FileService.fileDownloadedMessage + reportFileName);
         } else {
             logger.info("Exported Data Pool: \n" + exportedDataPoolString);
         }


### PR DESCRIPTION
#### Description

Success message refactors for export & import operations of data pools to stick with the current output structure of content-cli

#### Checklist

- [x] I have self-reviewed this PR
- [x] I have tested the change and proved that it works in different scenarios
- [ ] I have updated docs if needed
