### PR TITLE
tracing headers fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celonis/content-cli",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "CLI Tool to help manage content in Celonis EMS",
   "main": "content-cli.js",
   "bin": {

--- a/src/util/tracing.ts
+++ b/src/util/tracing.ts
@@ -5,7 +5,7 @@ export class TracingUtils {
     public static getTracingHeaders(): { [key: string]: string } {
         return {
             "x-datadog-trace-id": this.getTraceId(),
-            "x-datadog-parent-id": this.getTraceId(),
+            "x-datadog-parent-id": this.getParentId(),
             "x-datadog-sampling-priority": "1",
         };
     }
@@ -13,6 +13,11 @@ export class TracingUtils {
     private static getTraceId(): string {
         return process.env.TRACE_ID || this.generateId();
     }
+
+    private static getParentId(): string {
+        return process.env.PARENT_ID || this.generateId();
+    }
+
 
     private static generateId(): string {
         return crypto.randomBytes(8).toString("hex");

--- a/src/util/tracing.ts
+++ b/src/util/tracing.ts
@@ -5,6 +5,7 @@ export class TracingUtils {
     public static getTracingHeaders(): { [key: string]: string } {
         return {
             "x-datadog-trace-id": this.getTraceId(),
+            "x-datadog-parent-id": this.getTraceId(),
             "x-datadog-sampling-priority": "1",
         };
     }

--- a/src/util/tracing.ts
+++ b/src/util/tracing.ts
@@ -5,7 +5,7 @@ export class TracingUtils {
     public static getTracingHeaders(): { [key: string]: string } {
         return {
             "x-datadog-trace-id": this.getTraceId(),
-            "x-datadog-parent-id": this.getParentId(),
+            "x-datadog-parent-id": this.getTraceParentId(),
             "x-datadog-sampling-priority": "1",
         };
     }
@@ -14,8 +14,8 @@ export class TracingUtils {
         return process.env.TRACE_ID || this.generateId();
     }
 
-    private static getParentId(): string {
-        return process.env.PARENT_ID || this.generateId();
+    private static getTraceParentId(): string {
+        return process.env.PARENT_TRACE_ID || this.generateId();
     }
 
     private static generateId(): string {

--- a/src/util/tracing.ts
+++ b/src/util/tracing.ts
@@ -5,7 +5,7 @@ export class TracingUtils {
     public static getTracingHeaders(): { [key: string]: string } {
         return {
             "x-datadog-trace-id": this.getTraceId(),
-            "x-datadog-parent-id": this.getTraceParentId(),
+            "x-datadog-parent-id": this.getParentTraceId(),
             "x-datadog-sampling-priority": "1",
         };
     }
@@ -14,7 +14,7 @@ export class TracingUtils {
         return process.env.TRACE_ID || this.generateId();
     }
 
-    private static getTraceParentId(): string {
+    private static getParentTraceId(): string {
         return process.env.PARENT_TRACE_ID || this.generateId();
     }
 

--- a/src/util/tracing.ts
+++ b/src/util/tracing.ts
@@ -18,7 +18,6 @@ export class TracingUtils {
         return process.env.PARENT_ID || this.generateId();
     }
 
-
     private static generateId(): string {
         return crypto.randomBytes(8).toString("hex");
     }


### PR DESCRIPTION
#### Description

Passing `x-datadog-parent-id` header as null causes a generation of new trace-id on the service layer. Populated `x-datadog-parent-id` via trace-id as well to avoid it.

#### Checklist

- [x] I have self-reviewed this PR
- [x] I have tested the change and proved that it works in different scenarios
