### PR TITLE
TN-4564: Improve performance of listing and export

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celonis/content-cli",
-  "version": "0.4.9",
+  "version": "0.5.0",
   "description": "CLI Tool to help manage content in Celonis EMS",
   "main": "content-cli.js",
   "bin": {

--- a/src/api/compute-pool-api.ts
+++ b/src/api/compute-pool-api.ts
@@ -1,12 +1,11 @@
-import {StudioDataModelTransport} from "../interfaces/package-manager.interfaces";
+import {StudioComputeNodeDescriptor} from "../interfaces/package-manager.interfaces";
 import {httpClientV2} from "../services/http-client-service.v2";
-import {FatalError} from "../util/logger";
 
 class ComputePoolApi {
     public static readonly INSTANCE = new ComputePoolApi();
 
-    public async findAssignedDatamodels(packageKey: string): Promise<StudioDataModelTransport[]> {
-        return httpClientV2.get(`/package-manager/api/compute-pools/data-models/assigned?packageKey=${packageKey}`)
+    public async findAllDataModelsDetails(): Promise<StudioComputeNodeDescriptor[]> {
+        return httpClientV2.get("/package-manager/api/compute-pools/data-models/details")
             .catch(e => {
                 return null;
             });

--- a/src/api/package-api.ts
+++ b/src/api/package-api.ts
@@ -1,7 +1,7 @@
 import {httpClientV2} from "../services/http-client-service.v2";
 import {
     ActivatePackageTransport,
-    ContentNodeTransport, PackageHistoryTransport, PackageWithVariableAssignments
+    ContentNodeTransport, PackageHistoryTransport, PackageManagerVariableType, PackageWithVariableAssignments
 } from "../interfaces/package-manager.interfaces";
 import {FatalError} from "../util/logger";
 
@@ -25,8 +25,13 @@ class PackageApi {
         });
     }
 
-    public async findAllPackagesWithVariableAssignments(): Promise<PackageWithVariableAssignments[]> {
-        return httpClientV2.get("/package-manager/api/packages/with-variable-assignments").catch(e => {
+    public async findAllPackagesWithVariableAssignments(type: PackageManagerVariableType): Promise<PackageWithVariableAssignments[]> {
+        const queryParams = new URLSearchParams();
+        if (type) {
+            queryParams.set("type", type);
+        }
+
+        return httpClientV2.get(`/package-manager/api/packages/with-variable-assignments?${queryParams.toString()}`).catch(e => {
             throw new FatalError(`Problem getting variables of packages: : ${e}`);
         });
     }

--- a/src/api/package-api.ts
+++ b/src/api/package-api.ts
@@ -1,7 +1,10 @@
 import {httpClientV2} from "../services/http-client-service.v2";
 import {
     ActivatePackageTransport,
-    ContentNodeTransport, PackageHistoryTransport, PackageManagerVariableType, PackageWithVariableAssignments
+    ContentNodeTransport,
+    PackageHistoryTransport,
+    PackageManagerVariableType,
+    PackageWithVariableAssignments
 } from "../interfaces/package-manager.interfaces";
 import {FatalError} from "../util/logger";
 

--- a/src/api/variables-api.ts
+++ b/src/api/variables-api.ts
@@ -1,6 +1,6 @@
 import {
     ContentNodeTransport,
-    VariableDefinitionWithValue, VariablesAssignments
+    VariablesAssignments
 } from "../interfaces/package-manager.interfaces";
 import {httpClientV2} from "../services/http-client-service.v2";
 import {FatalError} from "../util/logger";

--- a/src/interfaces/batch-export-node-transport.ts
+++ b/src/interfaces/batch-export-node-transport.ts
@@ -1,7 +1,9 @@
 import {
-    ContentNodeTransport, DataModelTransport,
+    ContentNodeTransport,
     PackageDependencyTransport,
-    PackageHistoryTransport, StudioDataModelTransport, VariablesAssignments
+    PackageHistoryTransport,
+    StudioComputeNodeDescriptor,
+    VariablesAssignments
 } from "./package-manager.interfaces";
 import {SpaceTransport} from "./save-space.interface";
 
@@ -10,7 +12,7 @@ export interface BatchExportNodeTransport extends ContentNodeTransport {
     activatedDraftId: string;
     version?: PackageHistoryTransport;
     dependencies?: PackageDependencyTransport[];
-    datamodels?: StudioDataModelTransport[];
+    datamodels?: StudioComputeNodeDescriptor[];
     variables?: VariablesAssignments[];
     space?: SpaceTransport;
 }

--- a/src/interfaces/package-manager.interfaces.ts
+++ b/src/interfaces/package-manager.interfaces.ts
@@ -59,11 +59,18 @@ export interface VariablesAssignments {
 
 export interface VariableDefinitionWithValue {
     key: string;
-    type: string;
+    type: PackageManagerVariableType;
     description?: string;
     source?: string;
     runtime?: boolean;
     metadata?: object;
+}
+
+export enum PackageManagerVariableType {
+    DATA_MODEL="DATA_MODEL",
+    CONNECTION="CONNECTION",
+    ASSIGNMENT_RULE="ASSIGNMENT_RULE",
+    PLAIN_TEXT= "PLAIN_TEXT"
 }
 
 export interface PackageHistoryTransport {
@@ -81,6 +88,7 @@ export interface StudioDataModelTransport {
 export interface StudioComputeNodeDescriptor {
     name: string;
     dataModelId: string;
+    poolId: string;
 }
 
 export interface ComputePoolTransport {

--- a/src/services/package-manager/datamodel-service.ts
+++ b/src/services/package-manager/datamodel-service.ts
@@ -1,22 +1,18 @@
-import {BatchExportNodeTransport} from "../../interfaces/batch-export-node-transport";
 import {computePoolApi} from "../../api/compute-pool-api";
 import {
-    PackageManagerVariableType,
+    PackageWithVariableAssignments,
     StudioComputeNodeDescriptor
 } from "../../interfaces/package-manager.interfaces";
-import {variableService} from "./variable-service";
 
 class DataModelService {
     public static readonly INSTANCE = new DataModelService();
 
-    public async getDataModelDetailsForNodes(nodes: BatchExportNodeTransport[]): Promise<Map<string, StudioComputeNodeDescriptor[]>> {
+    public async getDataModelDetailsForPackages(packagesWithDataModelVariables: PackageWithVariableAssignments[]): Promise<Map<string, StudioComputeNodeDescriptor[]>> {
         const dataModelsMap = new Map<string, StudioComputeNodeDescriptor[]>();
         const allAvailableDataModels = await computePoolApi.findAllDataModelsDetails();
 
-        const packageWithVariableAssignments = await variableService.getVariableAssignmentsForNodes(PackageManagerVariableType.DATA_MODEL);
-
-        for (const node of nodes) {
-            const variablesOfPackage = packageWithVariableAssignments.find(nodeWithVariablesAssignment => nodeWithVariablesAssignment.key === node.key)?.variableAssignments;
+        for (const node of packagesWithDataModelVariables) {
+            const variablesOfPackage = packagesWithDataModelVariables.find(nodeWithVariablesAssignment => nodeWithVariablesAssignment.key === node.key)?.variableAssignments;
             const dataModelIds = variablesOfPackage.filter(variable => variable.value).map(variable => variable.value.toString());
 
             const assignedDataModels = allAvailableDataModels.filter(dataModel => dataModelIds.includes(dataModel.dataModelId));
@@ -24,8 +20,6 @@ class DataModelService {
         }
         return dataModelsMap;
     }
-
-
 }
 
 export const dataModelService = DataModelService.INSTANCE;

--- a/src/services/package-manager/variable-service.ts
+++ b/src/services/package-manager/variable-service.ts
@@ -1,16 +1,15 @@
 import {packageApi} from "../../api/package-api";
 import {
+    PackageManagerVariableType,
     PackageWithVariableAssignments,
-    VariableDefinitionWithValue,
     VariablesAssignments
 } from "../../interfaces/package-manager.interfaces";
-import {BatchExportNodeTransport} from "../../interfaces/batch-export-node-transport";
 import {variablesApi} from "../../api/variables-api";
 
 class VariableService {
 
-    public async getVariableAssignmentsForNodes(nodes: BatchExportNodeTransport[]): Promise<PackageWithVariableAssignments[]> {
-        return await packageApi.findAllPackagesWithVariableAssignments();
+    public async getVariableAssignmentsForNodes(type?: PackageManagerVariableType): Promise<PackageWithVariableAssignments[]> {
+        return await packageApi.findAllPackagesWithVariableAssignments(type);
     }
 
     public async assignVariableValues(packageKey: string, variablesAssignments: VariablesAssignments[]): Promise<void> {


### PR DESCRIPTION
#### Description
The endpoint we were using for fetching datapools was really slow. We swapped it out for a more lightweight endpoint that returns less data. We also removed the dataPool name  and changed the signature of the listing and manifest file to comply to the new endpoint.
#### Checklist

- [x] I have self-reviewed this PR
- [x] I have tested the change and proved that it works in different scenarios
- [x] I have updated docs if needed
