### PR TITLE
TN-4557 Add overwrite flag to not allow unpublished changes to be overwritten by default

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -300,6 +300,13 @@ the data pool import command.
 content-cli import packages -p <profileName> --file <exportedPackagesFile> --dataModelMappingsFile <dataModelMappingsFile>
 ```
 
+By default, you can not overwrite a package in the target team. To do this you can use the overwrite flag -o --overwrite
+
+```
+// Example usage of dataModelMappingsFile
+content-cli import packages -p <profileName> --file <exportedPackagesFile> --dataModelMappingsFile <dataModelMappingsFile> -o/--overwrite
+```
+
 ### List all spaces in Studio
 With this command you can retrieve a list of all spaces within a team.
 The command takes your permissions into consideration and only lists the

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -300,7 +300,7 @@ the data pool import command.
 content-cli import packages -p <profileName> --file <exportedPackagesFile> --dataModelMappingsFile <dataModelMappingsFile>
 ```
 
-By default, you can not overwrite a package in the target team. To do this you can use the overwrite flag -o, --overwrite
+By default, you can not overwrite a package in the target team. To do this you can use the overwrite flag --overwrite
 
 ```
 // Example usage of dataModelMappingsFile

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -300,11 +300,11 @@ the data pool import command.
 content-cli import packages -p <profileName> --file <exportedPackagesFile> --dataModelMappingsFile <dataModelMappingsFile>
 ```
 
-By default, you can not overwrite a package in the target team. To do this you can use the overwrite flag -o --overwrite
+By default, you can not overwrite a package in the target team. To do this you can use the overwrite flag -o, --overwrite
 
 ```
 // Example usage of dataModelMappingsFile
-content-cli import packages -p <profileName> --file <exportedPackagesFile> --dataModelMappingsFile <dataModelMappingsFile> -o/--overwrite
+content-cli import packages -p <profileName> --file <exportedPackagesFile> --dataModelMappingsFile <dataModelMappingsFile> --overwrite
 ```
 
 ### List all spaces in Studio

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celonis/content-cli",
-  "version": "0.4.8",
+  "version": "0.4.9",
   "description": "CLI Tool to help manage content in Celonis EMS",
   "main": "content-cli.js",
   "bin": {

--- a/src/commands/package.command.ts
+++ b/src/commands/package.command.ts
@@ -48,7 +48,7 @@ export class PackageCommand {
         await packageService.batchExportPackages(packageKeys, includeDependencies);
     }
 
-    public async batchImportPackages(spaceMappings: string[], dataModelMappingsFilePath: string, exportedPackagesFile: string): Promise<void> {
-        await packageService.batchImportPackages(spaceMappings ?? [], dataModelMappingsFilePath, exportedPackagesFile);
+    public async batchImportPackages(spaceMappings: string[], dataModelMappingsFilePath: string, exportedPackagesFile: string, overwrite: boolean): Promise<void> {
+        await packageService.batchImportPackages(spaceMappings ?? [], dataModelMappingsFilePath, exportedPackagesFile, overwrite);
     }
 }

--- a/src/content-cli-import.ts
+++ b/src/content-cli-import.ts
@@ -15,10 +15,11 @@ export class Import {
                 "--spaceMappings <spaceMappings...>",
                 "List of mappings for importing packages to different target spaces. Mappings should follow format 'packageKey:targetSpaceKey'"
             )
+            .option("-o --overwrite", "Flag to allow overwriting of packages")
             .option("--dataModelMappingsFile <dataModelMappingsFile>", "DataModel variable mappings file path")
             .requiredOption("-f, --file <file>", "Exported packages file (relative path)")
             .action(async cmd => {
-                await new PackageCommand().batchImportPackages(cmd.spaceMappings, cmd.dataModelMappingsFile, cmd.file);
+                await new PackageCommand().batchImportPackages(cmd.spaceMappings, cmd.dataModelMappingsFile, cmd.file, cmd.overwrite);
                 process.exit();
             });
 

--- a/src/content-cli-import.ts
+++ b/src/content-cli-import.ts
@@ -15,7 +15,7 @@ export class Import {
                 "--spaceMappings <spaceMappings...>",
                 "List of mappings for importing packages to different target spaces. Mappings should follow format 'packageKey:targetSpaceKey'"
             )
-            .option("-o --overwrite", "Flag to allow overwriting of packages")
+            .option("--overwrite", "Flag to allow overwriting of packages")
             .option("--dataModelMappingsFile <dataModelMappingsFile>", "DataModel variable mappings file path")
             .requiredOption("-f, --file <file>", "Exported packages file (relative path)")
             .action(async cmd => {

--- a/src/services/package-manager/package-service.ts
+++ b/src/services/package-manager/package-service.ts
@@ -30,7 +30,7 @@ class PackageService {
     }
 
     public async findAndExportListOfAllPackages(includeDependencies: boolean, packageKeys: string[]): Promise<void> {
-        const fieldsToInclude = ["key", "name", "changeDate", "activatedDraftId","workingDraftId", "spaceId"];
+        const fieldsToInclude = ["key", "name", "changeDate", "activatedDraftId", "workingDraftId", "spaceId"];
 
         let nodesListToExport: BatchExportNodeTransport[] = await packageApi.findAllPackages();
         if (packageKeys.length > 0) {
@@ -88,7 +88,7 @@ class PackageService {
                 .filter(node => manifestNodeKeys.includes(node.key))
                 .forEach(node => {
                     if (node.workingDraftId !== node.activatedDraftId) {
-                        throw new FatalError(`Cannot overwrite package that has unpublished changes. Package with key ${node.key}`)
+                        throw new FatalError("Failed to import. Cannot overwrite packages.");
                     }
                 })
         }

--- a/src/services/package-manager/package-service.ts
+++ b/src/services/package-manager/package-service.ts
@@ -30,7 +30,7 @@ class PackageService {
     }
 
     public async findAndExportListOfAllPackages(includeDependencies: boolean, packageKeys: string[]): Promise<void> {
-        const fieldsToInclude = ["key", "name", "changeDate", "activatedDraftId", "spaceId"];
+        const fieldsToInclude = ["key", "name", "changeDate", "activatedDraftId","workingDraftId", "spaceId"];
 
         let nodesListToExport: BatchExportNodeTransport[] = await packageApi.findAllPackages();
         if (packageKeys.length > 0) {


### PR DESCRIPTION
#### Description
Added a overwrite flag in the import packages command. When overwrite flag is false we need to check if any of the nodes we are trying to import on the target have any unpublished changes there. If they do we fail it. If overwrite is true we proccede as before.

#### Checklist

- [x] I have self-reviewed this PR
- [x] I have tested the change and proved that it works in different scenarios
- [x] I have updated docs if needed
