### PR TITLE
TA-3684: Add node info to diff transport

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celonis/content-cli",
-  "version": "0.13.3",
+  "version": "0.13.4",
   "description": "CLI Tool to help manage content in Celonis EMS",
   "main": "content-cli.js",
   "bin": {

--- a/src/interfaces/diff-package.transport.ts
+++ b/src/interfaces/diff-package.transport.ts
@@ -6,8 +6,19 @@ export interface ConfigurationChangeTransport {
     fromValue: object;
 }
 
+export enum NodeConfigurationChangeType {
+    ADDED = "ADDED",
+    DELETED = "DELETED",
+    CHANGED = "CHANGED",
+    UNCHANGED = "UNCHANGED",
+    INVALID = "INVALID"
+}
+
 export interface NodeDiffTransport {
     nodeKey: string;
+    name: string;
+    type: string;
+    changeType: NodeConfigurationChangeType;
     changes: ConfigurationChangeTransport[];
 }
 

--- a/tests/config/config-diff.spec.ts
+++ b/tests/config/config-diff.spec.ts
@@ -3,6 +3,7 @@ import {ConfigUtils} from "../utls/config-utils";
 import * as path from "path";
 import {mockCreateReadStream, mockExistsSync, mockReadFileSync} from "../utls/fs-mock-utils";
 import {
+    NodeConfigurationChangeType,
     PackageDiffMetadata,
     PackageDiffTransport,
 } from "../../src/interfaces/diff-package.transport";
@@ -67,7 +68,10 @@ describe("Config diff", () => {
                     fromValue: null
                 }],
             nodesWithChanges: [{
-                nodeKey: "key-1",
+                nodeKey: firstChildNode.key,
+                name: firstChildNode.name,
+                type: firstChildNode.type,
+                changeType: NodeConfigurationChangeType.ADDED,
                 changes: [{
                     op: "add",
                     path: "/test",
@@ -111,7 +115,10 @@ describe("Config diff", () => {
                     fromValue: null
                 }],
             nodesWithChanges: [{
-                nodeKey: "key-1",
+                nodeKey: firstChildNode.key,
+                name: firstChildNode.name,
+                type: firstChildNode.type,
+                changeType: NodeConfigurationChangeType.ADDED,
                 changes: [{
                     op: "add",
                     path: "/test",


### PR DESCRIPTION
#### Description

Add node info to diff transport

#### Checklist

- [x] I have self-reviewed this PR
- [x] I have tested the change and proved that it works in different scenarios
- [x] I have updated docs if needed
