### PR TITLE
TA-2865: Skip overwriting existing connection variable metadata

### DIFF
--- a/src/interfaces/package-export-transport.ts
+++ b/src/interfaces/package-export-transport.ts
@@ -29,7 +29,7 @@ export interface PackageManifestTransport {
 
 export interface VariableExportTransport {
     key: string;
-    value: object;
+    value: any;
     type: string;
     metadata: object;
 }

--- a/src/services/studio/studio.service.ts
+++ b/src/services/studio/studio.service.ts
@@ -43,15 +43,13 @@ class StudioService {
     public fixConnectionVariables(variables: VariableManifestTransport[]): VariableManifestTransport[] {
         return variables.map(variableManifest => ({
             ...variableManifest,
-            variables: variableManifest.variables.map(variable => ({
-                ...variable,
-                metadata: variable.type === PackageManagerVariableType.CONNECTION ? {
-                    ...variable.metadata,
-                    appName: variable.value["appName"] || ""
-                } : {
-                    ...variable.metadata
+            variables: variableManifest.variables.map(variable => {
+                if (variable.type !== PackageManagerVariableType.CONNECTION) {
+                    return variable;
                 }
-            }))
+
+                return this.fixConnectionVariable(variable);
+            })
         }));
     }
 
@@ -122,6 +120,20 @@ class StudioService {
                             }))
             } : pkg;
         });
+    }
+
+    private fixConnectionVariable(variable: VariableExportTransport): VariableExportTransport {
+        if (!variable.value.appName) {
+            return variable;
+        }
+
+        return {
+            ...variable,
+            metadata: {
+                ...variable.metadata,
+                appName: variable.value.appName
+            }
+        }
     }
 
     private deleteScenarioAssets(packageZip: AdmZip): void {

--- a/tests/config/config-export.spec.ts
+++ b/tests/config/config-export.spec.ts
@@ -117,6 +117,11 @@ describe("Config export", () => {
                 key: "key2-var",
                 type: PackageManagerVariableType.DATA_MODEL,
                 runtime: false
+            },
+            {
+                key: "key-2-connection",
+                type: PackageManagerVariableType.CONNECTION,
+                runtime: false
             }
         ];
 
@@ -156,6 +161,14 @@ describe("Config export", () => {
                         type: PackageManagerVariableType.DATA_MODEL,
                         value: "dm-id" as unknown as object,
                         metadata: {}
+                    },
+                    {
+                        key: "key-2-connection",
+                        type: PackageManagerVariableType.CONNECTION,
+                        value: "connection-id",
+                        metadata: {
+                            appName: "nameOfApp"
+                        }
                     }
                 ]
             },
@@ -211,6 +224,14 @@ describe("Config export", () => {
                     type: PackageManagerVariableType.DATA_MODEL,
                     value: "dm-id",
                     metadata: {}
+                },
+                {
+                    key: "key-2-connection",
+                    type: PackageManagerVariableType.CONNECTION,
+                    value: "connection-id",
+                    metadata: {
+                        appName: "nameOfApp"
+                    }
                 }
             ]
         });
@@ -303,6 +324,11 @@ describe("Config export", () => {
                 metadata: {
                     appName: "celonis"
                 }
+            },
+            {
+                key: "key-2-connection",
+                type: PackageManagerVariableType.CONNECTION,
+                runtime: false
             }
         ];
 
@@ -347,6 +373,14 @@ describe("Config export", () => {
                         metadata: {
                             appName: "celonis"
                         }
+                    },
+                    {
+                        key: "key-2-connection",
+                        type: PackageManagerVariableType.CONNECTION,
+                        value: "connection-id",
+                        metadata: {
+                            appName: "nameOfApp"
+                        }
                     }
                 ]
             },
@@ -389,8 +423,17 @@ describe("Config export", () => {
         const secondPackageExportedNode: NodeExportTransport = parse(secondPackageExportedZip.getEntry("package.yml").getData().toString());
         expect(secondPackageExportedNode).toBeTruthy();
         const secondPackageContent: NodeSerializedContent = parse(secondPackageExportedNode.serializedContent);
-        expect(secondPackageContent.variables).toHaveLength(1);
-        expect(secondPackageContent.variables).toEqual([...secondPackageVariableDefinition]);
+        expect(secondPackageContent.variables).toHaveLength(2);
+        expect(secondPackageContent.variables).toEqual([{
+                ...secondPackageVariableDefinition[0],
+            },
+            {
+                ...secondPackageVariableDefinition[1],
+                metadata: {
+                    appName: "nameOfApp"
+                }
+            }
+        ]);
     })
 
     it("Should export with SCENARIO nodes removed and CONNECTION variables fixed for package key with multiple underscores", async () => {
@@ -405,6 +448,11 @@ describe("Config export", () => {
             },
             {
                 key: "key-1-connection",
+                type: PackageManagerVariableType.CONNECTION,
+                runtime: false
+            },
+            {
+                key: "key-1-another-connection",
                 type: PackageManagerVariableType.CONNECTION,
                 runtime: false
             }
@@ -435,6 +483,14 @@ describe("Config export", () => {
                             connectionId: "connection-id"
                         } as unknown as object,
                         metadata: null
+                    },
+                    {
+                        key: "key-1-another-connection",
+                        type: PackageManagerVariableType.CONNECTION,
+                        value: "connection-id",
+                        metadata: {
+                            appName: "nameOfApp"
+                        }
                     }
                 ]
             }
@@ -458,7 +514,7 @@ describe("Config export", () => {
         const firstPackageExportedNode: NodeExportTransport = parse(firstPackageExportedZip.getEntry("package.yml").getData().toString());
         expect(firstPackageExportedNode).toBeTruthy();
         const firstPackageContent: NodeSerializedContent = parse(firstPackageExportedNode.serializedContent);
-        expect(firstPackageContent.variables).toHaveLength(2);
+        expect(firstPackageContent.variables).toHaveLength(3);
         expect(firstPackageContent.variables).toEqual([
             {
                 ...firstPackageVariableDefinition[0],
@@ -467,6 +523,11 @@ describe("Config export", () => {
                 ...firstPackageVariableDefinition[1],
                 metadata: {
                     appName: "celonis"
+                }
+            }, {
+                ...firstPackageVariableDefinition[2],
+                metadata: {
+                    appName: "nameOfApp"
                 }
             }
         ]);

--- a/tests/config/config-list-variables.spec.ts
+++ b/tests/config/config-list-variables.spec.ts
@@ -50,6 +50,21 @@ describe("Config listVariables", () => {
         ]
     };
 
+    const thirdManifest: VariableManifestTransport = {
+        packageKey: "key-3",
+        version: "1.0.0",
+        variables: [
+            {
+                key: "key2-var",
+                type: PackageManagerVariableType.CONNECTION,
+                value: "connection-id",
+                metadata: {
+                    appName: "celonis"
+                }
+            }
+        ]
+    }
+
     const fixedVariableManifests: VariableManifestTransport[] = [
         {
             ...firstManifest,
@@ -67,6 +82,9 @@ describe("Config listVariables", () => {
         },
         {
             ...secondManifest
+        },
+        {
+            ...thirdManifest
         }
     ];
 
@@ -78,26 +96,31 @@ describe("Config listVariables", () => {
         {
             packageKey: "key-2",
             version: "1.0.0"
+        },
+        {
+            packageKey: "key-3",
+            version: "1.0.0"
         }
     ];
 
     beforeEach(() => {
-        mockAxiosPost("https://myTeam.celonis.cloud/package-manager/api/core/packages/export/batch/variables-with-assignments", [{...firstManifest}, {...secondManifest}]);
+        mockAxiosPost("https://myTeam.celonis.cloud/package-manager/api/core/packages/export/batch/variables-with-assignments", [{...firstManifest}, {...secondManifest}, {...thirdManifest}]);
     })
 
     it("Should list fixed variables for non-json response", async () => {
-        await new ConfigCommand().listVariables(false, ["key-1:1.0.0", "key-2:1.0.0"], null);
+        await new ConfigCommand().listVariables(false, ["key-1:1.0.0", "key-2:1.0.0", "key-3:1.0.0"], null);
 
-        expect(testTransport.logMessages.length).toBe(2);
+        expect(testTransport.logMessages.length).toBe(3);
         expect(testTransport.logMessages[0].message).toContain(JSON.stringify(fixedVariableManifests[0]));
         expect(testTransport.logMessages[1].message).toContain(JSON.stringify(fixedVariableManifests[1]));
+        expect(testTransport.logMessages[2].message).toContain(JSON.stringify(fixedVariableManifests[2]));
 
         const variableExportRequest = parse(mockedPostRequestBodyByUrl.get("https://myTeam.celonis.cloud/package-manager/api/core/packages/export/batch/variables-with-assignments"));
         expect(variableExportRequest).toEqual(packageKeyAndVersionPairs);
     })
 
     it("Should export fixed variables for json response", async () => {
-        await new ConfigCommand().listVariables(true, ["key-1:1.0.0", "key-2:1.0.0"], null);
+        await new ConfigCommand().listVariables(true, ["key-1:1.0.0", "key-2:1.0.0", "key-3:1.0.0"], null);
 
         expect(testTransport.logMessages.length).toBe(1);
         expect(testTransport.logMessages[0].message).toContain(FileService.fileDownloadedMessage);
@@ -115,9 +138,10 @@ describe("Config listVariables", () => {
 
         await new ConfigCommand().listVariables(false, [], "key_version_mapping.json");
 
-        expect(testTransport.logMessages.length).toBe(2);
+        expect(testTransport.logMessages.length).toBe(3);
         expect(testTransport.logMessages[0].message).toContain(JSON.stringify(fixedVariableManifests[0]));
         expect(testTransport.logMessages[1].message).toContain(JSON.stringify(fixedVariableManifests[1]));
+        expect(testTransport.logMessages[2].message).toContain(JSON.stringify(fixedVariableManifests[2]));
 
         const variableExportRequest = parse(mockedPostRequestBodyByUrl.get("https://myTeam.celonis.cloud/package-manager/api/core/packages/export/batch/variables-with-assignments"));
         expect(variableExportRequest).toEqual(packageKeyAndVersionPairs);


### PR DESCRIPTION
#### Description

Skip overwriting existing connection variable metadata if the appName is not set in the value.

#### Checklist

- [x] I have self-reviewed this PR
- [x] I have tested the change and proved that it works in different scenarios
- [x] I have updated docs if needed
