### PR TITLE
TA-3622: Downgrade AdmZip version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celonis/content-cli",
-  "version": "0.13.2",
+  "version": "0.13.3",
   "description": "CLI Tool to help manage content in Celonis EMS",
   "main": "content-cli.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "@datadog/datadog-ci": "2.48.0",
-    "adm-zip": "0.5.16",
+    "adm-zip": "0.5.14",
     "axios": "1.7.9",
     "commander": "13.1.0",
     "form-data": "4.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2097,10 +2097,10 @@ acorn@^8.11.0, acorn@^8.4.1:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.14.0.tgz#063e2c70cac5fb4f6467f0b11152e04c682795b0"
   integrity sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==
 
-adm-zip@0.5.16:
-  version "0.5.16"
-  resolved "https://registry.yarnpkg.com/adm-zip/-/adm-zip-0.5.16.tgz#0b5e4c779f07dedea5805cdccb1147071d94a909"
-  integrity sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ==
+adm-zip@0.5.14:
+  version "0.5.14"
+  resolved "https://registry.yarnpkg.com/adm-zip/-/adm-zip-0.5.14.tgz#2c557c0bf12af4311cf6d32970f4060cf8133b2a"
+  integrity sha512-DnyqqifT4Jrcvb8USYjp6FHtBpEIz1mnXu6pTRHZ0RL69LbQYiO+0lDFg5+OKA7U29oWSs3a/i8fhn8ZcceIWg==
 
 agent-base@6:
   version "6.0.2"


### PR DESCRIPTION
#### Description

Downgrade AdmZip library to a version where zip descriptors are not checked. The nested zips we are generating during `config export/import` commands create zips that don't contain descriptors, and the library we are using doesn't provide with any way to force zip descriptors to be written during exports. Issues were introduced with this [PR](https://github.com/cthackers/adm-zip/pull/508)

Downgrade will offer a temporary solution until either a fix is provided in the library itself, or otherwise we will need to switch libraries.

Ticket: https://celonis.atlassian.net/browse/TA-3622

#### Checklist

- [x] I have self-reviewed this PR
- [x] I have tested the change and proved that it works in different scenarios
  - Tested `config export` and `config import`
- [x] I have updated docs if needed
