### PR TITLE
TA-3012: Add diff packages command

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -11,6 +11,13 @@ const config: Config.InitialOptions = {
     setupFilesAfterEnv: [
         "<rootDir>/tests/jest.setup.ts",
     ],
+    globals: {
+        "ts-jest": {
+            tsconfig: {
+                sourceMap: true
+            }
+        }
+    }
 }
 
 export default config

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "homepage": "https://github.com/celonis/content-cli",
   "scripts": {
     "build": "./node_modules/.bin/tsc && cp package.json dist/package.json",
+    "build-dev": "./node_modules/.bin/tsc --sourceMap && cp package.json dist/package.json",
     "lint": "tslint -p .",
     "test": "jest"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celonis/content-cli",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "description": "CLI Tool to help manage content in Celonis EMS",
   "main": "content-cli.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
   "homepage": "https://github.com/celonis/content-cli",
   "scripts": {
     "build": "./node_modules/.bin/tsc && cp package.json dist/package.json",
-    "build-dev": "./node_modules/.bin/tsc --sourceMap && cp package.json dist/package.json",
     "lint": "tslint -p .",
     "test": "jest"
   },

--- a/src/api/diff-api.ts
+++ b/src/api/diff-api.ts
@@ -1,0 +1,23 @@
+import {PackageDiffTransport} from "../interfaces/diff-package.transport";
+import {httpClientV2} from "../services/http-client-service.v2";
+import * as FormData from "form-data";
+
+class DiffApi {
+    public static readonly INSTANCE = new DiffApi();
+
+    public async diffPackages(data: FormData): Promise<PackageDiffTransport[]> {
+        return httpClientV2.postFile(
+            "/package-manager/api/core/packages/diff/configuration",
+            data
+        );
+    }
+
+    public async hasChanges(data: FormData): Promise<PackageDiffTransport[]> {
+        return httpClientV2.postFile(
+            "/package-manager/api/core/packages/diff/configuration/has-changes",
+            data
+        );
+    }
+}
+
+export const diffApi = DiffApi.INSTANCE;

--- a/src/commands/config.command.ts
+++ b/src/commands/config.command.ts
@@ -1,5 +1,6 @@
 import {batchImportExportService} from "../services/package-manager/batch-import-export-service";
 import {variableService} from "../services/package-manager/variable-service";
+import {diffService} from "../services/package-manager/diff-service";
 
 export class ConfigCommand {
 
@@ -25,5 +26,9 @@ export class ConfigCommand {
 
     public batchImportPackages(file: string, overwrite: boolean): Promise<void> {
         return batchImportExportService.batchImportPackages(file, overwrite);
+    }
+
+    public diffPackages(file: string, hasChanges: boolean, jsonResponse: boolean): Promise<void> {
+        return diffService.diffPackages(file, hasChanges, jsonResponse);
     }
 }

--- a/src/content-cli-config.ts
+++ b/src/content-cli-config.ts
@@ -70,6 +70,22 @@ export class Config {
 
         return program;
     }
+
+    public static diff(program: CommanderStatic): CommanderStatic {
+        program
+            .command("diff")
+            .description("Command to diff configs of packages")
+            .option("-p, --profile <profile>", "Profile of the team/realm which you want to use to diff the packages with")
+            .option("--hasChanges", "Flag to return only the information if the package has changes without the actual changes")
+            .option("--json", "Return the response as a JSON file")
+            .requiredOption("-f --file <file>", "Exported packages file (relative path)")
+            .action(async cmd => {
+                await new ConfigCommand().diffPackages(cmd.file, cmd.hasChanges, cmd.json);
+                process.exit();
+            });
+
+        return program;
+    }
 }
 
 const loadAllCommands = () => {
@@ -77,6 +93,7 @@ const loadAllCommands = () => {
     Config.listVariables(commander);
     Config.export(commander);
     Config.import(commander);
+    Config.diff(commander)
     commander.parse(process.argv);
 };
 

--- a/src/content-cli-config.ts
+++ b/src/content-cli-config.ts
@@ -78,7 +78,7 @@ export class Config {
             .option("-p, --profile <profile>", "Profile of the team/realm which you want to use to diff the packages with")
             .option("--hasChanges", "Flag to return only the information if the package has changes without the actual changes")
             .option("--json", "Return the response as a JSON file")
-            .requiredOption("-f --file <file>", "Exported packages file (relative path)")
+            .requiredOption("-f --file <file>", "Exported packages file (relative or absolute path)")
             .action(async cmd => {
                 await new ConfigCommand().diffPackages(cmd.file, cmd.hasChanges, cmd.json);
                 process.exit();

--- a/src/content-cli-config.ts
+++ b/src/content-cli-config.ts
@@ -78,7 +78,7 @@ export class Config {
             .option("-p, --profile <profile>", "Profile of the team/realm which you want to use to diff the packages with")
             .option("--hasChanges", "Flag to return only the information if the package has changes without the actual changes")
             .option("--json", "Return the response as a JSON file")
-            .requiredOption("-f --file <file>", "Exported packages file (relative or absolute path)")
+            .requiredOption("-f, --file <file>", "Exported packages file (relative or absolute path)")
             .action(async cmd => {
                 await new ConfigCommand().diffPackages(cmd.file, cmd.hasChanges, cmd.json);
                 process.exit();

--- a/src/interfaces/diff-package.transport.ts
+++ b/src/interfaces/diff-package.transport.ts
@@ -1,0 +1,18 @@
+export interface ConfigurationChangeTransport {
+    op: string;
+    path: string;
+    from: string;
+    value: object;
+}
+
+export interface NodeDiffTransport {
+    nodeKey: string;
+    changes: ConfigurationChangeTransport[];
+}
+
+export interface PackageDiffTransport {
+    packageKey: string;
+    hasChanges: boolean
+    packageChanges: ConfigurationChangeTransport[];
+    nodesWithChanges: NodeDiffTransport[];
+}

--- a/src/services/package-manager/diff-service.ts
+++ b/src/services/package-manager/diff-service.ts
@@ -1,0 +1,73 @@
+import * as AmdZip from "adm-zip";
+import {Readable} from "stream";
+import * as FormData from "form-data";
+import {diffApi} from "../../api/diff-api";
+import {FileService, fileService} from "../file-service";
+import {logger} from "../../util/logger";
+import {PackageDiffTransport} from "../../interfaces/diff-package.transport";
+import {v4 as uuidv4} from "uuid";
+
+class DiffService {
+
+    public async diffPackages(file: string, hasChanges: boolean, jsonResponse: boolean): Promise<void> {
+        if (hasChanges) {
+            await this.hasChanges(file, jsonResponse);
+        } else {
+            await this.diffPackagesAndReturnDiff(file, jsonResponse);
+        }
+    }
+
+    private async hasChanges(file: string, jsonResponse: boolean): Promise<void> {
+        const packages = new AmdZip(file);
+        const formData = this.buildBodyForDiff(packages);
+        const returnedHasChangesData = await diffApi.hasChanges(formData);
+
+        if (jsonResponse) {
+            this.exportListOfPackageDiffs(returnedHasChangesData);
+        } else {
+            logger.info(this.buildStringResponse(returnedHasChangesData));
+        }
+    }
+
+    private async diffPackagesAndReturnDiff(file: string, jsonResponse: boolean): Promise<void> {
+        const packages = new AmdZip(file);
+        const formData = this.buildBodyForDiff(packages);
+        const returnedHasChangesData = await diffApi.diffPackages(formData);
+
+        if (jsonResponse) {
+            this.exportListOfPackageDiffs(returnedHasChangesData);
+        } else {
+            logger.info( this.buildStringResponse(returnedHasChangesData));
+        }
+    }
+
+    private buildBodyForDiff(packages: AmdZip): FormData {
+        const formData = new FormData();
+        const readableStream = this.getReadableStream(packages);
+
+        formData.append("file", readableStream, {filename: "packages.zip"});
+
+        return formData;
+    }
+
+    private getReadableStream(packages: AmdZip): Readable {
+        return new Readable({
+            read(): void {
+                this.push(packages.toBuffer());
+                this.push(null);
+            }
+        });
+    }
+
+    private exportListOfPackageDiffs(packageDiffs: PackageDiffTransport[]): void {
+        const filename = uuidv4() + ".json";
+        fileService.writeToFileWithGivenName(JSON.stringify(packageDiffs), filename);
+        logger.info(FileService.fileDownloadedMessage + filename);
+    }
+
+    private buildStringResponse(packageDiffs: PackageDiffTransport[]): string {
+        return "\n" + JSON.stringify(packageDiffs, null, 2);
+    }
+}
+
+export const diffService = new DiffService();

--- a/src/services/package-manager/diff-service.ts
+++ b/src/services/package-manager/diff-service.ts
@@ -37,7 +37,7 @@ class DiffService {
         if (jsonResponse) {
             this.exportListOfPackageDiffs(returnedHasChangesData);
         } else {
-            logger.info( this.buildStringResponse(returnedHasChangesData));
+            logger.info(this.buildStringResponse(returnedHasChangesData));
         }
     }
 

--- a/src/services/package-manager/diff-service.ts
+++ b/src/services/package-manager/diff-service.ts
@@ -1,4 +1,4 @@
-import * as AmdZip from "adm-zip";
+import * as AdmZip from "adm-zip";
 import {Readable} from "stream";
 import * as FormData from "form-data";
 import {diffApi} from "../../api/diff-api";
@@ -18,7 +18,7 @@ class DiffService {
     }
 
     private async hasChanges(file: string, jsonResponse: boolean): Promise<void> {
-        const packages = new AmdZip(file);
+        const packages = new AdmZip(file);
         const formData = this.buildBodyForDiff(packages);
         const returnedHasChangesData = await diffApi.hasChanges(formData);
 
@@ -30,7 +30,7 @@ class DiffService {
     }
 
     private async diffPackagesAndReturnDiff(file: string, jsonResponse: boolean): Promise<void> {
-        const packages = new AmdZip(file);
+        const packages = new AdmZip(file);
         const formData = this.buildBodyForDiff(packages);
         const returnedHasChangesData = await diffApi.diffPackages(formData);
 
@@ -41,7 +41,7 @@ class DiffService {
         }
     }
 
-    private buildBodyForDiff(packages: AmdZip): FormData {
+    private buildBodyForDiff(packages: AdmZip): FormData {
         const formData = new FormData();
         const readableStream = this.getReadableStream(packages);
 
@@ -50,7 +50,7 @@ class DiffService {
         return formData;
     }
 
-    private getReadableStream(packages: AmdZip): Readable {
+    private getReadableStream(packages: AdmZip): Readable {
         return new Readable({
             read(): void {
                 this.push(packages.toBuffer());

--- a/tests/config/config-diff.spec.ts
+++ b/tests/config/config-diff.spec.ts
@@ -36,16 +36,13 @@ describe("Config diff", () => {
             nodesWithChanges: []
         }];
 
-        const expectedMessage: string = "    \n" +
-            "\"[{\\\"packageKey\\\":\\\"package-key\\\",\\\"hasChanges\\\":true,\\\"packageChanges\\\":[],\\\"nodesWithChanges\\\":[]}]\"";
-
-        mockAxiosPost("https://myTeam.celonis.cloud/package-manager/api/core/packages/diff/configuration/has-changes", JSON.stringify(diffResponse));
+        mockAxiosPost("https://myTeam.celonis.cloud/package-manager/api/core/packages/diff/configuration/has-changes", diffResponse);
 
         await new ConfigCommand().diffPackages("./packages.zip", true, false);
 
         expect(testTransport.logMessages.length).toBe(1);
-        expect(testTransport.logMessages[0].message).toBe(
-            expectedMessage
+        expect(testTransport.logMessages[0].message).toContain(
+            JSON.stringify(diffResponse, null, 2)
         );
     });
 
@@ -82,16 +79,13 @@ describe("Config diff", () => {
             }]
         }];
 
-        const expectedMessage: string = "    \n" +
-            "\"[{\\\"packageKey\\\":\\\"package-key\\\",\\\"hasChanges\\\":true,\\\"packageChanges\\\":[{\\\"op\\\":\\\"add\\\",\\\"path\\\":\\\"/test\\\",\\\"from\\\":\\\"bbbb\\\",\\\"value\\\":123}],\\\"nodesWithChanges\\\":[{\\\"nodeKey\\\":\\\"key-1\\\",\\\"changes\\\":[{\\\"op\\\":\\\"add\\\",\\\"path\\\":\\\"/test\\\",\\\"from\\\":\\\"bbb\\\",\\\"value\\\":234}]}]}]\"";
-
-        mockAxiosPost("https://myTeam.celonis.cloud/package-manager/api/core/packages/diff/configuration", JSON.stringify(diffResponse));
+        mockAxiosPost("https://myTeam.celonis.cloud/package-manager/api/core/packages/diff/configuration", diffResponse);
 
         await new ConfigCommand().diffPackages("./packages.zip", false, false);
 
         expect(testTransport.logMessages.length).toBe(1);
-        expect(testTransport.logMessages[0].message).toBe(
-            expectedMessage
+        expect(testTransport.logMessages[0].message).toContain(
+            JSON.stringify(diffResponse, null, 2)
         );
     });
 
@@ -127,7 +121,6 @@ describe("Config diff", () => {
                 }]
             }]
         }];
-
 
         mockAxiosPost("https://myTeam.celonis.cloud/package-manager/api/core/packages/diff/configuration", diffResponse);
 

--- a/tests/config/config-diff.spec.ts
+++ b/tests/config/config-diff.spec.ts
@@ -1,0 +1,178 @@
+import {PackageManifestTransport} from "../../src/interfaces/package-export-transport";
+import {ConfigUtils} from "../utls/config-utils";
+import * as path from "path";
+import {stringify} from "../../src/util/yaml";
+import {mockCreateReadStream, mockExistsSync, mockReadFileSync} from "../utls/fs-mock-utils";
+import {
+    PackageDiffTransport
+} from "../../src/interfaces/diff-package.transport";
+import {mockAxiosPost} from "../utls/http-requests-mock";
+import {ConfigCommand} from "../../src/commands/config.command";
+import { mockWriteFileSync, mockWriteSync, testTransport } from "../jest.setup";
+import { FileService } from "../../src/services/file-service";
+
+describe("Config diff", () => {
+
+    beforeEach(() => {
+        mockExistsSync();
+    });
+
+    it("Should show on terminal if packages have changes with hasChanges set to true and jsonResponse false", async () => {
+        const manifest: PackageManifestTransport[] = [];
+        manifest.push(ConfigUtils.buildManifestForKeyAndFlavor("package-key", "STUDIO"));
+
+        const firstPackageNode = ConfigUtils.buildPackageNode("package-key", stringify({metadata: {description: "test"}, variables: [], dependencies: []}));
+        const firstChildNode = ConfigUtils.buildChildNode("key-1", "package-key", "TEST");
+        const firstPackageZip = ConfigUtils.buildExportPackageZip(firstPackageNode, [firstChildNode], "1.0.0");
+        const exportedPackagesZip = ConfigUtils.buildBatchExportZip(manifest, [firstPackageZip]);
+
+        mockReadFileSync(exportedPackagesZip.toBuffer());
+        mockCreateReadStream(exportedPackagesZip.toBuffer());
+
+        const diffResponse: PackageDiffTransport[] = [{
+            packageKey: "package-key",
+            hasChanges: true,
+            packageChanges: [],
+            nodesWithChanges: []
+        }];
+
+        const expectedMessage: string = "    \n" +
+            "\"[{\\\"packageKey\\\":\\\"package-key\\\",\\\"hasChanges\\\":true,\\\"packageChanges\\\":[],\\\"nodesWithChanges\\\":[]}]\"";
+
+        mockAxiosPost("https://myTeam.celonis.cloud/package-manager/api/core/packages/diff/configuration/has-changes", JSON.stringify(diffResponse));
+
+        await new ConfigCommand().diffPackages("./packages.zip", true, false);
+
+        expect(testTransport.logMessages.length).toBe(1);
+        expect(testTransport.logMessages[0].message).toBe(
+            expectedMessage
+        );
+    });
+
+    it("Should show diff on terminal with hasChanges set to false and jsonResponse false", async () => {
+        const manifest: PackageManifestTransport[] = [];
+        manifest.push(ConfigUtils.buildManifestForKeyAndFlavor("package-key", "STUDIO"));
+
+        const firstPackageNode = ConfigUtils.buildPackageNode("package-key", stringify({metadata: {description: "test"}, variables: [], dependencies: []}));
+        const firstChildNode = ConfigUtils.buildChildNode("key-1", "package-key", "TEST");
+        const firstPackageZip = ConfigUtils.buildExportPackageZip(firstPackageNode, [firstChildNode], "1.0.0");
+        const exportedPackagesZip = ConfigUtils.buildBatchExportZip(manifest, [firstPackageZip]);
+
+        mockReadFileSync(exportedPackagesZip.toBuffer());
+        mockCreateReadStream(exportedPackagesZip.toBuffer());
+
+        const diffResponse: PackageDiffTransport[] = [{
+            packageKey: "package-key",
+            hasChanges: true,
+            packageChanges: [
+                {
+                    op: "add",
+                    path: "/test",
+                    from: "bbbb",
+                    value: JSON.parse("123")
+                }],
+            nodesWithChanges: [{
+                nodeKey: "key-1",
+                changes: [{
+                    op: "add",
+                    path: "/test",
+                    from: "bbb",
+                    value: JSON.parse("234")
+                }]
+            }]
+        }];
+
+        const expectedMessage: string = "    \n" +
+            "\"[{\\\"packageKey\\\":\\\"package-key\\\",\\\"hasChanges\\\":true,\\\"packageChanges\\\":[{\\\"op\\\":\\\"add\\\",\\\"path\\\":\\\"/test\\\",\\\"from\\\":\\\"bbbb\\\",\\\"value\\\":123}],\\\"nodesWithChanges\\\":[{\\\"nodeKey\\\":\\\"key-1\\\",\\\"changes\\\":[{\\\"op\\\":\\\"add\\\",\\\"path\\\":\\\"/test\\\",\\\"from\\\":\\\"bbb\\\",\\\"value\\\":234}]}]}]\"";
+
+        mockAxiosPost("https://myTeam.celonis.cloud/package-manager/api/core/packages/diff/configuration", JSON.stringify(diffResponse));
+
+        await new ConfigCommand().diffPackages("./packages.zip", false, false);
+
+        expect(testTransport.logMessages.length).toBe(1);
+        expect(testTransport.logMessages[0].message).toBe(
+            expectedMessage
+        );
+    });
+
+    it("Should generate a json file with diff info when hasChanges is set to false and jsonResponse is set to true", async () => {
+        const manifest: PackageManifestTransport[] = [];
+        manifest.push(ConfigUtils.buildManifestForKeyAndFlavor("package-key", "STUDIO"));
+
+        const firstPackageNode = ConfigUtils.buildPackageNode("package-key", stringify({metadata: {description: "test"}, variables: [], dependencies: []}));
+        const firstChildNode = ConfigUtils.buildChildNode("key-1", "package-key", "TEST");
+        const firstPackageZip = ConfigUtils.buildExportPackageZip(firstPackageNode, [firstChildNode], "1.0.0");
+        const exportedPackagesZip = ConfigUtils.buildBatchExportZip(manifest, [firstPackageZip]);
+
+        mockReadFileSync(exportedPackagesZip.toBuffer());
+        mockCreateReadStream(exportedPackagesZip.toBuffer());
+
+        const diffResponse: PackageDiffTransport[] = [{
+            packageKey: "package-key",
+            hasChanges: true,
+            packageChanges: [
+                {
+                    op: "add",
+                    path: "/test",
+                    from: "bbbb",
+                    value: JSON.parse("123")
+                }],
+            nodesWithChanges: [{
+                nodeKey: "key-1",
+                changes: [{
+                    op: "add",
+                    path: "/test",
+                    from: "bbb",
+                    value: JSON.parse("234")
+                }]
+            }]
+        }];
+
+
+        mockAxiosPost("https://myTeam.celonis.cloud/package-manager/api/core/packages/diff/configuration", diffResponse);
+
+        await new ConfigCommand().diffPackages("./packages.zip", false, true);
+
+        const expectedFileName = testTransport.logMessages[0].message.split(FileService.fileDownloadedMessage)[1];
+
+        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), expect.any(String), {encoding: "utf-8"});
+        const exportedPackageDiffTransport = JSON.parse(mockWriteFileSync.mock.calls[0][1]) as PackageDiffTransport[];
+        expect(exportedPackageDiffTransport.length).toBe(1);
+
+        const exportedFirstPackageDiffTransport = exportedPackageDiffTransport.filter(diffTransport => diffTransport.packageKey === firstPackageNode.key);
+        expect(exportedFirstPackageDiffTransport).toEqual(diffResponse);
+    });
+
+    it("Should generate a json file with info whether packages have changes when hasChanges is set to true and jsonResponse is set to true", async () => {
+        const manifest: PackageManifestTransport[] = [];
+        manifest.push(ConfigUtils.buildManifestForKeyAndFlavor("package-key", "STUDIO"));
+
+        const firstPackageNode = ConfigUtils.buildPackageNode("package-key", stringify({metadata: {description: "test"}, variables: [], dependencies: []}));
+        const firstChildNode = ConfigUtils.buildChildNode("key-1", "package-key", "TEST");
+        const firstPackageZip = ConfigUtils.buildExportPackageZip(firstPackageNode, [firstChildNode], "1.0.0");
+        const exportedPackagesZip = ConfigUtils.buildBatchExportZip(manifest, [firstPackageZip]);
+
+        mockReadFileSync(exportedPackagesZip.toBuffer());
+        mockCreateReadStream(exportedPackagesZip.toBuffer());
+
+        const diffResponse: PackageDiffTransport[] = [{
+            packageKey: "package-key",
+            hasChanges: true,
+            packageChanges: [],
+            nodesWithChanges: []
+        }];
+
+        mockAxiosPost("https://myTeam.celonis.cloud/package-manager/api/core/packages/diff/configuration/has-changes", diffResponse);
+
+        await new ConfigCommand().diffPackages("./packages.zip", true, true);
+
+        const expectedFileName = testTransport.logMessages[0].message.split(FileService.fileDownloadedMessage)[1];
+
+        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), expect.any(String), {encoding: "utf-8"});
+        const exportedPackageDiffTransport = JSON.parse(mockWriteFileSync.mock.calls[0][1]) as PackageDiffTransport[];
+        expect(exportedPackageDiffTransport.length).toBe(1);
+
+        const exportedFirstPackageDiffTransport = exportedPackageDiffTransport.filter(diffTransport => diffTransport.packageKey === firstPackageNode.key);
+        expect(exportedFirstPackageDiffTransport).toEqual(diffResponse);
+    });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     "declarationDir": "./dist/lib",
     "noImplicitAny": false,
     "target": "es2015",
-    "sourceMap": false,
+    "sourceMap": true,
     "declaration": true,
     "stripInternal": true,
     "module": "umd",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     "declarationDir": "./dist/lib",
     "noImplicitAny": false,
     "target": "es2015",
-    "sourceMap": true,
+    "sourceMap": false,
     "declaration": true,
     "stripInternal": true,
     "module": "umd",


### PR DESCRIPTION
#### Description

Added a new command to diff the configuration of a sent zip of packages and their nodes with their configuration on production:

`config diff --profile (profile) --file (the zip of packages) --json --hasChanges `

This command has a few options:

- `--file` - the zip of packages that will be diffed. This file should come from `config export` command.
- `--profile` - the profile that references the team/realm where we want to get the production packages that will be diffed. It's a required option.
- `--hasChanges` - option that when sent on the command, sets only the `packageKey` and `hasChanges` flag for each package transport, meanwhile the `packageChanges` and `nodesWithChanges` arrays are left as empty.
- `--json` - when this option is sent on the command, the response is saved in a JSON file. By default, when this option is not sent, the response is written on the console as a prettified JSON.

#### Other

- Set `sourceMap` to true while running Jest tests, so that the code can be debugged while writing the tests.

#### Checklist

- [x] I have self-reviewed this PR
- [x] I have tested the change and proved that it works in different scenarios
- [ ] I have updated docs if needed
