### PR TITLE
TA-2896: Send body as FormData on dataModel push

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celonis/content-cli",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "CLI Tool to help manage content in Celonis EMS",
   "main": "content-cli.js",
   "bin": {

--- a/src/content/manager/ctp.datamodel.manager.ts
+++ b/src/content/manager/ctp.datamodel.manager.ts
@@ -1,4 +1,5 @@
 import { CtpManager } from "./ctp.manager";
+import * as FormData from "form-data";
 
 export class CtpDataModelManager extends CtpManager {
     private static BASE_URL = "/cpm-ems-migrator/migration/api/ctp";
@@ -16,15 +17,13 @@ export class CtpDataModelManager extends CtpManager {
     }
 
     protected getBody(): object {
-        return {
-            formData: {
-                file: this.content,
-                transport: JSON.stringify({
-                    password: this.password,
-                    existingPoolId: this.existingPoolId,
-                    globalPoolName: this.globalPoolName,
-                }),
-            },
-        };
+        const formData = new FormData();
+        formData.append("file", this.content);
+        formData.append("transport", JSON.stringify({
+            password: this.password,
+            existingPoolId: this.existingPoolId,
+            globalPoolName: this.globalPoolName,
+        }));
+        return formData;
     }
 }


### PR DESCRIPTION
#### Description

When [switching to axios](https://github.com/celonis/content-cli/commit/0d59227baeffc2fa6676ba2346e5bf5dfba88416#diff-5f5bad588680c79554e1d44f914acec5a2d21f11f64ba816e0009b63f8f413a0R34) `CtpDataModelManager.getBody` method was not migrated, leading to invalid multipart request. This PR fixes the body format to send FormData.

#### Checklist

- [x] I have self-reviewed this PR
- [x] I have tested the change and proved that it works in different scenarios
- [x] I have updated docs if needed
