### PR TITLE
TA-2855: Fix packageKey extraction from zip name

### DIFF
--- a/src/services/package-manager/batch-import-export-service.ts
+++ b/src/services/package-manager/batch-import-export-service.ts
@@ -59,10 +59,14 @@ class BatchImportExportService {
         exportedPackagesZip.addFile(BatchExportImportConstants.STUDIO_FILE_NAME, Buffer.from(stringify(studioData), "utf8"));
 
         exportedPackagesZip.getEntries().forEach(entry => {
-            if (entry.name.endsWith(".zip") && studioPackageKeys.includes(entry.name.split("_")[0])) {
-                const updatedPackage = studioService.processPackageForExport(entry, exportedVariables);
+            if (entry.name.endsWith(".zip")) {
+                const lastUnderscoreIndex = entry.name.lastIndexOf("_");
+                const namePart = entry.name.substring(0, lastUnderscoreIndex);
 
-                exportedPackagesZip.updateFile(entry, updatedPackage.toBuffer());
+                if (studioPackageKeys.includes(namePart)) {
+                    const updatedPackage = studioService.processPackageForExport(entry, exportedVariables);
+                    exportedPackagesZip.updateFile(entry, updatedPackage.toBuffer());
+                }
             }
         });
 

--- a/src/services/package-manager/batch-import-export-service.ts
+++ b/src/services/package-manager/batch-import-export-service.ts
@@ -61,9 +61,9 @@ class BatchImportExportService {
         exportedPackagesZip.getEntries().forEach(entry => {
             if (entry.name.endsWith(".zip")) {
                 const lastUnderscoreIndex = entry.name.lastIndexOf("_");
-                const namePart = entry.name.substring(0, lastUnderscoreIndex);
+                const packageKey = entry.name.substring(0, lastUnderscoreIndex);
 
-                if (studioPackageKeys.includes(namePart)) {
+                if (studioPackageKeys.includes(packageKey)) {
                     const updatedPackage = studioService.processPackageForExport(entry, exportedVariables);
                     exportedPackagesZip.updateFile(entry, updatedPackage.toBuffer());
                 }

--- a/src/services/studio/studio.service.ts
+++ b/src/services/studio/studio.service.ts
@@ -139,21 +139,23 @@ class StudioService {
 
         const connectionVariablesByKey = this.getConnectionVariablesByKeyForPackage(packageKeyAndVersion.packageKey, packageKeyAndVersion.version, exportedVariables);
 
-        if (connectionVariablesByKey.size) {
-            const packageEntry = packageZip.getEntry("package.yml");
-
-            const exportedNode: NodeExportTransport = parse(packageEntry.getData().toString());
-            const nodeContent: NodeSerializedContent = parse(exportedNode.serializedContent);
-
-            nodeContent.variables = nodeContent.variables.map(variable => ({
-                ...variable,
-                metadata: variable.type === PackageManagerVariableType.CONNECTION ?
-                    connectionVariablesByKey.get(variable.key).metadata : variable.metadata
-            }));
-
-            exportedNode.serializedContent = stringify(nodeContent);
-            packageZip.updateFile(packageEntry, Buffer.from(stringify(exportedNode)));
+        if (connectionVariablesByKey.size === 0) {
+            return;
         }
+
+        const packageEntry = packageZip.getEntry("package.yml");
+
+        const exportedNode: NodeExportTransport = parse(packageEntry.getData().toString());
+        const nodeContent: NodeSerializedContent = parse(exportedNode.serializedContent);
+
+        nodeContent.variables = nodeContent.variables.map(variable => ({
+            ...variable,
+            metadata: variable.type === PackageManagerVariableType.CONNECTION ?
+                connectionVariablesByKey.get(variable.key).metadata : variable.metadata
+        }));
+
+        exportedNode.serializedContent = stringify(nodeContent);
+        packageZip.updateFile(packageEntry, Buffer.from(stringify(exportedNode)));
     }
 
     private getPackageKeyAndVersion(zipName: string): PackageKeyAndVersionPair {

--- a/src/services/studio/studio.service.ts
+++ b/src/services/studio/studio.service.ts
@@ -2,6 +2,7 @@ import {
     NodeExportTransport,
     NodeSerializedContent,
     PackageExportTransport,
+    PackageKeyAndVersionPair,
     StudioPackageManifest,
     VariableExportTransport,
     VariableManifestTransport
@@ -137,11 +138,9 @@ class StudioService {
     private fixConnectionVariablesForRootNodeFiles(packageZip: AdmZip, zipName: string, exportedVariables: VariableManifestTransport[]): void {
         packageZip.getEntries().forEach(entry => {
             if (entry.name === "package.yml") {
-                const lastUnderscoreIndex = zipName.lastIndexOf("_");
-                const packageKey = zipName.replace(".zip", "").substring(0, lastUnderscoreIndex);
-                const packageVersion = zipName.replace(".zip", "").substring(lastUnderscoreIndex + 1);
+                const packageKeyAndVersion = this.getPackageKeyAndVersion(zipName);
 
-                const connectionVariablesByKey = this.getConnectionVariablesByKeyForPackage(packageKey, packageVersion, exportedVariables);
+                const connectionVariablesByKey = this.getConnectionVariablesByKeyForPackage(packageKeyAndVersion.packageKey, packageKeyAndVersion.version, exportedVariables);
 
                 if (connectionVariablesByKey.size) {
                     const exportedNode: NodeExportTransport = parse(entry.getData().toString());
@@ -158,6 +157,17 @@ class StudioService {
                 }
             }
         })
+    }
+
+    private getPackageKeyAndVersion(zipName: string): PackageKeyAndVersionPair {
+        const lastUnderscoreIndex = zipName.lastIndexOf("_");
+        const packageKey = zipName.replace(".zip", "").substring(0, lastUnderscoreIndex);
+        const packageVersion = zipName.replace(".zip", "").substring(lastUnderscoreIndex + 1);
+
+        return {
+            packageKey: packageKey,
+            version: packageVersion
+        }
     }
 
     private getConnectionVariablesByKeyForPackage(packageKey: string, packageVersion: string, variables: VariableManifestTransport[]): Map<string, VariableExportTransport> {

--- a/tests/config/config-export.spec.ts
+++ b/tests/config/config-export.spec.ts
@@ -443,7 +443,7 @@ describe("Config export", () => {
         mockAxiosGet("https://myTeam.celonis.cloud/package-manager/api/core/packages/export/batch?packageKeys=key_with_underscores_1&withDependencies=true", exportedPackagesZip.toBuffer());
         mockAxiosPost("https://myTeam.celonis.cloud/package-manager/api/core/packages/export/batch/variables-with-assignments", exportedVariables);
         mockAxiosGet(`https://myTeam.celonis.cloud/package-manager/api/nodes/${firstPackageNode.key}/${firstPackageNode.key}`, {...firstPackageNode, spaceId: "space-1"});
-        mockAxiosGet(`https://myTeam.celonis.cloud/package-manager/api/nodes/by-package-key/${firstPackageNode.key}/variables/runtime-values`, []);
+        mockAxiosGet(`https://myTeam.celonis.cloud/package-manager/api/nodes/by-package-key/${firstPackageNode.key}/variables/runtime-values?appMode=VIEWER`, []);
 
         await new ConfigCommand().batchExportPackages(["key_with_underscores_1"], true);
 


### PR DESCRIPTION
#### Description

Fixed logic for extracting package key from exported zip name for keys with multiple underscores (e.g. UUIDs).
Moved logic of deleting and updating files to separate loops to avoid losing references between the two operations.


#### Checklist

- [x] I have self-reviewed this PR
- [x] I have tested the change and proved that it works in different scenarios
- [x] I have updated docs if needed
