### PR TITLE
PAD-2329: extending "can not overwrite message"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celonis/content-cli",
-  "version": "0.4.10",
+  "version": "0.4.11",
   "description": "CLI Tool to help manage content in Celonis EMS",
   "main": "content-cli.js",
   "bin": {

--- a/src/services/package-manager/package-service.ts
+++ b/src/services/package-manager/package-service.ts
@@ -84,13 +84,13 @@ class PackageService {
         if (!overwrite) {
             const allTargetPackages = await packageApi.findAllPackages();
             const manifestNodeKeys = manifestNodes.map(node => node.packageKey);
-            allTargetPackages
-                .filter(node => manifestNodeKeys.includes(node.key))
-                .forEach(node => {
-                    if (node.workingDraftId !== node.activatedDraftId) {
-                        throw new FatalError("Failed to import. Cannot overwrite packages.");
-                    }
-                })
+            const packagesWithDraftChanges = allTargetPackages
+                .filter(node => manifestNodeKeys.includes(node.key) && node.workingDraftId !== node.activatedDraftId)
+                .map(node => node.key)
+                .join(", ");
+            if (!!packagesWithDraftChanges) {
+                throw new FatalError(`Failed to import. Cannot overwrite packages with key(s) ${packagesWithDraftChanges}`)
+            }
         }
 
         let dmTargetIdsBySourceIds: Map<string, string> = new Map();


### PR DESCRIPTION
#### Description

Can not overwrite message on the import is extended with problematic packages info.

existing message;
<img width="488" alt="image" src="https://github.com/celonis/content-cli/assets/93587193/6c81d55e-b128-4f43-8da4-a3b2f5c3c3b9">
updated message;
<img width="1466" alt="image" src="https://github.com/celonis/content-cli/assets/93587193/9a6b1ba2-8107-4f0e-95bf-c0a330222d82">
<img width="916" alt="image" src="https://github.com/celonis/content-cli/assets/93587193/ba4b1716-a55b-4448-a963-9efefe534e8b">
Does not affect when there are no unpublished changes on the target
<img width="1676" alt="image" src="https://github.com/celonis/content-cli/assets/93587193/efae37c7-a5dd-4ace-8979-e1fb253f0648">


#### Checklist

- [x] I have self-reviewed this PR
- [x] I have tested the change and proved that it works in different scenarios
- [ ] I have updated docs if needed
