### PR TITLE
TA-2977: Rename config export properties to match API

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celonis/content-cli",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "CLI Tool to help manage content in Celonis EMS",
   "main": "content-cli.js",
   "bin": {

--- a/src/interfaces/package-export-transport.ts
+++ b/src/interfaces/package-export-transport.ts
@@ -51,7 +51,7 @@ export interface NodeExportTransport {
     name: string;
     type: string;
     exportSerializationType: string;
-    serializedContent: string;
+    configuration: string;
     schemaVersion: number;
 
     spaceId: string;

--- a/src/interfaces/package-export-transport.ts
+++ b/src/interfaces/package-export-transport.ts
@@ -48,18 +48,16 @@ export interface PackageKeyAndVersionPair {
 export interface NodeExportTransport {
     key: string;
     parentNodeKey: string;
-    packageNodeKey: string;
     name: string;
     type: string;
     exportSerializationType: string;
     serializedContent: string;
     schemaVersion: number;
 
-    unversionedMetadata: any;
-    versionedMetdata: object;
+    spaceId: string;
 
     invalidContent?: boolean;
-    serializedDocument: Buffer;
+    serializedDocument?: Buffer;
 }
 
 export interface NodeSerializedContent {

--- a/src/services/studio/studio.service.ts
+++ b/src/services/studio/studio.service.ts
@@ -254,9 +254,10 @@ class StudioService {
             await variableService.assignVariableValues(manifest.packageKey, manifest.runtimeVariableAssignments);
         }
     }
+
     private updateSpaceIdForNode(nodeContent: string, spaceId: string): string {
         const exportedNode: NodeExportTransport = parse(nodeContent);
-        const oldSpaceId = exportedNode.unversionedMetadata.spaceId;
+        const oldSpaceId = exportedNode.spaceId;
 
         nodeContent = nodeContent.replace(new RegExp(oldSpaceId, "g"), spaceId);
         return nodeContent;

--- a/src/services/studio/studio.service.ts
+++ b/src/services/studio/studio.service.ts
@@ -160,7 +160,7 @@ class StudioService {
         const packageEntry = packageZip.getEntry("package.yml");
 
         const exportedNode: NodeExportTransport = parse(packageEntry.getData().toString());
-        const nodeContent: NodeSerializedContent = parse(exportedNode.serializedContent);
+        const nodeContent: NodeSerializedContent = parse(exportedNode.configuration);
 
         nodeContent.variables = nodeContent.variables.map(variable => ({
             ...variable,
@@ -168,7 +168,7 @@ class StudioService {
                 connectionVariablesByKey.get(variable.key).metadata : variable.metadata
         }));
 
-        exportedNode.serializedContent = stringify(nodeContent);
+        exportedNode.configuration = stringify(nodeContent);
         packageZip.updateFile(packageEntry, Buffer.from(stringify(exportedNode)));
     }
 

--- a/tests/config/config-export.spec.ts
+++ b/tests/config/config-export.spec.ts
@@ -405,7 +405,7 @@ describe("Config export", () => {
         const firstPackageExportedZip = new AdmZip(actualZip.getEntry("key-1_1.0.0.zip").getData());
         const firstPackageExportedNode: NodeExportTransport = parse(firstPackageExportedZip.getEntry("package.yml").getData().toString());
         expect(firstPackageExportedNode).toBeTruthy();
-        const firstPackageContent: NodeSerializedContent = parse(firstPackageExportedNode.serializedContent);
+        const firstPackageContent: NodeSerializedContent = parse(firstPackageExportedNode.configuration);
         expect(firstPackageContent.variables).toHaveLength(2);
         expect(firstPackageContent.variables).toEqual([
             {
@@ -422,7 +422,7 @@ describe("Config export", () => {
         const secondPackageExportedZip = new AdmZip(actualZip.getEntry("key-2_1.0.0.zip").getData());
         const secondPackageExportedNode: NodeExportTransport = parse(secondPackageExportedZip.getEntry("package.yml").getData().toString());
         expect(secondPackageExportedNode).toBeTruthy();
-        const secondPackageContent: NodeSerializedContent = parse(secondPackageExportedNode.serializedContent);
+        const secondPackageContent: NodeSerializedContent = parse(secondPackageExportedNode.configuration);
         expect(secondPackageContent.variables).toHaveLength(2);
         expect(secondPackageContent.variables).toEqual([{
                 ...secondPackageVariableDefinition[0],
@@ -513,7 +513,7 @@ describe("Config export", () => {
         const firstPackageExportedZip = new AdmZip(actualZip.getEntry("key_with_underscores_1_1.0.0.zip").getData());
         const firstPackageExportedNode: NodeExportTransport = parse(firstPackageExportedZip.getEntry("package.yml").getData().toString());
         expect(firstPackageExportedNode).toBeTruthy();
-        const firstPackageContent: NodeSerializedContent = parse(firstPackageExportedNode.serializedContent);
+        const firstPackageContent: NodeSerializedContent = parse(firstPackageExportedNode.configuration);
         expect(firstPackageContent.variables).toHaveLength(3);
         expect(firstPackageContent.variables).toEqual([
             {

--- a/tests/utls/config-utils.ts
+++ b/tests/utls/config-utils.ts
@@ -63,16 +63,14 @@ export class ConfigUtils {
         return {
             key,
             parentNodeKey: key,
-            packageNodeKey: key,
             name: "name",
             type: "PACKAGE",
             exportSerializationType: "YAML",
             serializedContent,
             schemaVersion: 1,
-            unversionedMetadata: {},
-            versionedMetdata: {},
             invalidContent: false,
-            serializedDocument: null
+            serializedDocument: null,
+            spaceId: null
         };
     }
 
@@ -80,16 +78,14 @@ export class ConfigUtils {
         return {
             key,
             parentNodeKey: parentKey,
-            packageNodeKey: parentKey,
             name: "name",
             type: type,
             exportSerializationType: "YAML",
             serializedContent: "",
             schemaVersion: 1,
-            unversionedMetadata: {},
-            versionedMetdata: {},
             invalidContent: false,
-            serializedDocument: null
+            serializedDocument: null,
+            spaceId: null
         };
     }
 

--- a/tests/utls/config-utils.ts
+++ b/tests/utls/config-utils.ts
@@ -59,14 +59,14 @@ export class ConfigUtils {
         };
     }
 
-    public static buildPackageNode(key: string, serializedContent: string): NodeExportTransport {
+    public static buildPackageNode(key: string, configuration: string): NodeExportTransport {
         return {
             key,
             parentNodeKey: key,
             name: "name",
             type: "PACKAGE",
             exportSerializationType: "YAML",
-            serializedContent,
+            configuration: configuration,
             schemaVersion: 1,
             invalidContent: false,
             serializedDocument: null,
@@ -81,7 +81,7 @@ export class ConfigUtils {
             name: "name",
             type: type,
             exportSerializationType: "YAML",
-            serializedContent: "",
+            configuration: "",
             schemaVersion: 1,
             invalidContent: false,
             serializedDocument: null,


### PR DESCRIPTION
#### Description

Changes are made to ensure that used properties match the provided API interface.

#### Checklist

- [x] I have self-reviewed this PR
- [x] I have tested the change and proved that it works in different scenarios
- [x] I have updated docs if needed
