### PR TITLE
TA-2856: Reject from data on export packages error

### DIFF
--- a/src/services/http-client-service.v2.ts
+++ b/src/services/http-client-service.v2.ts
@@ -36,6 +36,7 @@ class HttpClientServiceV2 {
                 response.data.on("end", () => {
                     if (response.status !== 200) {
                         reject(Buffer.concat(data).toString());
+                        return;
                     }
 
                     this.handleResponseStreamData(Buffer.concat(data), resolve, reject);

--- a/tests/utls/http-requests-mock.ts
+++ b/tests/utls/http-requests-mock.ts
@@ -17,6 +17,7 @@ const mockAxiosGet = (url: string, responseData: any) => {
                 readableStream.push(response.data)
                 readableStream.push(null);
                 return Promise.resolve({
+                    status: 200,
                     data: readableStream,
                 });
             } else {


### PR DESCRIPTION
#### Description

Changed error handling on export getFile method to reject with returned data on error.

#### Checklist

- [x] I have self-reviewed this PR
- [x] I have tested the change and proved that it works in different scenarios
- [x] I have updated docs if needed



|         Original          |         Updated          |
| :-----------------------: | :----------------------: |
| ![image](https://github.com/celonis/content-cli/assets/93651741/b14687f0-2a43-4c9d-8c1c-5c7920b5e1bc) | ![image](https://github.com/celonis/content-cli/assets/93651741/81ef5677-ec02-497a-8054-0a1730229e7b) |
