### PR TITLE
TA-3028: Update response transports for diff endpoints

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celonis/content-cli",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "description": "CLI Tool to help manage content in Celonis EMS",
   "main": "content-cli.js",
   "bin": {

--- a/src/api/diff-api.ts
+++ b/src/api/diff-api.ts
@@ -1,4 +1,4 @@
-import {PackageDiffTransport} from "../interfaces/diff-package.transport";
+import { PackageDiffMetadata, PackageDiffTransport } from "../interfaces/diff-package.transport";
 import {httpClientV2} from "../services/http-client-service.v2";
 import * as FormData from "form-data";
 
@@ -12,7 +12,7 @@ class DiffApi {
         );
     }
 
-    public async hasChanges(data: FormData): Promise<PackageDiffTransport[]> {
+    public async hasChanges(data: FormData): Promise<PackageDiffMetadata[]> {
         return httpClientV2.postFile(
             "/package-manager/api/core/packages/diff/configuration/has-changes",
             data

--- a/src/interfaces/diff-package.transport.ts
+++ b/src/interfaces/diff-package.transport.ts
@@ -12,7 +12,11 @@ export interface NodeDiffTransport {
 
 export interface PackageDiffTransport {
     packageKey: string;
-    hasChanges: boolean
     packageChanges: ConfigurationChangeTransport[];
     nodesWithChanges: NodeDiffTransport[];
+}
+
+export interface PackageDiffMetadata {
+    packageKey: string;
+    hasChanges: boolean;
 }

--- a/src/services/package-manager/diff-service.ts
+++ b/src/services/package-manager/diff-service.ts
@@ -4,7 +4,7 @@ import * as FormData from "form-data";
 import {diffApi} from "../../api/diff-api";
 import {FileService, fileService} from "../file-service";
 import {logger} from "../../util/logger";
-import {PackageDiffTransport} from "../../interfaces/diff-package.transport";
+import { PackageDiffMetadata, PackageDiffTransport } from "../../interfaces/diff-package.transport";
 import {v4 as uuidv4} from "uuid";
 
 class DiffService {
@@ -23,9 +23,9 @@ class DiffService {
         const returnedHasChangesData = await diffApi.hasChanges(formData);
 
         if (jsonResponse) {
-            this.exportListOfPackageDiffs(returnedHasChangesData);
+            this.exportListOfPackageDiffMetadata(returnedHasChangesData);
         } else {
-            logger.info(this.buildStringResponse(returnedHasChangesData));
+            logger.info(this.buildStringResponseForPackageDiffMetadataList(returnedHasChangesData));
         }
     }
 
@@ -37,7 +37,7 @@ class DiffService {
         if (jsonResponse) {
             this.exportListOfPackageDiffs(returnedHasChangesData);
         } else {
-            logger.info(this.buildStringResponse(returnedHasChangesData));
+            logger.info(this.buildStringResponseForPackageDiffs(returnedHasChangesData));
         }
     }
 
@@ -65,8 +65,18 @@ class DiffService {
         logger.info(FileService.fileDownloadedMessage + filename);
     }
 
-    private buildStringResponse(packageDiffs: PackageDiffTransport[]): string {
+    private exportListOfPackageDiffMetadata(packageDiffMetadata: PackageDiffMetadata[]): void {
+        const filename = uuidv4() + ".json";
+        fileService.writeToFileWithGivenName(JSON.stringify(packageDiffMetadata), filename);
+        logger.info(FileService.fileDownloadedMessage + filename);
+    }
+
+    private buildStringResponseForPackageDiffs(packageDiffs: PackageDiffTransport[]): string {
         return "\n" + JSON.stringify(packageDiffs, null, 2);
+    }
+
+    private buildStringResponseForPackageDiffMetadataList(packageDiffMetadata: PackageDiffMetadata[]): string {
+        return "\n" + JSON.stringify(packageDiffMetadata, null, 2);
     }
 }
 

--- a/tests/config/config-diff.spec.ts
+++ b/tests/config/config-diff.spec.ts
@@ -4,7 +4,8 @@ import * as path from "path";
 import {stringify} from "../../src/util/yaml";
 import {mockCreateReadStream, mockExistsSync, mockReadFileSync} from "../utls/fs-mock-utils";
 import {
-    PackageDiffTransport
+    PackageDiffMetadata,
+    PackageDiffTransport,
 } from "../../src/interfaces/diff-package.transport";
 import {mockAxiosPost} from "../utls/http-requests-mock";
 import {ConfigCommand} from "../../src/commands/config.command";
@@ -29,11 +30,9 @@ describe("Config diff", () => {
         mockReadFileSync(exportedPackagesZip.toBuffer());
         mockCreateReadStream(exportedPackagesZip.toBuffer());
 
-        const diffResponse: PackageDiffTransport[] = [{
+        const diffResponse: PackageDiffMetadata[] = [{
             packageKey: "package-key",
-            hasChanges: true,
-            packageChanges: [],
-            nodesWithChanges: []
+            hasChanges: true
         }];
 
         mockAxiosPost("https://myTeam.celonis.cloud/package-manager/api/core/packages/diff/configuration/has-changes", diffResponse);
@@ -60,7 +59,6 @@ describe("Config diff", () => {
 
         const diffResponse: PackageDiffTransport[] = [{
             packageKey: "package-key",
-            hasChanges: true,
             packageChanges: [
                 {
                     op: "add",
@@ -103,7 +101,6 @@ describe("Config diff", () => {
 
         const diffResponse: PackageDiffTransport[] = [{
             packageKey: "package-key",
-            hasChanges: true,
             packageChanges: [
                 {
                     op: "add",
@@ -148,11 +145,9 @@ describe("Config diff", () => {
         mockReadFileSync(exportedPackagesZip.toBuffer());
         mockCreateReadStream(exportedPackagesZip.toBuffer());
 
-        const diffResponse: PackageDiffTransport[] = [{
+        const diffResponse: PackageDiffMetadata[] = [{
             packageKey: "package-key",
-            hasChanges: true,
-            packageChanges: [],
-            nodesWithChanges: []
+            hasChanges: true
         }];
 
         mockAxiosPost("https://myTeam.celonis.cloud/package-manager/api/core/packages/diff/configuration/has-changes", diffResponse);


### PR DESCRIPTION
#### Description

Updated the transports that are returned from diff endpoints with the following changes:

- Diff package endpoint returns `PackageDiffTransport` which doesn't include the `hasChanges` property anymore.
- Has changes endpoint now returns the `PackageDiffMetadata` which contains the `packageKey` and `hasChanges` properties.

Note: This PR should not be merged for now, because the backend changes haven't still been merged.

#### Checklist

- [x] I have self-reviewed this PR
- [x] I have tested the change and proved that it works in different scenarios
- [ ] I have updated docs if needed
