### PR TITLE
TA-2859: Move to space fails because of non existing space reference

### DIFF
--- a/src/interfaces/batch-export-import-constants.ts
+++ b/src/interfaces/batch-export-import-constants.ts
@@ -6,6 +6,6 @@ export enum BatchExportImportConstants {
     APP_MODE_VIEWER = "VIEWER",
     ZIP_EXTENSION = ".zip",
     YAML_EXTENSION = ".yml",
-    NODES_FOLDER_NAME = "/nodes",
+    NODES_FOLDER_NAME = "nodes/",
     SCENARIO_NODE = "SCENARIO"
 }

--- a/src/interfaces/batch-export-import-constants.ts
+++ b/src/interfaces/batch-export-import-constants.ts
@@ -3,5 +3,9 @@ export enum BatchExportImportConstants {
     VARIABLES_FILE_NAME = "variables.yml",
     MANIFEST_FILE_NAME = "manifest.yml",
     STUDIO = "STUDIO",
-    APP_MODE_VIEWER = "VIEWER"
+    APP_MODE_VIEWER = "VIEWER",
+    ZIP_EXTENSION = ".zip",
+    YAML_EXTENSION = ".yml",
+    NODES_FOLDER_NAME = "/nodes",
+    SCENARIO_NODE = "SCENARIO"
 }

--- a/src/interfaces/package-export-transport.ts
+++ b/src/interfaces/package-export-transport.ts
@@ -55,7 +55,7 @@ export interface NodeExportTransport {
     serializedContent: string;
     schemaVersion: number;
 
-    unversionedMetadata: object;
+    unversionedMetadata: any;
     versionedMetdata: object;
 
     invalidContent?: boolean;

--- a/src/services/package-manager/batch-import-export-service.ts
+++ b/src/services/package-manager/batch-import-export-service.ts
@@ -61,7 +61,7 @@ class BatchImportExportService {
         exportedPackagesZip.addFile(BatchExportImportConstants.STUDIO_FILE_NAME, Buffer.from(stringify(studioData), "utf8"));
 
         exportedPackagesZip.getEntries().forEach(entry => {
-            if (entry.name.endsWith(".zip")) {
+            if (entry.name.endsWith(BatchExportImportConstants.ZIP_EXTENSION)) {
                 const lastUnderscoreIndex = entry.name.lastIndexOf("_");
                 const packageKey = entry.name.substring(0, lastUnderscoreIndex);
 

--- a/src/services/package-manager/batch-import-export-service.ts
+++ b/src/services/package-manager/batch-import-export-service.ts
@@ -140,7 +140,7 @@ class BatchImportExportService {
 
     private parseEntryData(configs: AdmZip, fileName: string): any {
         const entry = configs.getEntry(fileName);
-        if(entry) {
+        if (entry) {
             return (parse(entry.getData().toString()));
         }
         return null;

--- a/src/services/package-manager/batch-import-export-service.ts
+++ b/src/services/package-manager/batch-import-export-service.ts
@@ -93,7 +93,7 @@ class BatchImportExportService {
         const formData = this.buildBodyForImport(zipFilePath, filename, file, configs);
 
         const postPackageImportData = await batchImportExportApi.importPackages(formData, overwrite);
-        await studioService.processImportedPackages(configs, []);
+        await studioService.processImportedPackages(updatedFiles, []);
 
         const reportFileName = "config_import_report_" + uuidv4() + ".json";
         fileService.writeToFileWithGivenName(JSON.stringify(postPackageImportData), reportFileName);
@@ -132,11 +132,11 @@ class BatchImportExportService {
     private buildBodyForImport(file: string, filename: string, s: string, configs: AdmZip): FormData {
         const formData = new FormData();
 
-        formData.append("file", fs.createReadStream(file), {
-            filename: filename
-        });
+        const newConfigs = new AdmZip(file);
 
-        const variablesEntry = configs.getEntry(BatchExportImportConstants.VARIABLES_FILE_NAME);
+        formData.append("file", fs.createReadStream(file));
+
+        const variablesEntry = newConfigs.getEntry(BatchExportImportConstants.VARIABLES_FILE_NAME);
         if (variablesEntry) {
             formData.append("mappedVariables", JSON.stringify(parse(variablesEntry.getData().toString())), {
                 contentType: "application/json"

--- a/src/services/package-manager/batch-import-export-service.ts
+++ b/src/services/package-manager/batch-import-export-service.ts
@@ -15,7 +15,7 @@ import * as FormData from "form-data";
 import {BatchExportImportConstants} from "../../interfaces/batch-export-import-constants";
 import {packageApi} from "../../api/package-api";
 import {Readable} from "stream";
-import AdmZip = require("adm-zip");
+import * as AdmZip from "adm-zip";
 
 class BatchImportExportService {
 

--- a/src/services/package-manager/batch-import-export-service.ts
+++ b/src/services/package-manager/batch-import-export-service.ts
@@ -95,7 +95,6 @@ class BatchImportExportService {
         fileService.writeToFileWithGivenName(JSON.stringify(postPackageImportData), reportFileName);
         logger.info("Config import report file: " + reportFileName);
         this.cleanUpFileSystem(rootDirectoryZipPath);
-
     }
 
     private rezipRoot(updatedFiles: AdmZip) {
@@ -155,7 +154,6 @@ class BatchImportExportService {
 
     private cleanUpFileSystem(rootDirectoryZipPath: string) {
         fs.unlinkSync(rootDirectoryZipPath);
-
     }
 }
 

--- a/src/services/studio/studio.service.ts
+++ b/src/services/studio/studio.service.ts
@@ -89,12 +89,10 @@ class StudioService {
 
         if (studioFile) {
             const studioManifests: StudioPackageManifest[] = parse(configs.getEntry(BatchExportImportConstants.STUDIO_FILE_NAME).getData().toString());
+            for (const manifest of studioManifests) {
+                await this.movePackageToSpace(manifest);
 
-            await Promise.all(studioManifests.map(async manifest => {
-                if(existingStudioPackages.some(obj => obj.key === manifest.packageKey)){
-                    await this.movePackageToSpace(manifest);
-                }
-            }));
+            }
         }
     }
 
@@ -198,10 +196,10 @@ class StudioService {
                     const packageZip = new AdmZip(entry.getData());
                     console.log("entries", packageZip.getEntries().length)
                     packageZip.getEntries().forEach(entry => {
-                        if(entry.entryName.endsWith(".yml")) {
-                            console.log(entry.entryName)
+                        if(entry.entryName === "package.yml") {
+                            console.log("beforeUpdate ", entry.getData().toString())
                             const updatedNodeFile = this.updateSpaceIdForNode(entry, spaceId);
-                            console.log(updatedNodeFile)
+                            console.log("afterUpdate  ", updatedNodeFile)
                             packageZip.updateFile(entry, Buffer.from(stringify(updatedNodeFile)));
                         }
                     });

--- a/src/services/studio/studio.service.ts
+++ b/src/services/studio/studio.service.ts
@@ -195,7 +195,7 @@ class StudioService {
                         if(entry.entryName.endsWith("yml")) {
                             const updatedNodeFile = this.updateSpaceIdForNode(entry, spaceId);
                             // console.log("node-i", updatedNodeFile)
-                            packageZip.updateFile(entry, Buffer.from(stringify(updatedNodeFile)));
+                            packageZip.updateFile(entry, Buffer.from(updatedNodeFile));
                         }
                     });
                     exportedFiles.updateFile(entry.entryName, packageZip.toBuffer());
@@ -233,7 +233,6 @@ class StudioService {
             }
 
             const spaceTransport = await spaceService.createSpace(studioPackageManifest.space.name, studioPackageManifest.space.iconReference);
-            console.log("Created space by name ", targetSpaceByName.id, targetSpaceByName.name)
             return spaceTransport.id;
         }
     }
@@ -246,17 +245,17 @@ class StudioService {
 
     // tslint:disable-next-line:typedef
     private updateSpaceIdForNode(entry: AdmZip.IZipEntry, spaceId: string) {
-        console.log("contenti \n", entry.getData().toString());
+        console.log(entry.getData().toString());
+        let content = entry.getData().toString();
 
-        const exportedNode: NodeExportTransport = parse(entry.getData().toString());
+        const exportedNode: NodeExportTransport = parse(content);
         // @ts-ignore
         const oldSpaceId = exportedNode.unversionedMetadata.spaceId;
         console.log("Old space id",oldSpaceId)
         console.log("New space id",spaceId)
 
-        let content  = entry.getData().toString();
-        content = content.replaceAll(oldSpaceId, spaceId);
-        console.log("contenti updated \n", content);
+        content = content.replace(oldSpaceId, spaceId);
+        console.log(content);
         // @ts-ignore
         return content;
     }

--- a/src/services/studio/studio.service.ts
+++ b/src/services/studio/studio.service.ts
@@ -190,14 +190,11 @@ class StudioService {
 
                             const spaceId = await this.findDesiredSpaceIdForPackage(packageKey, studioManifest);
                             studioManifest.space.id = spaceId;
-                            console.log(studioManifest)
 
                             const packageZip = new AdmZip(packageZipFile.getData());
                             packageZip.getEntries().forEach(nodeFile => {
                                 if (nodeFile.entryName.endsWith("yml")) {
-                                    console.log(nodeFile.entryName)
                                     const updatedNodeFile = this.updateSpaceIdForNode(nodeFile.getData().toString(), spaceId);
-                                    console.log(updatedNodeFile)
                                     packageZip.updateFile(nodeFile, Buffer.from(updatedNodeFile));
                                 }
                             });
@@ -241,12 +238,7 @@ class StudioService {
     }
     private updateSpaceIdForNode(nodeContent: string, spaceId: string): string {
         const exportedNode: NodeExportTransport = parse(nodeContent);
-        console.log(exportedNode.packageNodeKey)
-        const key: string = "spaceId";
-        console.log(exportedNode)
-        // @ts-ignore
-        const oldSpaceId = exportedNode.unversionedMetadata[key]
-        console.log(oldSpaceId)
+        const oldSpaceId = exportedNode.unversionedMetadata.spaceId;
 
         nodeContent = nodeContent.replace(new RegExp(oldSpaceId, "g"), spaceId);
         return nodeContent;

--- a/src/services/studio/studio.service.ts
+++ b/src/services/studio/studio.service.ts
@@ -25,7 +25,8 @@ import {SpaceTransport} from "../../interfaces/save-space.interface";
 import {spaceService} from "../package-manager/space-service";
 import {variableService} from "../package-manager/variable-service";
 import {BatchExportImportConstants} from "../../interfaces/batch-export-import-constants";
-import AdmZip = require("adm-zip");
+import * as AdmZip from "adm-zip";
+
 
 class StudioService {
 

--- a/src/services/studio/studio.service.ts
+++ b/src/services/studio/studio.service.ts
@@ -219,22 +219,21 @@ class StudioService {
     private async findDesiredSpaceIdForPackage(studioPackageManifest: StudioPackageManifest): Promise<string> {
         const allSpaces = await spaceService.refreshAndGetAllSpaces();
 
-            if (studioPackageManifest.space.id) {
-                const targetSpace = allSpaces.find(space => space.id === studioPackageManifest.space.id);
-               if (!targetSpace) {
-                    throw Error("Provided space ID does not exist.");
-                }
-                return targetSpace.id;
+        if (studioPackageManifest.space.id) {
+            const targetSpace = allSpaces.find(space => space.id === studioPackageManifest.space.id);
+           if (!targetSpace) {
+                throw Error("Provided space ID does not exist.");
             }
+            return targetSpace.id;
+        }
 
-            const targetSpaceByName = allSpaces.find(space => space.name === studioPackageManifest.space.name);
-            if (targetSpaceByName) {
-                return targetSpaceByName.id;
-            }
+        const targetSpaceByName = allSpaces.find(space => space.name === studioPackageManifest.space.name);
+        if (targetSpaceByName) {
+            return targetSpaceByName.id;
+        }
 
-            const spaceTransport = await spaceService.createSpace(studioPackageManifest.space.name, studioPackageManifest.space.iconReference);
-            return spaceTransport.id;
-
+        const spaceTransport = await spaceService.createSpace(studioPackageManifest.space.name, studioPackageManifest.space.iconReference);
+        return spaceTransport.id;
     }
 
     private async assignRuntimeVariables(manifest: StudioPackageManifest): Promise<void> {

--- a/src/services/studio/studio.service.ts
+++ b/src/services/studio/studio.service.ts
@@ -190,12 +190,15 @@ class StudioService {
 
                             const spaceId = await this.findDesiredSpaceIdForPackage(packageKey, studioManifest);
                             studioManifest.space.id = spaceId;
+                            console.log(studioManifest)
 
                             const packageZip = new AdmZip(packageZipFile.getData());
                             packageZip.getEntries().forEach(nodeFile => {
                                 if (nodeFile.entryName.endsWith("yml")) {
+                                    console.log(nodeFile.entryName)
                                     const updatedNodeFile = this.updateSpaceIdForNode(nodeFile.getData().toString(), spaceId);
-                                    packageZip.updateFile(nodeFile, Buffer.from(stringify(updatedNodeFile)));
+                                    console.log(updatedNodeFile)
+                                    packageZip.updateFile(nodeFile, Buffer.from(updatedNodeFile));
                                 }
                             });
                             exportedFiles.updateFile(packageZipFile, packageZip.toBuffer());
@@ -238,9 +241,14 @@ class StudioService {
     }
     private updateSpaceIdForNode(nodeContent: string, spaceId: string): string {
         const exportedNode: NodeExportTransport = parse(nodeContent);
+        console.log(exportedNode.packageNodeKey)
+        const key: string = "spaceId";
+        console.log(exportedNode)
         // @ts-ignore
-        const oldSpaceId = exportedNode.unversionedMetadata.spaceId;
-        nodeContent = nodeContent.replaceAll(oldSpaceId, spaceId);
+        const oldSpaceId = exportedNode.unversionedMetadata[key]
+        console.log(oldSpaceId)
+
+        nodeContent = nodeContent.replace(new RegExp(oldSpaceId, "g"), spaceId);
         return nodeContent;
     }
 }

--- a/tests/config/config-import.spec.ts
+++ b/tests/config/config-import.spec.ts
@@ -127,11 +127,9 @@ describe("Config import", () => {
         mockAxiosGet("https://myTeam.celonis.cloud/package-manager/api/packages", []);
         mockAxiosGet("https://myTeam.celonis.cloud/package-manager/api/spaces", [space]);
 
-        try{
-            await new ConfigCommand().batchImportPackages("./export_file.zip", true);
-        } catch (err) {
-            expect(err.message).toBe("Provided space ID does not exist.")
-        }
+        await expect(
+            new ConfigCommand().batchImportPackages("./export_file.zip", true)
+        ).rejects.toThrow("Provided space ID does not exist.");
     })
 
     it("Should batch import configs & map space ID as specified in manifest file for Studio Packages & move to space for existing packages.", async () => {

--- a/tests/config/config-import.spec.ts
+++ b/tests/config/config-import.spec.ts
@@ -2,9 +2,7 @@ import {ConfigCommand} from "../../src/commands/config.command";
 import {
     mockAxiosGet,
     mockAxiosPost,
-    mockAxiosPut,
-    mockAxios,
-    mockedPostRequestBodyByUrl
+    mockAxiosPut, mockedPostRequestBodyByUrl
 } from "../utls/http-requests-mock";
 import {
     PackageManifestTransport,
@@ -17,9 +15,14 @@ import * as path from "path";
 import {stringify} from "../../src/util/yaml";
 import {SpaceTransport} from "../../src/interfaces/save-space.interface";
 import {packageApi} from "../../src/api/package-api";
-import {PackageManagerVariableType, VariablesAssignments} from "../../src/interfaces/package-manager.interfaces";
+import {
+    ContentNodeTransport,
+    PackageManagerVariableType,
+    VariablesAssignments
+} from "../../src/interfaces/package-manager.interfaces";
 import {mockCreateReadStream, mockExistsSync, mockReadFileSync} from "../utls/fs-mock-utils";
 import {BatchExportImportConstants} from "../../src/interfaces/batch-export-import-constants";
+
 import axios from "axios";
 
 describe("Config import", () => {
@@ -40,6 +43,7 @@ describe("Config import", () => {
 
         mockReadFileSync(exportedPackagesZip.toBuffer());
         mockCreateReadStream(exportedPackagesZip.toBuffer());
+        mockAxiosGet("https://myTeam.celonis.cloud/package-manager/api/packages", []);
 
         const importResponse: PostPackageImportData[] = [{
             packageKey: "key-1",
@@ -57,35 +61,16 @@ describe("Config import", () => {
         expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), JSON.stringify(importResponse), {encoding: "utf-8"});
     })
 
-    it("Should move studio package to target space after import", async () => {
+    it("Should batch import configs & map space ID as specified in manifest file for Studio Packages", async () => {
         const manifest: PackageManifestTransport[] = [];
-        manifest.push(ConfigUtils.buildManifestForKeyAndFlavor("key-1", "STUDIO"));
-        const exportedPackagesZip = ConfigUtils.buildBatchExportZip(manifest, []);
-        const studioManifest: StudioPackageManifest[] = [{
-            packageKey: "key-1",
-            space: {
-                name: "space",
-                iconReference: "earth"
-            },
-            runtimeVariableAssignments: []
-        }];
-        exportedPackagesZip.addFile(BatchExportImportConstants.STUDIO_FILE_NAME, Buffer.from(stringify(studioManifest)));
+        manifest.push(ConfigUtils.buildManifestForKeyAndFlavor("key-2", "STUDIO"));
 
-        mockReadFileSync(exportedPackagesZip.toBuffer());
-        mockCreateReadStream(exportedPackagesZip.toBuffer());
+        const studioManifest: StudioPackageManifest[] = [];
+        studioManifest.push(ConfigUtils.buildStudioManifestForKeyWithSpace("key-2", "spaceName", "space-id"));
 
-        const importResponse: PostPackageImportData[] = [{
-            packageKey: "key-1",
-            importedVersions: [{
-                oldVersion: "1.0.2",
-                newVersion: "1.0.0"
-            }]
-        }];
-
-        const node = {
-            id: "node-id",
-            key: "key-1"
-        }
+        const firstPackageNode = ConfigUtils.buildPackageNode("key-2", stringify({variables: []}));
+        const firstPackageZip = ConfigUtils.buildExportPackageZip(firstPackageNode, [], "1.0.0");
+        const exportedPackagesZip = ConfigUtils.buildBatchExportZipWithStudioManifest(manifest, studioManifest,[firstPackageZip]);
 
         const space: SpaceTransport = {
             id: "space-id",
@@ -93,37 +78,16 @@ describe("Config import", () => {
             iconReference: "earth"
         };
 
-        mockAxiosPost("https://myTeam.celonis.cloud/package-manager/api/core/packages/import/batch", importResponse);
-        mockAxiosGet("https://myTeam.celonis.cloud/package-manager/api/nodes/key-1/key-1", node);
-        mockAxiosGet("https://myTeam.celonis.cloud/package-manager/api/spaces", [space]);
-        mockAxiosPut("https://myTeam.celonis.cloud/package-manager/api/packages/node-id/move/space-id", {});
-
-       const movePackageToSpaceSpy = jest.spyOn(packageApi, "movePackageToSpace");
-
-        await new ConfigCommand().batchImportPackages("./export_file.zip", true);
-
-        const expectedFileName = testTransport.logMessages[0].message.split(LOG_MESSAGE)[1];
-        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), JSON.stringify(importResponse), {encoding: "utf-8"});
-
-        expect(movePackageToSpaceSpy).toHaveBeenCalledWith("node-id", "space-id");
-    })
-
-    it("Should create space to move package after import if target space does not exist", async () => {
-        const manifest: PackageManifestTransport[] = [];
-        manifest.push(ConfigUtils.buildManifestForKeyAndFlavor("key-1", "STUDIO"));
-        const exportedPackagesZip = ConfigUtils.buildBatchExportZip(manifest, []);
-        const studioManifest: StudioPackageManifest[] = [{
-            packageKey: "key-1",
-            space: {
-                name: "new-space",
-                iconReference: "earth"
-            },
-            runtimeVariableAssignments: []
-        }];
-        exportedPackagesZip.addFile(BatchExportImportConstants.STUDIO_FILE_NAME, Buffer.from(stringify(studioManifest)));
+        const otherSpace: SpaceTransport = {
+            id: "spaceId",
+            name: "spaceName",
+            iconReference: "earth"
+        };
 
         mockReadFileSync(exportedPackagesZip.toBuffer());
         mockCreateReadStream(exportedPackagesZip.toBuffer());
+        mockAxiosGet("https://myTeam.celonis.cloud/package-manager/api/packages", []);
+        mockAxiosGet("https://myTeam.celonis.cloud/package-manager/api/spaces", [space, otherSpace]);
 
         const importResponse: PostPackageImportData[] = [{
             packageKey: "key-1",
@@ -133,43 +97,176 @@ describe("Config import", () => {
             }]
         }];
 
-        const node = {
-            id: "node-id",
-            key: "key-1"
-        }
-
-        const space: SpaceTransport = {
-            id: "space-id",
-            name: "new-space",
-            iconReference: "earth"
-        };
-
-        const createSpaceUrl = "https://myTeam.celonis.cloud/package-manager/api/spaces";
         mockAxiosPost("https://myTeam.celonis.cloud/package-manager/api/core/packages/import/batch", importResponse);
-        mockAxiosGet("https://myTeam.celonis.cloud/package-manager/api/nodes/key-1/key-1", node);
-        mockAxiosGet("https://myTeam.celonis.cloud/package-manager/api/spaces", []);
-        mockAxiosPost(createSpaceUrl, space);
-        mockAxiosPut("https://myTeam.celonis.cloud/package-manager/api/packages/node-id/move/space-id", {});
-
-        const movePackageToSpaceSpy = jest.spyOn(packageApi, "movePackageToSpace");
 
         await new ConfigCommand().batchImportPackages("./export_file.zip", true);
 
         const expectedFileName = testTransport.logMessages[0].message.split(LOG_MESSAGE)[1];
         expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), JSON.stringify(importResponse), {encoding: "utf-8"});
+    })
 
-        expect(movePackageToSpaceSpy).toHaveBeenCalledWith("node-id", "space-id");
+    it("Should fail to map space ID as the space id specified in manifest file cannot be found", async () => {
+        const manifest: PackageManifestTransport[] = [];
+        manifest.push(ConfigUtils.buildManifestForKeyAndFlavor("key-2", "STUDIO"));
 
-        const createSpaceRequest: SpaceTransport = JSON.parse(mockedPostRequestBodyByUrl.get(createSpaceUrl));
-        expect(createSpaceRequest.name).toEqual(space.name);
-        expect(createSpaceRequest.iconReference).toEqual(space.iconReference);
+        const studioManifest: StudioPackageManifest[] = [];
+        studioManifest.push(ConfigUtils.buildStudioManifestForKeyWithSpace("key-2", "spaceName", "space"));
+
+        const firstPackageNode = ConfigUtils.buildPackageNode("key-2", stringify({variables: []}));
+        const firstPackageZip = ConfigUtils.buildExportPackageZip(firstPackageNode, [], "1.0.0");
+        const exportedPackagesZip = ConfigUtils.buildBatchExportZipWithStudioManifest(manifest, studioManifest,[firstPackageZip]);
+
+        const space: SpaceTransport = {
+            id: "space-id",
+            name: "space",
+            iconReference: "earth"
+        };
+
+        mockReadFileSync(exportedPackagesZip.toBuffer());
+        mockCreateReadStream(exportedPackagesZip.toBuffer());
+        mockAxiosGet("https://myTeam.celonis.cloud/package-manager/api/packages", []);
+        mockAxiosGet("https://myTeam.celonis.cloud/package-manager/api/spaces", [space]);
+
+        try{
+            await new ConfigCommand().batchImportPackages("./export_file.zip", true);
+        } catch (err) {
+            expect(err.message).toBe("Provided space ID does not exist.")
+        }
+    })
+
+    it("Should batch import configs & map space ID as specified in manifest file for Studio Packages & move to space for existing packages.", async () => {
+        const manifest: PackageManifestTransport[] = [];
+        manifest.push(ConfigUtils.buildManifestForKeyAndFlavor("key-2", "STUDIO"));
+
+        const studioManifest: StudioPackageManifest[] = [];
+        studioManifest.push(ConfigUtils.buildStudioManifestForKeyWithSpace("key-2", "space", "spaceId"));
+
+        const firstPackageNode = ConfigUtils.buildPackageNode("key-2", stringify({variables: []}));
+        const firstPackageZip = ConfigUtils.buildExportPackageZip(firstPackageNode, [], "1.0.0");
+        const exportedPackagesZip = ConfigUtils.buildBatchExportZipWithStudioManifest(manifest, studioManifest,[firstPackageZip]);
+
+
+        const existingNode: Partial<ContentNodeTransport> = {
+            id: "node-id",
+            key: "key-2"
+        }
+
+        const space: SpaceTransport = {
+            id: "spaceId",
+            name: "space",
+            iconReference: "earth"
+        };
+
+        mockReadFileSync(exportedPackagesZip.toBuffer());
+        mockCreateReadStream(exportedPackagesZip.toBuffer());
+        mockAxiosGet("https://myTeam.celonis.cloud/package-manager/api/packages", [existingNode]);
+        mockAxiosGet("https://myTeam.celonis.cloud/package-manager/api/spaces", [space]);
+        mockAxiosPut("https://myTeam.celonis.cloud/package-manager/api/packages/node-id/move/spaceId", {});
+
+        const importResponse: PostPackageImportData[] = [{
+            packageKey: "key-1",
+            importedVersions: [{
+                oldVersion: "1.0.2",
+                newVersion: "1.0.0"
+            }]
+        }];
+
+        mockAxiosPost("https://myTeam.celonis.cloud/package-manager/api/core/packages/import/batch", importResponse);
+        const movePackageToSpaceSpy = jest.spyOn(packageApi, "movePackageToSpace");
+
+        await new ConfigCommand().batchImportPackages("./export_file.zip", true);
+        const expectedFileName = testTransport.logMessages[0].message.split(LOG_MESSAGE)[1];
+        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), JSON.stringify(importResponse), {encoding: "utf-8"});
+        expect(movePackageToSpaceSpy).toBeCalledTimes(1)
+        expect(movePackageToSpaceSpy).toHaveBeenCalledWith("node-id", "spaceId");
+    })
+
+    it("Should batch import configs & map space ID by finding space with name as specified in manifest file", async () => {
+        const manifest: PackageManifestTransport[] = [];
+        manifest.push(ConfigUtils.buildManifestForKeyAndFlavor("key-2", "STUDIO"));
+
+        const studioManifest: StudioPackageManifest[] = [];
+        studioManifest.push(ConfigUtils.buildStudioManifestForKeyWithSpace("key-2", "spaceName", null));
+
+        const firstPackageNode = ConfigUtils.buildPackageNode("key-2", stringify({variables: []}));
+        const firstPackageZip = ConfigUtils.buildExportPackageZip(firstPackageNode, [], "1.0.0");
+        const exportedPackagesZip = ConfigUtils.buildBatchExportZipWithStudioManifest(manifest, studioManifest,[firstPackageZip]);
+
+        const space: SpaceTransport = {
+            id: "spaceId",
+            name: "spaceName",
+            iconReference: "earth"
+        };
+        mockReadFileSync(exportedPackagesZip.toBuffer());
+        mockCreateReadStream(exportedPackagesZip.toBuffer());
+        mockAxiosGet("https://myTeam.celonis.cloud/package-manager/api/packages", []);
+        mockAxiosGet("https://myTeam.celonis.cloud/package-manager/api/spaces", [space]);
+
+        const importResponse: PostPackageImportData[] = [{
+            packageKey: "key-1",
+            importedVersions: [{
+                oldVersion: "1.0.2",
+                newVersion: "1.0.0"
+            }]
+        }];
+
+        mockAxiosPost("https://myTeam.celonis.cloud/package-manager/api/core/packages/import/batch", importResponse);
+
+        await new ConfigCommand().batchImportPackages("./export_file.zip", true);
+
+        const expectedFileName = testTransport.logMessages[0].message.split(LOG_MESSAGE)[1];
+        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), JSON.stringify(importResponse), {encoding: "utf-8"});
+    })
+
+    it("Should batch import configs & create new space", async () => {
+        const manifest: PackageManifestTransport[] = [];
+        manifest.push(ConfigUtils.buildManifestForKeyAndFlavor("key-2", "STUDIO"));
+
+        const studioManifest: StudioPackageManifest[] = [];
+        studioManifest.push(ConfigUtils.buildStudioManifestForKeyWithSpace("key-2", "spaceName", null));
+
+        const firstPackageNode = ConfigUtils.buildPackageNode("key-2", stringify({variables: []}));
+        const firstPackageZip = ConfigUtils.buildExportPackageZip(firstPackageNode, [], "1.0.0");
+        const exportedPackagesZip = ConfigUtils.buildBatchExportZipWithStudioManifest(manifest, studioManifest,[firstPackageZip]);
+
+        const space: SpaceTransport = {
+            id: "space-id",
+            name: "space-name",
+            iconReference: "earth"
+        };
+
+        const newSpace: SpaceTransport = {
+            id: "spaceId",
+            name: "spaceName",
+            iconReference: "earth"
+        };
+
+        mockReadFileSync(exportedPackagesZip.toBuffer());
+        mockCreateReadStream(exportedPackagesZip.toBuffer());
+        mockAxiosGet("https://myTeam.celonis.cloud/package-manager/api/packages", []);
+        mockAxiosGet("https://myTeam.celonis.cloud/package-manager/api/spaces", [space]);
+        mockAxiosPost("https://myTeam.celonis.cloud/package-manager/api/spaces", [newSpace]);
+
+
+        const importResponse: PostPackageImportData[] = [{
+            packageKey: "key-1",
+            importedVersions: [{
+                oldVersion: "1.0.2",
+                newVersion: "1.0.0"
+            }]
+        }];
+
+        mockAxiosPost("https://myTeam.celonis.cloud/package-manager/api/core/packages/import/batch", importResponse);
+
+        await new ConfigCommand().batchImportPackages("./export_file.zip", true);
+
+        const expectedFileName = testTransport.logMessages[0].message.split(LOG_MESSAGE)[1];
+        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), JSON.stringify(importResponse), {encoding: "utf-8"});
     })
 
     it("Should assign studio runtime variable values after import", async () => {
-        const {get, post, put} = mockAxios();
-
         const manifest: PackageManifestTransport[] = [];
-        manifest.push(ConfigUtils.buildManifestForKeyAndFlavor("key-1", "TEST"));
+        manifest.push(ConfigUtils.buildManifestForKeyAndFlavor("key-1", "STUDIO"));
         const exportedPackagesZip = ConfigUtils.buildBatchExportZip(manifest, []);
         const variableAssignment: VariablesAssignments = {
             key: "variable-1",
@@ -179,6 +276,7 @@ describe("Config import", () => {
         const studioManifest: StudioPackageManifest[] = [{
             packageKey: "key-1",
             space: {
+                id: "space-id",
                 name: "space",
                 iconReference: "earth"
             },
@@ -197,7 +295,7 @@ describe("Config import", () => {
             }]
         }];
 
-        const node = {
+        const node: Partial<ContentNodeTransport> = {
             id: "node-id",
             key: "key-1"
         }
@@ -210,17 +308,17 @@ describe("Config import", () => {
 
         const assignVariablesUrl = "https://myTeam.celonis.cloud/package-manager/api/nodes/by-package-key/key-1/variables/values";
 
-        post("https://myTeam.celonis.cloud/package-manager/api/core/packages/import/batch", importResponse);
-        get("https://myTeam.celonis.cloud/package-manager/api/nodes/key-1/key-1", node);
-        get("https://myTeam.celonis.cloud/package-manager/api/spaces", [space]);
-        put("https://myTeam.celonis.cloud/package-manager/api/packages/node-id/move/space-id", {});
-        post(assignVariablesUrl, {});
+        mockAxiosPost("https://myTeam.celonis.cloud/package-manager/api/core/packages/import/batch", importResponse);
+        mockAxiosGet("https://myTeam.celonis.cloud/package-manager/api/nodes/key-1/key-1", node);
+        mockAxiosGet("https://myTeam.celonis.cloud/package-manager/api/spaces", [space]);
+        mockAxiosPut("https://myTeam.celonis.cloud/package-manager/api/packages/node-id/move/space-id", {});
+        mockAxiosPost(assignVariablesUrl, {});
+        mockAxiosGet("https://myTeam.celonis.cloud/package-manager/api/packages", [node]);
 
         await new ConfigCommand().batchImportPackages("./export_file.zip", true);
 
         const expectedFileName = testTransport.logMessages[0].message.split(LOG_MESSAGE)[1];
         expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), JSON.stringify(importResponse), {encoding: "utf-8"});
 
-        expect(axios.post as jest.Mock).toHaveBeenCalledWith(assignVariablesUrl, JSON.stringify([variableAssignment]), expect.any(Object));
-    })
+        expect(mockedPostRequestBodyByUrl.get(assignVariablesUrl)).toEqual(JSON.stringify([variableAssignment]));    })
 })

--- a/tests/utls/config-utils.ts
+++ b/tests/utls/config-utils.ts
@@ -2,12 +2,26 @@ import AdmZip = require("adm-zip");
 import {
     DependencyTransport,
     NodeExportTransport,
-    PackageManifestTransport
+    PackageManifestTransport, StudioPackageManifest
 } from "../../src/interfaces/package-export-transport";
 import {stringify} from "../../src/util/yaml";
+import {SpaceTransport} from "../../src/interfaces/save-space.interface";
 
 export class ConfigUtils {
 
+    public static buildBatchExportZipWithStudioManifest(manifest: PackageManifestTransport[], studioManifest: StudioPackageManifest[], packageZips: AdmZip[]): AdmZip {
+
+        const zipExport = new AdmZip();
+        zipExport.addFile("manifest.yml", Buffer.from(stringify(manifest)));
+        zipExport.addFile("studio.yml", Buffer.from(stringify(studioManifest)));
+        packageZips.forEach(packageZip => {
+            const fileName = `${packageZip.getZipComment()}.zip`
+            packageZip.addZipComment("")
+            zipExport.addFile(fileName, packageZip.toBuffer());
+        })
+
+        return zipExport;
+    }
     public static buildBatchExportZip(manifest: PackageManifestTransport[], packageZips: AdmZip[]): AdmZip {
 
         const zipExport = new AdmZip();
@@ -76,6 +90,22 @@ export class ConfigUtils {
             versionedMetdata: {},
             invalidContent: false,
             serializedDocument: null
+        };
+    }
+
+    public static buildStudioManifestForKeyWithSpace(key: string, spaceName: string, spaceId: string): StudioPackageManifest {
+        const space: Partial<SpaceTransport> = {
+            name: spaceName
+        };
+
+        if (spaceId) {
+            space.id = spaceId;
+        }
+
+        return {
+            packageKey: key,
+            space: space,
+            runtimeVariableAssignments: []
         };
     }
 }

--- a/tests/utls/http-requests-mock.ts
+++ b/tests/utls/http-requests-mock.ts
@@ -5,6 +5,34 @@ const mockedGetResponseByUrl = new Map<string, any>();
 const mockedPostResponseByUrl = new Map<string, any>();
 const mockedPostRequestBodyByUrl = new Map<string, any>();
 
+const getMockAxiosGet = () => {
+    const mockedGetResponseByUrl = new Map<string, any>();
+
+    (axios.get as jest.Mock).mockImplementation(requestUrl => {
+        if (mockedGetResponseByUrl.has(requestUrl)) {
+            const response = {data: mockedGetResponseByUrl.get(requestUrl)};
+
+            if (response.data instanceof Buffer) {
+                const readableStream = new Readable();
+                readableStream.push(response.data)
+                readableStream.push(null);
+                return Promise.resolve({
+                    status: 200,
+                    data: readableStream,
+                });
+            } else {
+                return Promise.resolve(response);
+            }
+        } else {
+            fail("API call not mocked.")
+        }
+    });
+
+    return (url: string, responseData: any) => {
+        mockedGetResponseByUrl.set(url, responseData);
+    };
+}
+
 const mockAxiosGet = (url: string, responseData: any) => {
     mockedGetResponseByUrl.set(url, responseData);
 
@@ -29,6 +57,23 @@ const mockAxiosGet = (url: string, responseData: any) => {
     });
 };
 
+const getMockAxiosPost = () => {
+    const mockedPostResponseByUrl = new Map<string, any>();
+    axios.post = jest.fn();
+    (axios.post as jest.Mock).mockImplementation((requestUrl: string, data: any) => {
+        if (mockedPostResponseByUrl.has(requestUrl)) {
+            const response = {data: mockedPostResponseByUrl.get(requestUrl)};
+            return Promise.resolve(response);
+        } else {
+            fail("API call not mocked.")
+        }
+    })
+
+    return (url: string, responseData: any) => {
+        mockedPostResponseByUrl.set(url, responseData);
+    }
+}
+
 const mockAxiosPost = (url: string, responseData: any) => {
     mockedPostResponseByUrl.set(url, responseData);
 
@@ -42,6 +87,23 @@ const mockAxiosPost = (url: string, responseData: any) => {
             fail("API call not mocked.")
         }
     })
+}
+
+const getMockAxiosPut = () => {
+    const mockedPutResponseByUrl = new Map<string, any>();
+
+    (axios.put as jest.Mock).mockImplementation((requestUrl: string, data: any) => {
+        if (mockedPutResponseByUrl.has(requestUrl)) {
+            const response = {data: mockedPutResponseByUrl.get(requestUrl)};
+            return Promise.resolve(response);
+        } else {
+            fail("API call not mocked." + requestUrl)
+        }
+    })
+
+    return (url: string, responseData: any) => {
+        mockedPutResponseByUrl.set(url, responseData);
+    }
 }
 
 const mockAxiosPut = (url: string, responseData: any) => {
@@ -65,4 +127,18 @@ afterEach(() => {
     mockedPostRequestBodyByUrl.clear();
 })
 
-export {mockAxiosGet, mockAxiosPost, mockAxiosPut, mockedPostRequestBodyByUrl};
+const mockAxios = () => {
+    return {
+        get: getMockAxiosGet(),
+        post: getMockAxiosPost(),
+        put: getMockAxiosPut()
+    }
+}
+
+export {
+    mockAxiosGet,
+    mockAxiosPost,
+    mockAxiosPut,
+    mockedPostRequestBodyByUrl,
+    mockAxios
+};

--- a/tests/utls/http-requests-mock.ts
+++ b/tests/utls/http-requests-mock.ts
@@ -5,37 +5,8 @@ const mockedGetResponseByUrl = new Map<string, any>();
 const mockedPostResponseByUrl = new Map<string, any>();
 const mockedPostRequestBodyByUrl = new Map<string, any>();
 
-const getMockAxiosGet = () => {
-    const mockedGetResponseByUrl = new Map<string, any>();
-
-    (axios.get as jest.Mock).mockImplementation(requestUrl => {
-        if (mockedGetResponseByUrl.has(requestUrl)) {
-            const response = {data: mockedGetResponseByUrl.get(requestUrl)};
-
-            if (response.data instanceof Buffer) {
-                const readableStream = new Readable();
-                readableStream.push(response.data)
-                readableStream.push(null);
-                return Promise.resolve({
-                    status: 200,
-                    data: readableStream,
-                });
-            } else {
-                return Promise.resolve(response);
-            }
-        } else {
-            fail("API call not mocked.")
-        }
-    });
-
-    return (url: string, responseData: any) => {
-        mockedGetResponseByUrl.set(url, responseData);
-    };
-}
-
 const mockAxiosGet = (url: string, responseData: any) => {
     mockedGetResponseByUrl.set(url, responseData);
-
     (axios.get as jest.Mock).mockImplementation(requestUrl => {
         if (mockedGetResponseByUrl.has(requestUrl)) {
             const response = { data: mockedGetResponseByUrl.get(requestUrl) };
@@ -57,23 +28,6 @@ const mockAxiosGet = (url: string, responseData: any) => {
     });
 };
 
-const getMockAxiosPost = () => {
-    const mockedPostResponseByUrl = new Map<string, any>();
-    axios.post = jest.fn();
-    (axios.post as jest.Mock).mockImplementation((requestUrl: string, data: any) => {
-        if (mockedPostResponseByUrl.has(requestUrl)) {
-            const response = {data: mockedPostResponseByUrl.get(requestUrl)};
-            return Promise.resolve(response);
-        } else {
-            fail("API call not mocked.")
-        }
-    })
-
-    return (url: string, responseData: any) => {
-        mockedPostResponseByUrl.set(url, responseData);
-    }
-}
-
 const mockAxiosPost = (url: string, responseData: any) => {
     mockedPostResponseByUrl.set(url, responseData);
 
@@ -87,23 +41,6 @@ const mockAxiosPost = (url: string, responseData: any) => {
             fail("API call not mocked.")
         }
     })
-}
-
-const getMockAxiosPut = () => {
-    const mockedPutResponseByUrl = new Map<string, any>();
-
-    (axios.put as jest.Mock).mockImplementation((requestUrl: string, data: any) => {
-        if (mockedPutResponseByUrl.has(requestUrl)) {
-            const response = {data: mockedPutResponseByUrl.get(requestUrl)};
-            return Promise.resolve(response);
-        } else {
-            fail("API call not mocked." + requestUrl)
-        }
-    })
-
-    return (url: string, responseData: any) => {
-        mockedPutResponseByUrl.set(url, responseData);
-    }
 }
 
 const mockAxiosPut = (url: string, responseData: any) => {
@@ -127,18 +64,9 @@ afterEach(() => {
     mockedPostRequestBodyByUrl.clear();
 })
 
-const mockAxios = () => {
-    return {
-        get: getMockAxiosGet(),
-        post: getMockAxiosPost(),
-        put: getMockAxiosPut()
-    }
-}
-
 export {
     mockAxiosGet,
     mockAxiosPost,
     mockAxiosPut,
-    mockedPostRequestBodyByUrl,
-    mockAxios
+    mockedPostRequestBodyByUrl
 };


### PR DESCRIPTION
#### Description
Previously we were importing the nodes with the source team Space ID set inside the files, this resulted in failing when trying to move the packages to the desired space in the target team, because of the non-existing space ID reference.

Changes in this PR include:

- Map spaces before doing an import
    - For each studio package, we will find the desired space ID in the target team
        - If the studio manifest file contains the space ID - (users have mapped it in the UI), that will be assigned
        - Else if we can find a space in the target with the same name, that will be assigned
        - Otherwise, we will create a new space.

Added test for the specific cases:
- Space ID in manifest file -> find by space ID 
- Space ID in the manifest file but does not exist in target team -> fails
- Space ID not provided in the manifest file, but space name yes -> finds it by name
- Space ID not provided in manifest file & not found any matching spaces with name -> create new space 

Didn't provide tests that will check if the imported files have the correct ID set as that requires unzipping each file. This part will be tackled with manual E2E tests.

#### Checklist

- [x] I have self-reviewed this PR
- [x] I have tested the change and proved that it works in different scenarios
- [ ] I have updated docs if needed
