### PR TITLE
DP-1712 Fix list command profile parsing issue

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -425,7 +425,6 @@ In order to batch push a list of data pools use the following command:
     "targetTeamDomain": "dev1",
     "dataPoolImportRequests": [
         {
-            "sourcePoolId": "850728cc-c679-4925-954a-87fb39abb12b",
             "targetPoolId": "80a1389d-50c5-4976-ad6e-fb5b7a2b5517",
             "dataSourceMappings": {
                 "69e7c6b8-a36c-48ee-8dba-9bb89baf41dd": "98b4b2d9-898d-4b72-aeb9-ebd87c097cb3",
@@ -434,7 +433,6 @@ In order to batch push a list of data pools use the following command:
             "dataPool": {...}
         },
         {
-            "sourcePoolId": "510fde4e-4a53-4a4e-9331-31038bcaf891",
             "targetPoolId": "1b9b368b-e0df-4e74-99e8-59e2febe9687",
             "dataSourceMappings": {
                 "e9359d63-5ccf-4f0d-8da3-24cda8a42c01": "096c0280-4cb9-4279-a003-b77698287aba",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celonis/content-cli",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "description": "CLI Tool to help manage content in Celonis EMS",
   "main": "content-cli.js",
   "bin": {

--- a/src/content-cli-list.ts
+++ b/src/content-cli-list.ts
@@ -1,11 +1,10 @@
-import {PackageCommand} from "./commands/package.command";
-import {SpaceCommand} from "./commands/space.command";
-import {DataPoolCommand} from "./commands/data-pool.command";
-import {AssetCommand} from "./commands/asset.command";
-
+import { PackageCommand } from "./commands/package.command";
+import { SpaceCommand } from "./commands/space.command";
+import { DataPoolCommand } from "./commands/data-pool.command";
+import { AssetCommand } from "./commands/asset.command";
+import { logger } from "./util/logger";
 import commander = require("commander");
-import {contextService} from "./services/context.service";
-import {logger} from "./util/logger";
+import { ContextInitializer } from "./util/context-initializer";
 
 type CommanderStatic = commander.CommanderStatic;
 
@@ -19,7 +18,7 @@ export class List {
             .option("--includeDependencies", "Include variables and dependencies", "")
             .option("--packageKeys <packageKeys...>", "Lists only given package keys")
             .action(async cmd => {
-                await new PackageCommand().listPackages(cmd.json, cmd.includeDependencies, cmd.packageKeys)
+                await new PackageCommand().listPackages(cmd.json, cmd.includeDependencies, cmd.packageKeys);
                 process.exit();
             });
 
@@ -69,24 +68,24 @@ export class List {
     }
 }
 
-
-const options = commander.parseOptions(process.argv)
-const indexOfProfileOption = options.unknown.indexOf('-p') ?? options.unknown.indexOf('--profile');
-
 process.on("unhandledRejection", (e, promise) => {
     logger.error(e.toString());
-})
+});
 
-contextService.resolveProfile(options.unknown[indexOfProfileOption + 1]).then(() => {
+const loadAllCommands = () => {
     List.packages(commander);
     List.spaces(commander);
     List.dataPools(commander);
     List.assets(commander);
 
     commander.parse(process.argv);
-}).catch(e => {
-    console.log(e)
-});
+};
+
+ContextInitializer.initContext()
+    .then(loadAllCommands)
+    .catch(e => {
+        logger.error(e);
+    });
 
 if (!process.argv.slice(2).length) {
     commander.outputHelp();

--- a/src/services/data-pool/data-pool-service.ts
+++ b/src/services/data-pool/data-pool-service.ts
@@ -24,7 +24,7 @@ class DataPoolService {
         const exportedDataPoolString = JSON.stringify(exportedDataPool, null, 4);
 
         if (outputToJsonFile) {
-            const reportFileName = uuidv4() + "data_pool_" + poolId + ".json";
+            const reportFileName = uuidv4() + "_data_pool_" + poolId + ".json";
             fileService.writeToFileWithGivenName(exportedDataPoolString, reportFileName);
             logger.info(FileService.fileDownloadedMessage + reportFileName);
         } else {


### PR DESCRIPTION
#### Description

https://celonis.atlassian.net/browse/DP-1712

* Fix list command profile parsing issue. If the `--profile` option is used, the list command still gives the error that no profile was provided. This is due to a bug in determining `--profile` option index (see more in DP-1712 ticket description). This PR changes the implementation to use the `ContextInitializer`.

* Update documentation. Removed redundant field from data-pool import request json.

* Fix the name for data pool export file. Added an underscore between uuid and "data_pool".

#### Checklist

- [x] I have self-reviewed this PR
- [x] I have tested the change and proved that it works in different scenarios (tested all list commands, tested data pool export command)
- [x] I have updated docs if needed
