### PR TITLE
TA-2944: Use hpagent when proxying requests

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celonis/content-cli",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "CLI Tool to help manage content in Celonis EMS",
   "main": "content-cli.js",
   "bin": {
@@ -20,6 +20,7 @@
     "axios": "1.6.2",
     "commander": "^6.0.0",
     "form-data": "4.0.0",
+    "hpagent": "^1.2.0",
     "semver": "^7.3.2",
     "valid-url": "^1.0.9",
     "winston": "^3.1.0",

--- a/src/services/http-client-service.v2.ts
+++ b/src/services/http-client-service.v2.ts
@@ -3,14 +3,17 @@ import { contextService } from "./context.service";
 import { FatalError, logger } from "../util/logger";
 import {TracingUtils} from "../util/tracing";
 import {VersionUtils} from "../util/version";
-import axios, {AxiosResponse, RawAxiosRequestHeaders} from "axios";
+import {AxiosResponse, RawAxiosRequestHeaders} from "axios";
 import * as FormData from "form-data";
+import { AxiosInitializer } from "../util/axios-initializer";
 
 class HttpClientServiceV2 {
+    
+    private axios = AxiosInitializer.initializeAxios();
 
     public async get(url: string): Promise<any> {
         return new Promise<any>((resolve, reject) => {
-            axios.get(this.resolveUrl(url), {
+            this.axios.get(this.resolveUrl(url), {
                 headers: this.buildHeaders(contextService.getContext().profile)
             }).then(response => {
                 this.handleResponse(response, resolve, reject);
@@ -24,7 +27,7 @@ class HttpClientServiceV2 {
 
     public async getFile(url: string): Promise<any> {
         return new Promise<any>((resolve, reject) => {
-            axios.get(this.resolveUrl(url), {
+            this.axios.get(this.resolveUrl(url), {
                 headers: this.buildHeaders(contextService.getContext().profile),
                 responseType: "stream",
                 validateStatus: status => status >= 200
@@ -49,7 +52,7 @@ class HttpClientServiceV2 {
 
     public async postFile(url: string, formData: FormData, parameters?: {}): Promise<any> {
         return new Promise<any>((resolve, reject) => {
-            axios.post(
+            this.axios.post(
                 this.resolveUrl(url),
                 formData,
                 {
@@ -71,7 +74,7 @@ class HttpClientServiceV2 {
 
     public async post(url: string, body: any): Promise<any> {
         return new Promise<any>((resolve, reject) => {
-            axios.post(
+            this.axios.post(
                 this.resolveUrl(url),
                 typeof body === "string" || body instanceof String ? body : JSON.stringify(body),
                 {
@@ -89,7 +92,7 @@ class HttpClientServiceV2 {
 
     public async put(url: string, body: object): Promise<any> {
         return new Promise<any>((resolve, reject) => {
-            axios.put(
+            this.axios.put(
                 this.resolveUrl(url),
                 JSON.stringify(body),
                 {
@@ -107,7 +110,7 @@ class HttpClientServiceV2 {
 
     public async delete(url: string): Promise<any> {
         return new Promise<any>((resolve, reject) => {
-            axios.delete(this.resolveUrl(url), {
+            this.axios.delete(this.resolveUrl(url), {
                 headers: this.buildHeaders(contextService.getContext().profile, "application/json;charset=utf-8")
             }).then(response => {
                 this.handleResponse(response, resolve, reject);
@@ -121,7 +124,7 @@ class HttpClientServiceV2 {
 
     public async downloadFile(url: string): Promise<any> {
         return new Promise<any>((resolve, reject) => {
-            axios.post(this.resolveUrl(url), null, {
+            this.axios.post(this.resolveUrl(url), null, {
                 headers: this.buildHeaders(contextService.getContext().profile),
                 responseType: "stream"
             }).then(response => {

--- a/src/services/http-client.service.ts
+++ b/src/services/http-client.service.ts
@@ -1,9 +1,13 @@
 import { AuthenticationType, Profile } from "../interfaces/profile.interface";
 import {logger} from "../util/logger";
-import axios, {AxiosResponse, RawAxiosRequestHeaders} from "axios";
+import {AxiosResponse, RawAxiosRequestHeaders} from "axios";
 import * as FormData from "form-data";
+import { AxiosInitializer } from "../util/axios-initializer";
 
 export class HttpClientService {
+
+    private axios = AxiosInitializer.initializeAxios();
+
     public async pushData(url: string, profile: Profile, body: any): Promise<any> {
         return new Promise<any>((resolve, reject) => {
             const headers = this.buildAuthorizationHeaders(profile);
@@ -12,7 +16,7 @@ export class HttpClientService {
                 headers["Content-Type"] = "multipart/form-data";
             }
 
-            axios.post(url, body, {
+            this.axios.post(url, body, {
                 headers
             }).then(response => {
                 this.handleResponse(response, resolve, reject);
@@ -24,7 +28,7 @@ export class HttpClientService {
 
     public async pullData(url: string, profile: Profile): Promise<any> {
         return new Promise<any>((resolve, reject) => {
-            axios.get(url, {
+            this.axios.get(url, {
                 headers: this.buildAuthorizationHeaders(profile)
             }).then(response => {
                 this.handleResponse(response, resolve, reject);
@@ -36,7 +40,7 @@ export class HttpClientService {
 
     public async pullFileData(url: string, profile: Profile): Promise<any> {
         return new Promise<any>((resolve, reject) => {
-            axios.post(url, null, {
+            this.axios.post(url, null, {
                 headers: this.buildAuthorizationHeaders(profile),
                 responseType: "stream"
             }).then(response => {
@@ -59,7 +63,7 @@ export class HttpClientService {
 
     public async updateData(url: string, profile: Profile, body: object): Promise<any> {
         return new Promise<any>((resolve, reject) => {
-            axios.put(url, body, {
+            this.axios.put(url, body, {
                 headers: this.buildAuthorizationHeaders(profile)
             }).then(response => {
                 this.handleResponse(response, resolve, reject);
@@ -71,7 +75,7 @@ export class HttpClientService {
 
     public async findAll(url: string, profile: Profile): Promise<any> {
         return new Promise<any>((resolve, reject) => {
-            axios.get(url, {
+            this.axios.get(url, {
                 headers: this.buildAuthorizationHeaders(profile)
             }).then(response => {
                 this.handleResponse(response, resolve, reject);

--- a/src/util/axios-initializer.ts
+++ b/src/util/axios-initializer.ts
@@ -1,0 +1,21 @@
+import axios, { AxiosInstance } from "axios";
+import { HttpsProxyAgent } from "hpagent";
+
+export class AxiosInitializer {
+    public static initializeAxios(): AxiosInstance {
+        const httpsProxy = process.env.https_proxy || process.env.HTTPS_PROXY;
+
+        if (httpsProxy) {
+            const httpsAgent = new HttpsProxyAgent({
+                proxy: httpsProxy
+            })
+
+            return axios.create({
+                httpsAgent,
+                proxy: false
+            })
+        } else {
+            return axios.create();
+        }
+    }
+}

--- a/tests/jest.setup.ts
+++ b/tests/jest.setup.ts
@@ -2,9 +2,10 @@ import * as fs from 'fs';
 import {setDefaultProfile} from "./utls/context-mock";
 import {TestTransport} from "./utls/test-transport";
 import {logger} from "../src/util/logger";
+import { mockAxios } from "./utls/http-requests-mock";
 
 // Mock the modules using Jest
-jest.mock('axios');
+mockAxios();
 jest.mock('fs');
 
 const mockWriteFileSync = jest.fn();

--- a/tests/list/assignments.spec.ts
+++ b/tests/list/assignments.spec.ts
@@ -1,8 +1,8 @@
 import {VariableCommand} from "../../src/commands/variable.command";
-import axios from "axios";
 import {FileService} from "../../src/services/file-service";
 import * as path from "path";
 import {mockWriteFileSync, testTransport} from "../jest.setup";
+import { mockedAxiosInstance } from "../utls/http-requests-mock";
 
 describe("List assignments", () => {
 
@@ -12,7 +12,7 @@ describe("List assignments", () => {
             {id: "id-2"}
         ];
         const resp = {data: mockAssignmentValues};
-        (axios.get as jest.Mock).mockResolvedValue(resp);
+        (mockedAxiosInstance.get as jest.Mock).mockResolvedValue(resp);
 
         await new VariableCommand().listAssignments("DATA_MODEL", false, "");
 
@@ -20,7 +20,7 @@ describe("List assignments", () => {
         expect(testTransport.logMessages[0].message).toContain('{"id":"id-1"}');
         expect(testTransport.logMessages[1].message).toContain('{"id":"id-2"}');
 
-        expect(axios.get).toHaveBeenCalledWith("https://myTeam.celonis.cloud/package-manager/api/compute-pools/pools-with-data-models", expect.anything())
+        expect(mockedAxiosInstance.get).toHaveBeenCalledWith("https://myTeam.celonis.cloud/package-manager/api/compute-pools/pools-with-data-models", expect.anything())
     })
 
     it("Should export assignments for supported type and json response", async () => {
@@ -29,7 +29,7 @@ describe("List assignments", () => {
             {id: "id-2"}
         ];
         const resp = {data: mockAssignmentValues};
-        (axios.get as jest.Mock).mockResolvedValue(resp);
+        (mockedAxiosInstance.get as jest.Mock).mockResolvedValue(resp);
 
         await new VariableCommand().listAssignments("DATA_MODEL", true, "");
 
@@ -44,11 +44,11 @@ describe("List assignments", () => {
     it("Should contain url params in the url", async () => {
         const mockAssignmentValues = [{id: "id-1"}];
         const resp = {data: mockAssignmentValues};
-        (axios.get as jest.Mock).mockResolvedValue(resp);
+        (mockedAxiosInstance.get as jest.Mock).mockResolvedValue(resp);
 
         await new VariableCommand().listAssignments("CONNECTION", false, "param1=value1,param2=value2");
 
-        expect(axios.get).toHaveBeenCalledWith("https://myTeam.celonis.cloud/process-automation-v2/api/connections?param1=value1&param2=value2", expect.anything())
+        expect(mockedAxiosInstance.get).toHaveBeenCalledWith("https://myTeam.celonis.cloud/process-automation-v2/api/connections?param1=value1&param2=value2", expect.anything())
     })
 
     it("Should throw error for unsupported variable types", async () => {

--- a/tests/utls/http-requests-mock.ts
+++ b/tests/utls/http-requests-mock.ts
@@ -1,13 +1,25 @@
-import axios from "axios";
+import { AxiosInstance } from "axios";
 import {Readable} from "stream";
+import { AxiosInitializer } from "../../src/util/axios-initializer";
+
+const mockedAxiosInstance = {} as AxiosInstance;
+
 
 const mockedGetResponseByUrl = new Map<string, any>();
 const mockedPostResponseByUrl = new Map<string, any>();
 const mockedPostRequestBodyByUrl = new Map<string, any>();
 
+const mockAxios = () : void => {
+    AxiosInitializer.initializeAxios = jest.fn().mockReturnValue(mockedAxiosInstance);
+
+    mockedAxiosInstance.get = jest.fn();
+    mockedAxiosInstance.post = jest.fn();
+    mockedAxiosInstance.put = jest.fn();
+}
+
 const mockAxiosGet = (url: string, responseData: any) => {
     mockedGetResponseByUrl.set(url, responseData);
-    (axios.get as jest.Mock).mockImplementation(requestUrl => {
+    (mockedAxiosInstance.get as jest.Mock).mockImplementation(requestUrl => {
         if (mockedGetResponseByUrl.has(requestUrl)) {
             const response = { data: mockedGetResponseByUrl.get(requestUrl) };
 
@@ -31,7 +43,7 @@ const mockAxiosGet = (url: string, responseData: any) => {
 const mockAxiosPost = (url: string, responseData: any) => {
     mockedPostResponseByUrl.set(url, responseData);
 
-    (axios.post as jest.Mock).mockImplementation((requestUrl: string, data: any) => {
+    (mockedAxiosInstance.post as jest.Mock).mockImplementation((requestUrl: string, data: any) => {
         if (mockedPostResponseByUrl.has(requestUrl)) {
             const response = { data: mockedPostResponseByUrl.get(requestUrl) };
             mockedPostRequestBodyByUrl.set(requestUrl, data);
@@ -45,8 +57,7 @@ const mockAxiosPost = (url: string, responseData: any) => {
 
 const mockAxiosPut = (url: string, responseData: any) => {
     mockedPostResponseByUrl.set(url, responseData);
-
-    (axios.put as jest.Mock).mockImplementation((requestUrl: string, data: any) => {
+    (mockedAxiosInstance.put as jest.Mock).mockImplementation((requestUrl: string, data: any) => {
         if (mockedPostResponseByUrl.has(requestUrl)) {
             const response = { data: mockedPostResponseByUrl.get(requestUrl) };
             mockedPostRequestBodyByUrl.set(requestUrl, data);
@@ -65,6 +76,8 @@ afterEach(() => {
 })
 
 export {
+    mockedAxiosInstance,
+    mockAxios,
     mockAxiosGet,
     mockAxiosPost,
     mockAxiosPut,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2128,6 +2128,11 @@ hasown@^2.0.0:
   dependencies:
     function-bind "^1.1.2"
 
+hpagent@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/hpagent/-/hpagent-1.2.0.tgz#0ae417895430eb3770c03443456b8d90ca464903"
+  integrity sha512-A91dYTeIB6NoXG+PxTQpCCDDnfHsW9kc06Lvpu1TEe9gnd6ZFeiBoRO9JvzEv6xK7EX97/dUE8g/vBMTqTS3CA==
+
 html-escaper@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/html-escaper/-/html-escaper-2.0.2.tgz#dfd60027da36a36dfcbe236262c00a5822681453"


### PR DESCRIPTION
#### Description

Axios fails to proxy requests from a http proxy to https servers (https://github.com/axios/axios/issues/4531) . This PR adds hpagent when proxying requests. 

#### Checklist

- [x] I have self-reviewed this PR
- [x] I have tested the change and proved that it works in different scenarios
- [x] I have updated docs if needed
