### PR TITLE
[TA-2689] Add astro as codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*   @celonis/navi @gencblakqorip9
+*   @celonis/navi @gencblakqorip9 @celonis/astro


### PR DESCRIPTION
#### Description

Add astro team as code owners.

JIRA: [TA-2689](https://celonis.atlassian.net/browse/TA-2689)

[TA-2689]: https://celonis.atlassian.net/browse/TA-2689?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ