### PR TITLE
TA-2857: Move nodes to space sequentially on batch import

### DIFF
--- a/src/services/studio/studio.service.ts
+++ b/src/services/studio/studio.service.ts
@@ -87,10 +87,10 @@ class StudioService {
         if (studioFile) {
             const studioManifests: StudioPackageManifest[] = parse(configs.getEntry(BatchExportImportConstants.STUDIO_FILE_NAME).getData().toString());
 
-            await Promise.all(studioManifests.map(async manifest => {
+            for (const manifest of studioManifests) {
                 await this.movePackageToSpace(manifest);
                 await this.assignRuntimeVariables(manifest);
-            }));
+            }
         }
     }
 


### PR DESCRIPTION
#### Description

Replace Promise.all() with for...of to move Move nodes to space sequentially on batch import. This fixes the bug that creates multiple new spaces when moving multiple packages to a space that does not exist.

#### Checklist

- [x] I have self-reviewed this PR
- [x] I have tested the change and proved that it works in different scenarios
- [x] I have updated docs if needed
