### PR TITLE
TA-3598: Remove baseConfiguration from Diff transports

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celonis/content-cli",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "description": "CLI Tool to help manage content in Celonis EMS",
   "main": "content-cli.js",
   "bin": {

--- a/src/interfaces/diff-package.transport.ts
+++ b/src/interfaces/diff-package.transport.ts
@@ -3,6 +3,7 @@ export interface ConfigurationChangeTransport {
     path: string;
     from: string;
     value: object;
+    fromValue: object;
 }
 
 export interface NodeDiffTransport {

--- a/src/interfaces/diff-package.transport.ts
+++ b/src/interfaces/diff-package.transport.ts
@@ -8,36 +8,12 @@ export interface ConfigurationChangeTransport {
 export interface NodeDiffTransport {
     nodeKey: string;
     changes: ConfigurationChangeTransport[];
-    baseConfiguration: NodeConfiguration;
-}
-
-export interface NodeConfiguration {
-    [key: string]: any;
 }
 
 export interface PackageDiffTransport {
     packageKey: string;
-    basePackageConfiguration: PackageConfiguration;
     packageChanges: ConfigurationChangeTransport[];
     nodesWithChanges: NodeDiffTransport[];
-}
-
-export interface PackageConfiguration {
-    variables?: VariableDefinition[];
-    dependencies?: PackageDependency[];
-    [key: string]: any;
-}
-
-export interface PackageDependency {
-    key: string;
-    version: string;
-    [key: string]: any;
-}
-
-export interface VariableDefinition {
-    key: string;
-    type: string;
-    [key: string]: any;
 }
 
 export interface PackageDiffMetadata {

--- a/tests/config/config-diff.spec.ts
+++ b/tests/config/config-diff.spec.ts
@@ -63,7 +63,8 @@ describe("Config diff", () => {
                     op: "add",
                     path: "/test",
                     from: "bbbb",
-                    value: JSON.parse("123")
+                    value: JSON.parse("123"),
+                    fromValue: null
                 }],
             nodesWithChanges: [{
                 nodeKey: "key-1",
@@ -71,7 +72,8 @@ describe("Config diff", () => {
                     op: "add",
                     path: "/test",
                     from: "bbb",
-                    value: JSON.parse("234")
+                    value: JSON.parse("234"),
+                    fromValue: null
                 }]
             }]
         }];
@@ -105,7 +107,8 @@ describe("Config diff", () => {
                     op: "add",
                     path: "/test",
                     from: "bbbb",
-                    value: JSON.parse("123")
+                    value: JSON.parse("123"),
+                    fromValue: null
                 }],
             nodesWithChanges: [{
                 nodeKey: "key-1",
@@ -113,7 +116,8 @@ describe("Config diff", () => {
                     op: "add",
                     path: "/test",
                     from: "bbb",
-                    value: JSON.parse("234")
+                    value: JSON.parse("234"),
+                    fromValue: null
                 }]
             }]
         }];

--- a/tests/config/config-diff.spec.ts
+++ b/tests/config/config-diff.spec.ts
@@ -58,7 +58,6 @@ describe("Config diff", () => {
 
         const diffResponse: PackageDiffTransport[] = [{
             packageKey: "package-key",
-            basePackageConfiguration: {metadata: {description: "test"}},
             packageChanges: [
                 {
                     op: "add",
@@ -73,8 +72,7 @@ describe("Config diff", () => {
                     path: "/test",
                     from: "bbb",
                     value: JSON.parse("234")
-                }],
-                baseConfiguration: {}
+                }]
             }]
         }];
 
@@ -102,7 +100,6 @@ describe("Config diff", () => {
 
         const diffResponse: PackageDiffTransport[] = [{
             packageKey: "package-key",
-            basePackageConfiguration: {metadata: {description: "test"}},
             packageChanges: [
                 {
                     op: "add",
@@ -117,8 +114,7 @@ describe("Config diff", () => {
                     path: "/test",
                     from: "bbb",
                     value: JSON.parse("234")
-                }],
-                baseConfiguration: {}
+                }]
             }]
         }];
 


### PR DESCRIPTION
#### Description

This PR does the following:

 - Removes the `baseConfiguration` and `basePackageConfiguration` from Diff transports, since they're not needed anymore. 
 - Adds `fromValue` to `ConfigurationChangeTransport`.
 - Updates the tests accordingly.

#### Checklist

- [x] I have self-reviewed this PR
- [x] I have tested the change and proved that it works in different scenarios
- [ ] I have updated docs if needed
