### PR TITLE
Added ability to update connection properties programmatically

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -17,6 +17,7 @@
 -   [Data Pool export / import commands](#data-pool-export--import-commands)
     - [Export Data Pool](#export-data-pool)
     - [Batch Import multiple Data Pools](#batch-import-multiple-data-pools)
+-   [Updating connection properties](#updating-connection-properties-programmatically)
 
 ## Content CLI Core Features
 
@@ -465,5 +466,24 @@ The command outputs an import report.
 If the `--outputToJsonFile` option is specified, the import report will be written to a JSON file.
 The command output will give you all the details.
 
+### Updating connection properties programmatically
+
+In some cases, it might be required to update connection properties in data pools programmatically. 
+Examples include governance and compliance reasons or mechanisms which are rotating credentials automatically.
+
+With the `get` and `set` commands, users can update properties from connections in an automated fashion.
+
+You can get a list of all connections in a data pool using the `list` command: 
+
+```content-cli list connection --profile <profile> --dataPoolId <dataPoolId>```
+
+Depending on the type of source, the updatable properties may differ. You can use the following command to
+get a full list of properties for a data source connection:
+
+```content-cli get connection --profile <profile> --dataPoolId <dataPoolId> --connectionId <connectionId>```
+
+You can then update the property you want to update using the `set` command:
+
+```content-cli set connection --rpofile <profile> --dataPoolId <dataPoolId> --connectionId <connectionId> --property <property> --value <value>```
 
 |--------------------------------------------------------------------------------------------------------------------------------|

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -484,6 +484,6 @@ get a full list of properties for a data source connection:
 
 You can then update the property you want to update using the `set` command:
 
-```content-cli set connection --rpofile <profile> --dataPoolId <dataPoolId> --connectionId <connectionId> --property <property> --value <value>```
+```content-cli set connection --profile <profile> --dataPoolId <dataPoolId> --connectionId <connectionId> --property <property> --value <value>```
 
 |--------------------------------------------------------------------------------------------------------------------------------|

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celonis/content-cli",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "description": "CLI Tool to help manage content in Celonis EMS",
   "main": "content-cli.js",
   "bin": {

--- a/src/api/data-pool-api.ts
+++ b/src/api/data-pool-api.ts
@@ -22,6 +22,30 @@ class DataPoolApi {
             throw new FatalError(`Data Pool export failed: : ${e}`);
         });
     }
+
+    public async listConnections(poolId: string): Promise<any> {
+        return httpClientV2.get(`/integration/api/pools/${poolId}/overviews/data-sources`).catch(e => {
+            throw new FatalError(`Can not list connections: : ${e}`);
+        });
+    }
+
+    public async getConnection(poolId: string, connectionId: string): Promise<any> {
+        return httpClientV2.get(`/integration/api/pools/${poolId}/data-sources/${connectionId}`).catch(e => {
+            throw new FatalError(`Can not get connection: : ${e}`);
+        });
+    }
+
+    public async getTypedConnection(poolId: string, connectionId: string, type: string): Promise<any> {
+        return httpClientV2.get(`/integration/api/datasource/${type}/${connectionId}`).catch(e => {
+            throw new FatalError(`Can get typed connection: : ${e}`);
+        });
+    }
+
+    public async updateTypedConnection(poolId: string, connectionId: string, type: string, data: any): Promise<any> {
+        return httpClientV2.put(`/integration/api/datasource/${type}/${connectionId}`, data).catch(e => {
+            throw new FatalError(`Can not update typed connection: ${e}`);
+        });
+    }
 }
 
 export const dataPoolApi = DataPoolApi.INSTANCE;

--- a/src/commands/connection.command.ts
+++ b/src/commands/connection.command.ts
@@ -1,0 +1,18 @@
+import { ContentService } from "../services/content.service";
+import { DataPoolManagerFactory } from "../content/factory/data-pool-manager.factory";
+import { connectionService } from "../services/connection/connection.service";
+
+export class ConnectionCommand {
+    
+    public async updateProperty(profile: string, dataPoolId: string, connectionId: string, property: string, value: string): Promise<void>{
+        await connectionService.updateProperty(dataPoolId, connectionId, property, value);
+    }
+
+    public async getProperties(profile: string, dataPoolId: string, connectionId: string): Promise<void> {
+        await connectionService.listProperties(dataPoolId, connectionId);
+    }
+
+    public async listConnections(profile: string, dataPoolId: string): Promise<any> {
+        return await connectionService.findAllConnections(dataPoolId);
+    }
+}

--- a/src/content-cli-get.ts
+++ b/src/content-cli-get.ts
@@ -1,0 +1,36 @@
+import { ConnectionCommand } from "./commands/connection.command";
+
+import commander = require("commander");
+import { ContextInitializer } from "./util/context-initializer";
+import { logger } from "./util/logger";
+type CommanderStatic = commander.CommanderStatic;
+
+class Get {
+    public static connection(program: CommanderStatic): CommanderStatic {
+        program
+            .command("connection")
+            .description("Programmatically read properties of your connections")
+            .option("-p, --profile <profile>", "Profile which you want to use to update the data pool configuration")
+            .requiredOption("--dataPoolId <dataPoolId>", "Id of the data pool you want to update")
+            .requiredOption("--connectionId <connectionId>", "Id of the connection you want to update")
+            .action(async cmd => {
+                await new ConnectionCommand().getProperties(cmd.profile, cmd.dataPoolId, cmd.connectionId);
+                process.exit();
+            });
+        return program;
+    }
+}
+
+ContextInitializer.initContext()
+    .then(() => {
+        Get.connection(commander);
+        commander.parse(process.argv);
+    })
+    .catch(e => {
+        logger.error(e);
+    });
+
+if (!process.argv.slice(2).length) {
+    commander.outputHelp();
+    process.exit(1);
+}

--- a/src/content-cli-list.ts
+++ b/src/content-cli-list.ts
@@ -5,6 +5,7 @@ import { AssetCommand } from "./commands/asset.command";
 import { logger } from "./util/logger";
 import commander = require("commander");
 import { ContextInitializer } from "./util/context-initializer";
+import { ConnectionCommand } from "./commands/connection.command";
 
 type CommanderStatic = commander.CommanderStatic;
 
@@ -52,6 +53,20 @@ export class List {
 
         return program;
     }
+
+    public static connections(program: CommanderStatic):CommanderStatic {
+        program
+            .command("connection")
+            .description("Command to list all connections in a Data Pool")
+            .option("-p, --profile <profile>", "Profile which you want to use to list connections")
+            .requiredOption("--dataPoolId <dataPoolId>", "ID of the data pool")
+            .action(async cmd => {
+                await new ConnectionCommand().listConnections(cmd.profile, cmd.dataPoolId);
+                process.exit();
+            });
+        return program;
+    }
+
     public static assets(program: CommanderStatic): CommanderStatic {
         program
             .command("assets")
@@ -77,7 +92,7 @@ const loadAllCommands = () => {
     List.spaces(commander);
     List.dataPools(commander);
     List.assets(commander);
-
+    List.connections(commander)
     commander.parse(process.argv);
 };
 

--- a/src/content-cli-set.ts
+++ b/src/content-cli-set.ts
@@ -1,0 +1,39 @@
+import { ConnectionCommand } from "./commands/connection.command";
+import commander = require("commander");
+import { ContextInitializer } from "./util/context-initializer";
+import { logger } from "./util/logger";
+
+type CommanderStatic = commander.CommanderStatic;
+
+class Set {
+    public static connection(program: CommanderStatic): CommanderStatic {
+        program
+            .command("connection")
+            .description("Programmatically update properties of your connections")
+            .option("-p, --profile <profile>", "Profile which you want to use to update the data pool configuration")
+            .requiredOption("--dataPoolId <dataPoolId>", "Id of the data pool you want to update")
+            .requiredOption("--connectionId <connectionId>", "Id of the connection you want to update")
+            .requiredOption("--property <property>", "The property you want to update")
+            .requiredOption("--value <value>", "The value you want to update")
+            .action(async cmd => {
+                await new ConnectionCommand().updateProperty(cmd.profile, cmd.dataPoolId, cmd.connectionId, cmd.property, cmd.value);
+                process.exit();
+            });
+
+        return program;
+    }
+}
+
+ContextInitializer.initContext()
+    .then(() => {
+        Set.connection(commander);
+        commander.parse(process.argv);
+    })
+    .catch(e => {
+        logger.error(e);
+    });
+
+if (!process.argv.slice(2).length) {
+    commander.outputHelp();
+    process.exit(1);
+}

--- a/src/content-cli.ts
+++ b/src/content-cli.ts
@@ -26,6 +26,10 @@ program.command("update", "Commands to update content.");
 
 program.command("list", "Commands to list content.").alias("ls");
 
+program.command("get", "Commands to get configuration properties.");
+
+program.command("set", "Commands to set configuration properties.");
+
 program.version(VersionUtils.getCurrentCliVersion());
 program.parse(process.argv);
 

--- a/src/services/connection/connection.service.ts
+++ b/src/services/connection/connection.service.ts
@@ -1,0 +1,56 @@
+import { dataPoolApi } from "../../api/data-pool-api";
+import { logger } from "../../util/logger";
+
+class ConnectionService {
+    public async findAllConnections(dataPoolId: string): Promise<any[]> {
+        const connections =  await dataPoolApi.listConnections(dataPoolId);
+        connections.forEach(connection => {
+            logger.info(`Connection ID: ${connection.id} - Name: ${connection.name} - Type: ${connection.type}`);
+        })
+        return connections;
+    }
+
+    public async listProperties(dataPoolId: string, connectionId: string): Promise<any[]> {
+        const connection =  await dataPoolApi.getConnection(dataPoolId, connectionId);
+        const type = connection.type;
+        const typedConnection = await dataPoolApi.getTypedConnection(dataPoolId, connectionId, type);
+        logger.info(`Connection ID: ${connection.id} - Name: ${connection.name} - Type: ${connection.type}`);
+        logger.info(`Properties:`)
+        for (let k in typedConnection) {
+            if (typeof typedConnection[k] === 'object') {
+                for (let o in typedConnection[k]) {
+                    logger.info(`  ${k}.${o} : ${typeof typedConnection[k][o]} := ${typedConnection[k][o]}`)
+                }
+            } else {
+                logger.info(`  ${k} : ${typeof typedConnection[k]} := ${typedConnection[k]}`);
+            }
+        }
+        return typedConnection;
+    }
+
+    public async updateProperty(dataPoolId: string, connectionId: string, property: string, value: string) {
+        const connection =  await dataPoolApi.getConnection(dataPoolId, connectionId);
+        const type = connection.type;
+        const typedConnection = await dataPoolApi.getTypedConnection(dataPoolId, connectionId, type);
+        const parts = property.split(".");
+        // update the typed connection object
+        let currentObject = typedConnection;
+        for (let i = 0; i < parts.length; i++) {
+            const part = parts[i];
+            if (currentObject.hasOwnProperty(part)) {
+                if (i < parts.length - 1) {
+                    currentObject = currentObject[part];
+                } else {
+                    currentObject[part] = value;
+                }
+            } else {
+                logger.error(`Property ${property} not found on connection.`)
+                return;
+            }
+        }
+        await dataPoolApi.updateTypedConnection(dataPoolId, connectionId, type, typedConnection);
+        logger.info(`Property ${property} updated.`);
+    }
+}
+
+export const connectionService = new ConnectionService();


### PR DESCRIPTION
#### Description

Customer requirement to be able to programmatically update connection properties. Use case is connection properties or credentials being rotated automatically, and these need to be integrated into Celonis for compliance and governance reasons. This input can not be done manually by a user.

Command has been added in a way that supports adding updates to properties of other configuration objects if necessary.

#### Checklist

- [ X ] I have self-reviewed this PR
- [ X ] I have tested the change and proved that it works in different scenarios
- [ X ] I have updated docs if needed
