### PR TITLE
PAD-2316: find all spaces method fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celonis/content-cli",
-  "version": "0.4.9",
+  "version": "0.4.10",
   "description": "CLI Tool to help manage content in Celonis EMS",
   "main": "content-cli.js",
   "bin": {

--- a/src/services/package-manager/package-service.ts
+++ b/src/services/package-manager/package-service.ts
@@ -278,7 +278,7 @@ class PackageService {
 
     private async getTargetSpaceForExportedPackage(packageToImport: ManifestNodeTransport, spaceMappings: Map<string, string>): Promise<SpaceTransport> {
         let targetSpace;
-        const allSpaces = await spaceService.getAllSpaces();
+        const allSpaces = await spaceService.refreshAndGetAllSpaces();
         if (spaceMappings.has(packageToImport.packageKey)) {
             const customSpaceId = spaceMappings.get(packageToImport.packageKey);
             const customSpace = allSpaces.find(space => space.id === customSpaceId);

--- a/src/services/package-manager/space-service.ts
+++ b/src/services/package-manager/space-service.ts
@@ -28,15 +28,17 @@ class SpaceService {
             iconReference: spaceIcon
         });
 
+        await this.refreshAndGetAllSpaces();
         this.allSpaces.push(newSpace);
         return newSpace;
     }
 
-    public async getAllSpaces(): Promise<SpaceTransport[]> {
+    public async refreshAndGetAllSpaces(): Promise<SpaceTransport[]> {
         if (this.allSpaces.length) {
             return this.allSpaces;
         }
-        return await spaceApi.findAllSpaces();
+        this.allSpaces = await spaceApi.findAllSpaces();
+        return this.allSpaces;
     }
 }
 


### PR DESCRIPTION
#### Description

Please include a description of the change and why the change was made.
Two case below has been fixed for on space-api
- It was returning only 1 space when createSpace was called beforehand
- It was fetching the spaces from service every time since it was not assigning the result to allSpaces variable

#### Checklist

- [x] I have self-reviewed this PR
- [x] I have tested the change and proved that it works in different scenarios
