### PR TITLE
[TA-2674] Assign package variables from manifest file

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celonis/content-cli",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "CLI Tool to help manage content in Celonis EMS",
   "main": "content-cli.js",
   "bin": {

--- a/src/commands/package.command.ts
+++ b/src/commands/package.command.ts
@@ -48,7 +48,7 @@ export class PackageCommand {
         await packageService.batchExportPackages(packageKeys, includeDependencies);
     }
 
-    public async batchImportPackages(spaceMappings: string[], exportedPackagesFile: string, overwrite: boolean): Promise<void> {
-        await packageService.batchImportPackages(spaceMappings ?? [], exportedPackagesFile, overwrite);
+    public async batchImportPackages(spaceMappings: string[], dataModelMappingsFilePath: string, exportedPackagesFile: string, overwrite: boolean): Promise<void> {
+        await packageService.batchImportPackages(spaceMappings ?? [], dataModelMappingsFilePath, exportedPackagesFile, overwrite);
     }
 }

--- a/src/commands/package.command.ts
+++ b/src/commands/package.command.ts
@@ -48,7 +48,7 @@ export class PackageCommand {
         await packageService.batchExportPackages(packageKeys, includeDependencies);
     }
 
-    public async batchImportPackages(spaceMappings: string[], dataModelMappingsFilePath: string, exportedPackagesFile: string, overwrite: boolean): Promise<void> {
-        await packageService.batchImportPackages(spaceMappings ?? [], dataModelMappingsFilePath, exportedPackagesFile, overwrite);
+    public async batchImportPackages(spaceMappings: string[], exportedPackagesFile: string, overwrite: boolean): Promise<void> {
+        await packageService.batchImportPackages(spaceMappings ?? [], exportedPackagesFile, overwrite);
     }
 }

--- a/src/content-cli-import.ts
+++ b/src/content-cli-import.ts
@@ -16,10 +16,9 @@ export class Import {
                 "List of mappings for importing packages to different target spaces. Mappings should follow format 'packageKey:targetSpaceKey'"
             )
             .option("--overwrite", "Flag to allow overwriting of packages")
-            .option("--dataModelMappingsFile <dataModelMappingsFile>", "DataModel variable mappings file path")
             .requiredOption("-f, --file <file>", "Exported packages file (relative path)")
             .action(async cmd => {
-                await new PackageCommand().batchImportPackages(cmd.spaceMappings, cmd.dataModelMappingsFile, cmd.file, cmd.overwrite);
+                await new PackageCommand().batchImportPackages(cmd.spaceMappings, cmd.file, cmd.overwrite);
                 process.exit();
             });
 

--- a/src/content-cli-import.ts
+++ b/src/content-cli-import.ts
@@ -16,9 +16,10 @@ export class Import {
                 "List of mappings for importing packages to different target spaces. Mappings should follow format 'packageKey:targetSpaceKey'"
             )
             .option("--overwrite", "Flag to allow overwriting of packages")
+            .option("--dataModelMappingsFile <dataModelMappingsFile>", "DataModel variable mappings file path. If missing, variables will be mapped from manifest file.")
             .requiredOption("-f, --file <file>", "Exported packages file (relative path)")
             .action(async cmd => {
-                await new PackageCommand().batchImportPackages(cmd.spaceMappings, cmd.file, cmd.overwrite);
+                await new PackageCommand().batchImportPackages(cmd.spaceMappings, cmd.dataModelMappingsFile, cmd.file, cmd.overwrite);
                 process.exit();
             });
 

--- a/src/services/package-manager/package-service.ts
+++ b/src/services/package-manager/package-service.ts
@@ -71,7 +71,7 @@ class PackageService {
         this.exportListOfPackages(nodesListToExport, fieldsToInclude);
     }
 
-    public async batchImportPackages(spaceMappings: string[], dataModelMappingsFilePath: string, exportedPackagesFile: string, overwrite: boolean): Promise<void> {
+    public async batchImportPackages(spaceMappings: string[], exportedPackagesFile: string, overwrite: boolean): Promise<void> {
         exportedPackagesFile = exportedPackagesFile + (exportedPackagesFile.includes(".zip") ? "" : ".zip");
         const zip = new AdmZip(exportedPackagesFile);
         const importedFilePath = path.resolve(tmpdir(), "export_" + uuidv4());
@@ -90,12 +90,6 @@ class PackageService {
             if (!!packagesWithDraftChanges) {
                 throw new FatalError(`Failed to import. Cannot overwrite packages with key(s) ${packagesWithDraftChanges}`)
             }
-        }
-
-        let dmTargetIdsBySourceIds: Map<string, string> = new Map();
-        if (dataModelMappingsFilePath) {
-            const dataModelMappings: DataPoolInstallVersionReport = await fileService.readFileToJson<DataPoolInstallVersionReport>(dataModelMappingsFilePath);
-            dmTargetIdsBySourceIds = new Map(Object.entries(dataModelMappings.dataModelIdMappings));
         }
 
         manifestNodes.map(node => node.dependenciesByVersion = new Map(Object.entries(node.dependenciesByVersion)));
@@ -117,7 +111,7 @@ class PackageService {
 
         const draftIdsByPackageKeyAndVersion = new Map<string, string>();
         for (const node of manifestNodes) {
-            await this.importPackage(node, manifestNodes, sourceToTargetVersionsByNodeKey, customSpacesMap, dmTargetIdsBySourceIds, importedVersionsByNodeKey, draftIdsByPackageKeyAndVersion, importedFilePath)
+            await this.importPackage(node, manifestNodes, sourceToTargetVersionsByNodeKey, customSpacesMap, importedVersionsByNodeKey, draftIdsByPackageKeyAndVersion, importedFilePath)
         }
     }
 
@@ -141,7 +135,6 @@ class PackageService {
                                 manifestNodes: ManifestNodeTransport[],
                                 sourceToTargetVersionsByNodeKey: Map<string, Map<string, string>>,
                                 spaceMappings: Map<string, string>,
-                                dmTargetIdsBySourceIds: Map<string, string>,
                                 importedVersionsByNodeKey: Map<string, string[]>,
                                 draftIdsByPackageKeyAndVersion: Map<string, string>,
                                 importedFilePath: string): Promise<void> {
@@ -154,7 +147,7 @@ class PackageService {
 
         for (const version of versionsOfPackage) {
             try {
-                await this.importPackageVersion(packageToImport, manifestNodes, sourceToTargetVersionsByNodeKey, spaceMappings, dmTargetIdsBySourceIds, importedVersionsByNodeKey, draftIdsByPackageKeyAndVersion, importedFilePath, version);
+                await this.importPackageVersion(packageToImport, manifestNodes, sourceToTargetVersionsByNodeKey, spaceMappings, importedVersionsByNodeKey, draftIdsByPackageKeyAndVersion, importedFilePath, version);
             } catch (e) {
                 logger.error(`Problem import package with key: ${packageToImport.packageKey} ${version} ${e}`);
             }
@@ -165,14 +158,13 @@ class PackageService {
                                        manifestNodes: ManifestNodeTransport[],
                                        sourceToTargetVersionsByNodeKey: Map<string, Map<string, string>>,
                                        spaceMappings: Map<string, string>,
-                                       dmTargetIdsBySourceIds: Map<string, string>,
                                        importedVersionsByNodeKey: Map<string, string[]>,
                                        draftIdsByPackageKeyAndVersion: Map<string, string>,
                                        importedFilePath: string,
                                        versionOfPackageBeingImported: string): Promise<void> {
         if (packageToImport.dependenciesByVersion.get(versionOfPackageBeingImported).length) {
             const dependenciesOfPackageVersion = packageToImport.dependenciesByVersion.get(versionOfPackageBeingImported);
-            await this.importDependencyPackages(dependenciesOfPackageVersion, manifestNodes, sourceToTargetVersionsByNodeKey, spaceMappings, dmTargetIdsBySourceIds,
+            await this.importDependencyPackages(dependenciesOfPackageVersion, manifestNodes, sourceToTargetVersionsByNodeKey, spaceMappings,
                 importedVersionsByNodeKey, draftIdsByPackageKeyAndVersion, importedFilePath
             );
         }
@@ -197,13 +189,7 @@ class PackageService {
         nodeInTargetTeam = await nodeApi.findOneByKeyAndRootNodeKey(packageToImport.packageKey, packageToImport.packageKey);
 
         if (this.isLatestVersion(versionOfPackageBeingImported, [...packageToImport.dependenciesByVersion.keys()])) {
-            const variableAssignments = packageToImport.variables
-                .filter(variable => variable.type === PackageManagerVariableType.DATA_MODEL).map(variable => {
-                    variable.value = dmTargetIdsBySourceIds.get(variable.value?.toString()) as unknown as object;
-                    return variable;
-                })
-
-            await variableService.assignVariableValues(nodeInTargetTeam.key, variableAssignments);
+            await variableService.assignVariableValues(nodeInTargetTeam.key, packageToImport.variables);
         }
 
         draftIdsByPackageKeyAndVersion.set(`${nodeInTargetTeam.key}_${versionOfPackageBeingImported}`, nodeInTargetTeam.workingDraftId);
@@ -246,7 +232,6 @@ class PackageService {
                                            manifestNodes: ManifestNodeTransport[],
                                            sourceToTargetVersionsByNodeKey: Map<string, Map<string, string>>,
                                            spaceMappings: Map<string, string>,
-                                           dmTargetIdsBySourceIds: Map<string, string>,
                                            importedVersionsByNodeKey: Map<string, string[]>,
                                            draftIdsByPackageKeyAndVersion: Map<string, string>,
                                            importedFilePath: string): Promise<void> {
@@ -256,7 +241,7 @@ class PackageService {
             }
 
             const dependentPackage = manifestNodes.find((node) => node.packageKey === dependency.key);
-            await this.importPackage(dependentPackage, manifestNodes, sourceToTargetVersionsByNodeKey, spaceMappings, dmTargetIdsBySourceIds, importedVersionsByNodeKey, draftIdsByPackageKeyAndVersion, importedFilePath);
+            await this.importPackage(dependentPackage, manifestNodes, sourceToTargetVersionsByNodeKey, spaceMappings, importedVersionsByNodeKey, draftIdsByPackageKeyAndVersion, importedFilePath);
         }
     }
 


### PR DESCRIPTION
#### Description

Removed filtering of variables when assigning on batch package import, and assign them from package manifest. 
We will map only the data model variables if the mapping file is provided in order to keep backward compatibility.

[Design doc](https://docs.google.com/document/d/1gqn3CjE8rFPf_eLgimL55qwl_nGTjhfweiDmmaSFitE)

#### Checklist

- [x] I have self-reviewed this PR
- [x] I have tested the change and proved that it works in different scenarios
- [x] I have updated docs if needed
