### PR TITLE
TA-3768: Migrate Action Flows commands

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,6 +6,7 @@
 #/src/commands/configuration-management/           @celonis/astro
 #/src/commands/profile/                            @celonis/astro
 /src/commands/action-flows/                       @celonis/process-automation
+/tests/commands/action-flows/                     @celonis/process-automation
 /src/commands/analysis/                           @celonis/process-analytics
 /src/commands/cpm4/                               @celonis/cpm4
 /src/commands/data-pipeline/                      @Dusan-r @IvanGandacov @EktaCelonis @gorasoCelonis

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,7 +5,7 @@
 #/src/core                                         @celonis/astro
 #/src/commands/configuration-management/           @celonis/astro
 #/src/commands/profile/                            @celonis/astro
-#/src/commands/action-flows/                       @celonis/process-automation
+/src/commands/action-flows/                       @celonis/process-automation
 /src/commands/analysis/                           @celonis/process-analytics
 /src/commands/cpm4/                               @celonis/cpm4
 /src/commands/data-pipeline/                      @Dusan-r @IvanGandacov @EktaCelonis @gorasoCelonis

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,5 +16,5 @@ jobs:
       run: yarn install
     - name: Yarn Build
       run: yarn build
-#    - name: Yarn Test
-#      run: yarn test
+    - name: Yarn Test
+      run: yarn test

--- a/src/commands/action-flows/action-flow/action-flow-api.ts
+++ b/src/commands/action-flows/action-flow/action-flow-api.ts
@@ -1,0 +1,35 @@
+import * as FormData from "form-data";
+import { HttpClient } from "../../../core/http/http-client";
+import { Context } from "../../../core/command/cli-context";
+import { FatalError } from "../../../core/utils/logger";
+
+export class ActionFlowApi {
+
+    private httpClient: HttpClient;
+
+    constructor(context: Context) {
+        this.httpClient = context.httpClient;
+    }
+
+    public async exportRawAssets(packageId: string): Promise<Buffer> {
+        return this.httpClient.getFile(`/ems-automation/api/root/${packageId}/export/assets`).catch(e => {
+            throw new FatalError(`Problem getting Action Flow assets: ${e}`);
+        });
+    }
+
+    public async analyzeAssets(packageId: string): Promise<any> {
+        return this.httpClient.get(`/ems-automation/api/root/${packageId}/export/assets/analyze`).catch(e => {
+            throw new FatalError(`Problem analyzing Action Flow assets: ${e}`);
+        });
+    }
+
+    public async importAssets(packageId: string, data: FormData, dryRun: boolean): Promise<any> {
+        const params = {
+            dryRun: dryRun,
+        };
+
+        return this.httpClient.postFile(`/ems-automation/api/root/${packageId}/import/assets`, data, params).catch(e => {
+            throw new FatalError(`Problem importing Action Flow assets: ${e}`);
+        });
+    }
+}

--- a/src/commands/action-flows/action-flow/action-flow-command.service.ts
+++ b/src/commands/action-flows/action-flow/action-flow-command.service.ts
@@ -1,0 +1,23 @@
+import { Context } from "../../../core/command/cli-context";
+import { ActionFlowService } from "./action-flow.service";
+
+export class ActionFlowCommandService {
+
+    private actionFlowService: ActionFlowService;
+
+    constructor(context: Context) {
+        this.actionFlowService = new ActionFlowService(context);
+    }
+
+    public async exportActionFlows(packageId: string, metadataFile: string): Promise<void> {
+        await this.actionFlowService.exportActionFlows(packageId, metadataFile);
+    }
+
+    public async analyzeActionFlows(packageId: string, outputToJsonFile: boolean): Promise<void> {
+        await this.actionFlowService.analyzeActionFlows(packageId, outputToJsonFile);
+    }
+
+    public async importActionFlows(packageId: string, filePath: string, dryRun: boolean, outputToJsonFile: boolean): Promise<void> {
+        await this.actionFlowService.importActionFlows(packageId, filePath, dryRun, outputToJsonFile);
+    }
+}

--- a/src/commands/action-flows/action-flow/action-flow.service.ts
+++ b/src/commands/action-flows/action-flow/action-flow.service.ts
@@ -1,0 +1,79 @@
+import { v4 as uuidv4 } from "uuid";
+import * as AdmZip from "adm-zip";
+import * as FormData from "form-data";
+import * as fs from "fs";
+import { Context } from "../../../core/command/cli-context";
+import { ActionFlowApi } from "./action-flow-api";
+import { fileService, FileService } from "../../../core/utils/file-service";
+import { logger } from "../../../core/utils/logger";
+
+export class ActionFlowService {
+    public static readonly METADATA_FILE_NAME = "metadata.json";
+
+    private actionFlowApi: ActionFlowApi;
+
+    constructor(context: Context) {
+        this.actionFlowApi = new ActionFlowApi(context);
+    }
+
+    public async exportActionFlows(packageId: string, metadataFilePath: string): Promise<void> {
+        const exportedActionFlowsData = await this.actionFlowApi.exportRawAssets(packageId);
+        const tmpZip: AdmZip = new AdmZip(exportedActionFlowsData);
+
+        const zip = new AdmZip();
+        tmpZip.getEntries().forEach(entry => {
+            zip.addFile(entry.entryName, entry.getData());
+        });
+
+        if (metadataFilePath) {
+            this.attachMetadataFile(metadataFilePath, zip);
+        }
+
+        const fileName = "action-flows_export_" + uuidv4() + ".zip";
+        zip.writeZip(fileName);
+        logger.info(FileService.fileDownloadedMessage + fileName);
+    }
+
+    public async analyzeActionFlows(packageId: string, outputToJsonFile: boolean): Promise<void> {
+        const actionFlowsMetadata = await this.actionFlowApi.analyzeAssets(packageId);
+        const actionFlowsMetadataString = JSON.stringify(actionFlowsMetadata, null, 4);
+
+        if (outputToJsonFile) {
+            const metadataFileName = "action-flows_metadata_" + uuidv4() + ".json";
+            fileService.writeToFileWithGivenName(actionFlowsMetadataString, metadataFileName);
+            logger.info(FileService.fileDownloadedMessage + metadataFileName);
+        } else {
+            logger.info("Action flows analyze metadata: \n" + actionFlowsMetadataString);
+        }
+    }
+
+    public async importActionFlows(packageId: string, filePath: string, dryRun: boolean, outputToJsonFile: boolean): Promise<void> {
+        const actionFlowsZip = this.createBodyForImport(filePath);
+        const eventLog = await this.actionFlowApi.importAssets(packageId, actionFlowsZip, dryRun);
+        const eventLogString = JSON.stringify(eventLog, null, 4);
+
+        if (outputToJsonFile) {
+            const eventLogFileName = "action-flows_import_event_log_" + uuidv4() + ".json";
+            fileService.writeToFileWithGivenName(eventLogString, eventLogFileName);
+            logger.info(FileService.fileDownloadedMessage + eventLogFileName);
+        } else {
+            logger.info("Action flows import event log: \n" + eventLogString);
+        }
+    }
+
+    private createBodyForImport(fileName: string): FormData {
+        fileName = fileName + (fileName.endsWith(".zip") ? "" : ".zip");
+
+        const formData = new FormData();
+        formData.append("file", fs.createReadStream(fileName, { encoding: null }), { filename: fileName });
+
+        return formData;
+    }
+
+    private attachMetadataFile(fileName: string, zip: AdmZip): void {
+        fileName = fileName + (fileName.endsWith(".json") ? "" : ".json");
+        const metadata = fileService.readFile(fileName);
+
+        zip.addFile(ActionFlowService.METADATA_FILE_NAME, Buffer.from(metadata));
+    }
+}

--- a/src/commands/action-flows/module.ts
+++ b/src/commands/action-flows/module.ts
@@ -4,12 +4,75 @@
 
 import { Configurator, IModule } from "../../core/command/module-handler";
 import { Context } from "../../core/command/cli-context";
+import { Command, OptionValues } from "commander";
+import { ActionFlowCommandService } from "./action-flow/action-flow-command.service";
+import { SkillCommandService } from "./skill/skill-command.service";
 
 class Module extends IModule {
 
     register(context: Context, configurator: Configurator) {
+        const analyzeCommand = configurator.command("analyze");
+        analyzeCommand.command("action-flows")
+            .description("Analyze Action Flows dependencies for a certain package")
+            .option("-p, --profile <profile>", "Profile which you want to use to analyze Action Flows")
+            .requiredOption("--packageId <packageId>", "ID of the package from which you want to export Action Flows")
+            .option("-o, --outputToJsonFile", "Output the analyze result in a JSON file")
+            .action(this.analyzeActionFlows);
+
+        const exportCommand = configurator.command("export");
+        exportCommand.command("action-flows")
+            .description("Command to export all Action Flows in a package with their objects and dependencies")
+            .option("-p, --profile <profile>", "Profile which you want to use to export Action Flows")
+            .requiredOption("--packageId <packageId>", "ID of the package from which you want to export Action Flows")
+            .option("-f, --file <file>", "Action flows metadata file (relative path)")
+            .action(this.exportActionFlows);
+
+        const importCommand = configurator.command("import");
+        importCommand.command("action-flows")
+            .description("Command to import all Action Flows in a package with their objects and dependencies")
+            .option("-p, --profile <profile>", "Profile which you want to use to import Action Flows")
+            .requiredOption("--packageId <packageId>", "ID of the package to which you want to export Action Flows")
+            .requiredOption("-f, --file <file>", "Exported Action Flows file (relative path)")
+            .requiredOption("-d, --dryRun <dryRun>", "Execute the import on dry run mode")
+            .option("-o, --outputToJsonFile", "Output the import result in a JSON file")
+            .action(this.importActionFlows);
+
+        const pullCommand = configurator.command("pull");
+        pullCommand.command("skill")
+            .description("Command to pull a skill")
+            .option("-p, --profile <profile>", "Profile which you want to use to pull the skill")
+            .requiredOption("--projectId <projectId>", "Id of the project you want to pull")
+            .requiredOption("--skillId <skillId>", "Id of the skill you want to pull")
+            .action(this.pullSkill);
+
+        const pushCommand = configurator.command("push");
+        pushCommand.command("skill")
+            .description("Command to push a skill to a project")
+            .option("-p, --profile <profile>", "Profile which you want to use to push the skill")
+            .requiredOption("--projectId <projectId>", "Id of the project you want to push")
+            .requiredOption("-f, --file <file>", "The file you want to push")
+            .action(this.pushSkill);
     }
 
+    private async analyzeActionFlows(context: Context, command: Command, options: OptionValues): Promise<void> {
+        await new ActionFlowCommandService(context).analyzeActionFlows(options.packageId, options.outputToJsonFile);
+    }
+
+    private async exportActionFlows(context: Context, command: Command, options: OptionValues): Promise<void> {
+        await new ActionFlowCommandService(context).exportActionFlows(options.packageId, options.file);
+    }
+
+    private async importActionFlows(context: Context, command: Command, options: OptionValues): Promise<void> {
+        await new ActionFlowCommandService(context).importActionFlows(options.packageId, options.file, options.dryRun, options.outputToJsonFile);
+    }
+
+    private async pullSkill(context: Context, command: Command, options: OptionValues): Promise<void> {
+        await new SkillCommandService(context).pullSkill(options.profile, options.projectId, options.skillId);
+    }
+
+    private async pushSkill(context: Context, command: Command, options: OptionValues): Promise<void> {
+        await new SkillCommandService(context).pushSkill(options.profile, options.projectId, options.file);
+    }
 }
 
 export = Module;

--- a/src/commands/action-flows/skill/skill-command.service.ts
+++ b/src/commands/action-flows/skill/skill-command.service.ts
@@ -1,0 +1,20 @@
+import { ContentService } from "../../../core/http/http-shared/content.service";
+import { Context } from "../../../core/command/cli-context";
+import { SkillManagerFactory } from "./skill.manager-factory";
+
+export class SkillCommandService {
+    private contentService = new ContentService();
+    private skillManagerFactory: SkillManagerFactory;
+
+    constructor(context: Context) {
+        this.skillManagerFactory = new SkillManagerFactory(context);
+    }
+
+    public async pullSkill(profile: string, projectId: string, skillId: string): Promise<void> {
+        await this.contentService.pull(this.skillManagerFactory.createManager(projectId, skillId, null));
+    }
+
+    public async pushSkill(profile: string, projectId: string, filename: string): Promise<void> {
+        await this.contentService.push(this.skillManagerFactory.createManager(projectId, null, filename));
+    }
+}

--- a/src/commands/action-flows/skill/skill.manager-factory.ts
+++ b/src/commands/action-flows/skill/skill.manager-factory.ts
@@ -1,0 +1,32 @@
+import * as fs from "fs";
+import * as path from "path";
+import { Stream } from "stream";
+import { Context } from "../../../core/command/cli-context";
+import { FatalError, logger } from "../../../core/utils/logger";
+import { SkillManager } from "./skill.manager";
+
+export class SkillManagerFactory {
+
+    private readonly context: Context;
+
+    constructor(context: Context) {
+        this.context = context;
+    }
+
+    public createManager(projectId: string, skillId: string, filename: string): SkillManager {
+        const skillManager = new SkillManager(this.context);
+        skillManager.skillId = skillId;
+        skillManager.projectId = projectId;
+        if (filename !== null) {
+            skillManager.content = this.readFile(filename);
+        }
+        return skillManager;
+    }
+
+    private readFile(filename: string): Stream {
+        if (!fs.existsSync(path.resolve(process.cwd(), filename))) {
+            logger.error(new FatalError("The provided file does not exit"));
+        }
+        return fs.createReadStream(path.resolve(process.cwd(), filename), { encoding: "binary" });
+    }
+}

--- a/src/commands/action-flows/skill/skill.manager.ts
+++ b/src/commands/action-flows/skill/skill.manager.ts
@@ -1,0 +1,59 @@
+import * as FormData from "form-data";
+import { Context } from "../../../core/command/cli-context";
+import { BaseManager } from "../../../core/http/http-shared/base.manager";
+import { ManagerConfig } from "../../../core/http/http-shared/manager-config.interface";
+
+export class SkillManager extends BaseManager {
+    private static BASE_URL = "/action-engine/api/projects";
+    private _skillId: string;
+    private _projectId: string;
+    private _content: any;
+
+    constructor(context: Context) {
+        super(context);
+    }
+
+    public get content(): any {
+        return this._content;
+    }
+
+    public set content(value: any) {
+        this._content = value;
+    }
+    public get skillId(): string {
+        return this._skillId;
+    }
+
+    public set skillId(value: string) {
+        this._skillId = value;
+    }
+
+    public get projectId(): string {
+        return this._projectId;
+    }
+
+    public set projectId(value: string) {
+        this._projectId = value;
+    }
+
+    public getConfig(): ManagerConfig {
+        return {
+            pushUrl: `${SkillManager.BASE_URL}/${this.projectId}/skills/import-file`,
+            pullUrl: `${SkillManager.BASE_URL}/${this.projectId}/skills/${this.skillId}/export`,
+            exportFileName: "skill_" + this.skillId + ".json",
+            onPushSuccessMessage: (skill: any): string => {
+                return "Skill was pushed successfully. New ID: " + skill.id;
+            },
+        };
+    }
+
+    public getBody(): any {
+        const formData = new FormData();
+        formData.append("file", this.content);
+        return formData;
+    }
+
+    protected getSerializedFileContent(data: any): string {
+        return JSON.stringify(data);
+    }
+}

--- a/tests/commands/action-flows/analyze-action-flows.spec.ts
+++ b/tests/commands/action-flows/analyze-action-flows.spec.ts
@@ -1,9 +1,9 @@
 import * as path from "path";
 import { mockedAxiosInstance } from "../../utls/http-requests-mock";
-import { mockWriteFileSync, testTransport } from "../../jest.setup";
+import { loggingTestTransport, mockWriteFileSync } from "../../jest.setup";
 import { FileService } from "../../../src/core/utils/file-service";
 import { ActionFlowCommandService } from "../../../src/commands/action-flows/action-flow/action-flow-command.service";
-import { mockContext } from "../../utls/context-mock";
+import { testContext } from "../../utls/test-context";
 
 describe("Analyze action-flows", () => {
 
@@ -46,10 +46,10 @@ describe("Analyze action-flows", () => {
         const resp = { data: mockAnalyzeResponse };
         (mockedAxiosInstance.get as jest.Mock).mockResolvedValue(resp);
 
-        await new ActionFlowCommandService(mockContext).analyzeActionFlows(packageId, false);
+        await new ActionFlowCommandService(testContext).analyzeActionFlows(packageId, false);
 
-        expect(testTransport.logMessages.length).toBe(1);
-        expect(testTransport.logMessages[0].message).toContain(JSON.stringify(mockAnalyzeResponse, null, 4));
+        expect(loggingTestTransport.logMessages.length).toBe(1);
+        expect(loggingTestTransport.logMessages[0].message).toContain(JSON.stringify(mockAnalyzeResponse, null, 4));
 
         expect(mockedAxiosInstance.get).toHaveBeenCalledWith(`https://myTeam.celonis.cloud/ems-automation/api/root/${packageId}/export/assets/analyze`, expect.anything());
     });
@@ -58,11 +58,11 @@ describe("Analyze action-flows", () => {
         const resp = { data: mockAnalyzeResponse };
         (mockedAxiosInstance.get as jest.Mock).mockResolvedValue(resp);
 
-        await new ActionFlowCommandService(mockContext).analyzeActionFlows(packageId, true);
+        await new ActionFlowCommandService(testContext).analyzeActionFlows(packageId, true);
 
-        expect(testTransport.logMessages.length).toBe(1);
-        expect(testTransport.logMessages[0].message).toContain(FileService.fileDownloadedMessage);
-        const expectedFileName = testTransport.logMessages[0].message.split(FileService.fileDownloadedMessage)[1];
+        expect(loggingTestTransport.logMessages.length).toBe(1);
+        expect(loggingTestTransport.logMessages[0].message).toContain(FileService.fileDownloadedMessage);
+        const expectedFileName = loggingTestTransport.logMessages[0].message.split(FileService.fileDownloadedMessage)[1];
 
         expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), JSON.stringify(mockAnalyzeResponse, null, 4), { encoding: "utf-8" });
         expect(mockedAxiosInstance.get).toHaveBeenCalledWith(`https://myTeam.celonis.cloud/ems-automation/api/root/${packageId}/export/assets/analyze`, expect.anything());

--- a/tests/commands/action-flows/analyze-action-flows.spec.ts
+++ b/tests/commands/action-flows/analyze-action-flows.spec.ts
@@ -1,0 +1,70 @@
+import * as path from "path";
+import { mockedAxiosInstance } from "../../utls/http-requests-mock";
+import { mockWriteFileSync, testTransport } from "../../jest.setup";
+import { FileService } from "../../../src/core/utils/file-service";
+import { ActionFlowCommandService } from "../../../src/commands/action-flows/action-flow/action-flow-command.service";
+import { mockContext } from "../../utls/context-mock";
+
+describe("Analyze action-flows", () => {
+
+    const packageId = "123-456-789";
+    const mockAnalyzeResponse = {
+        "actionFlows": [
+            {
+                "key": "987_asset_key",
+                "rootNodeKey": "123_root_key_node",
+                "parentNodeKey": "555_parent_node_key",
+                "name": "T2T - simple package Automation",
+                "scenarioId": "321",
+                "webHookUrl": null,
+                "version": "10",
+                "sensorType": null,
+                "schedule": {
+                    "type": "indefinitely",
+                    "interval": 900,
+                },
+                "teamSpecific": {
+                    "connections": [],
+                    "variables": [],
+                    "celonisApps": [],
+                    "callingOtherAf": [],
+                    "datastructures": [],
+                },
+            },
+        ],
+        "connections": [],
+        "dataPools": [],
+        "dataModels": [],
+        "skills": [],
+        "analyses": [],
+        "datastructures": [],
+        "mappings": [],
+        "actionFlowsTeamId": "1234",
+    };
+
+    it("Should call import API and return non-json response", async () => {
+        const resp = { data: mockAnalyzeResponse };
+        (mockedAxiosInstance.get as jest.Mock).mockResolvedValue(resp);
+
+        await new ActionFlowCommandService(mockContext).analyzeActionFlows(packageId, false);
+
+        expect(testTransport.logMessages.length).toBe(1);
+        expect(testTransport.logMessages[0].message).toContain(JSON.stringify(mockAnalyzeResponse, null, 4));
+
+        expect(mockedAxiosInstance.get).toHaveBeenCalledWith(`https://myTeam.celonis.cloud/ems-automation/api/root/${packageId}/export/assets/analyze`, expect.anything());
+    });
+
+    it("Should call import API and return json response", async () => {
+        const resp = { data: mockAnalyzeResponse };
+        (mockedAxiosInstance.get as jest.Mock).mockResolvedValue(resp);
+
+        await new ActionFlowCommandService(mockContext).analyzeActionFlows(packageId, true);
+
+        expect(testTransport.logMessages.length).toBe(1);
+        expect(testTransport.logMessages[0].message).toContain(FileService.fileDownloadedMessage);
+        const expectedFileName = testTransport.logMessages[0].message.split(FileService.fileDownloadedMessage)[1];
+
+        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), JSON.stringify(mockAnalyzeResponse, null, 4), { encoding: "utf-8" });
+        expect(mockedAxiosInstance.get).toHaveBeenCalledWith(`https://myTeam.celonis.cloud/ems-automation/api/root/${packageId}/export/assets/analyze`, expect.anything());
+    });
+});

--- a/tests/commands/action-flows/export-action-flows.spec.ts
+++ b/tests/commands/action-flows/export-action-flows.spec.ts
@@ -1,0 +1,181 @@
+import * as AdmZip from "adm-zip";
+import * as fs from "fs";
+import { parse, stringify } from "yaml";
+import { mockAxiosGet } from "../../utls/http-requests-mock";
+import { ActionFlowCommandService } from "../../../src/commands/action-flows/action-flow/action-flow-command.service";
+import { mockWriteSync, testTransport } from "../../jest.setup";
+import { FileService } from "../../../src/core/utils/file-service";
+import { mockExistsSyncOnce, mockReadFileSync } from "../../utls/fs-mock-utils";
+import { mockContext } from "../../utls/context-mock";
+import { ActionFlowService } from "../../../src/commands/action-flows/action-flow/action-flow.service";
+
+describe("Export action-flows", () => {
+
+    const packageId = "123-456-789";
+    const actionFlowFileName = "20240711-scenario-1234.json";
+    const actionFlowConfig = {
+        "name": "T2T - simple package Automation",
+        "flow": [
+            {
+                "id": 6,
+                "module": "util:FunctionSleep",
+                "version": 1,
+                "parameters": {},
+                "metadata": {
+                    "expect": [
+                        {
+                            "name": "duration",
+                            "type": "uinteger",
+                            "label": "Delay",
+                            "required": true,
+                            "validate": {
+                                "max": 300,
+                                "min": 1,
+                            },
+                        },
+                    ],
+                    "restore": {},
+                    "designer": {
+                        "x": 300,
+                        "y": 0,
+                    },
+                },
+                "mapper": {
+                    "duration": "1",
+                },
+            },
+        ],
+        "metadata": {
+            "instant": false,
+            "version": 1,
+            "designer": {
+                "orphans": [],
+            },
+            "scenario": {
+                "dlq": false,
+                "dataloss": false,
+                "maxErrors": 3,
+                "autoCommit": true,
+                "roundtrips": 1,
+                "sequential": false,
+                "confidential": false,
+                "freshVariables": false,
+                "autoCommitTriggerLast": true,
+            },
+        },
+        "io": {
+            "output_spec": [],
+            "input_spec": [],
+        },
+    };
+
+    beforeEach(() => {
+        (fs.openSync as jest.Mock).mockReturnValue(100);
+    });
+
+    it("Should call export API and return the zip response", async () => {
+        const zipExport = new AdmZip();
+        zipExport.addFile(actionFlowFileName, Buffer.from(stringify(actionFlowConfig)));
+
+        mockAxiosGet(`https://myTeam.celonis.cloud/ems-automation/api/root/${packageId}/export/assets`, zipExport.toBuffer());
+
+        await new ActionFlowCommandService(mockContext).exportActionFlows(packageId, null);
+
+        expect(testTransport.logMessages.length).toBe(1);
+        const expectedZipFileName = testTransport.logMessages[0].message.split(FileService.fileDownloadedMessage)[1];
+        expect(fs.openSync).toHaveBeenCalledWith(expectedZipFileName, expect.anything(), expect.anything());
+        expect(mockWriteSync).toHaveBeenCalled();
+
+        const fileBuffer = mockWriteSync.mock.calls[0][1];
+        const receivedZip = new AdmZip(fileBuffer);
+
+        expect(receivedZip.getEntries().length).toBe(1);
+        const receivedZipEntry = receivedZip.getEntries()[0];
+        const receivedActionFlowConfig = parse(receivedZipEntry.getData().toString());
+        expect(receivedZipEntry.name).toEqual(actionFlowFileName);
+        expect(receivedActionFlowConfig).toEqual(actionFlowConfig);
+    });
+
+    it("Should call export API and attach the provided file to the zip response", async () => {
+        const metadata = {
+            "actionFlows": [
+                {
+                    "key": "123_asset_key",
+                    "rootNodeKey": "543_root_key",
+                    "parentNodeKey": "9099_parent_key",
+                    "name": "T2T - simple package Automation",
+                    "scenarioId": "1234",
+                    "webHookUrl": null,
+                    "version": "10",
+                    "sensorType": null,
+                    "schedule": {
+                        "type": "indefinitely",
+                        "interval": 900,
+                    },
+                    "teamSpecific": {
+                        "connections": [],
+                        "variables": [],
+                        "celonisApps": [],
+                        "callingOtherAf": [],
+                        "datastructures": [],
+                    },
+                },
+            ],
+            "connections": [],
+            "dataPools": [],
+            "dataModels": [],
+            "skills": [],
+            "analyses": [],
+            "datastructures": [],
+            "mappings": [],
+            "actionFlowsTeamId": "555",
+        };
+
+        mockExistsSyncOnce();
+        mockReadFileSync(stringify(metadata));
+        const zipExport = new AdmZip();
+        zipExport.addFile(actionFlowFileName, Buffer.from(stringify(actionFlowConfig)));
+
+        mockAxiosGet(`https://myTeam.celonis.cloud/ems-automation/api/root/${packageId}/export/assets`, zipExport.toBuffer());
+        await new ActionFlowCommandService(mockContext).exportActionFlows(packageId, ActionFlowService.METADATA_FILE_NAME);
+
+        expect(testTransport.logMessages.length).toBe(1);
+        const expectedZipFileName = testTransport.logMessages[0].message.split(FileService.fileDownloadedMessage)[1];
+        expect(fs.openSync).toHaveBeenCalledWith(expectedZipFileName, expect.anything(), expect.anything());
+        expect(mockWriteSync).toHaveBeenCalled();
+
+        const fileBuffer = mockWriteSync.mock.calls[0][1];
+        const receivedZip = new AdmZip(fileBuffer);
+
+        expect(receivedZip.getEntries().length).toBe(2);
+        expect(receivedZip.getEntries().filter(entry => entry.name === ActionFlowService.METADATA_FILE_NAME).length).toBe(1);
+
+        const receivedMetadataZipEntry = receivedZip.getEntries().filter(entry => entry.name === ActionFlowService.METADATA_FILE_NAME)[0];
+        const receivedActionFlowZipEntry = receivedZip.getEntries().filter(entry => entry.name !== ActionFlowService.METADATA_FILE_NAME)[0];
+        const receivedMetadataFile = parse(receivedMetadataZipEntry.getData().toString());
+        const receivedActionFlowFile = parse(receivedActionFlowZipEntry.getData().toString());
+
+        expect(receivedActionFlowZipEntry.name).toEqual(actionFlowFileName);
+        expect(receivedActionFlowFile).toEqual(actionFlowConfig);
+        expect(receivedMetadataFile).toEqual(metadata);
+    });
+
+    it("Should throw error if metadata files does not exist", async () => {
+        const zipExport = new AdmZip();
+        zipExport.addFile(actionFlowFileName, Buffer.from(stringify(actionFlowConfig)));
+
+        mockAxiosGet(`https://myTeam.celonis.cloud/ems-automation/api/root/${packageId}/export/assets`, zipExport.toBuffer());
+
+        const error = new Error("mock exit");
+        jest.spyOn(process, "exit").mockImplementation(() => {
+            throw error;
+        });
+
+        try {
+            await new ActionFlowCommandService(mockContext).exportActionFlows(packageId, ActionFlowService.METADATA_FILE_NAME);
+        } catch (e) {
+            expect(e).toBe(error);
+            expect(process.exit).toHaveBeenCalledWith(1);
+        }
+    });
+});

--- a/tests/commands/action-flows/export-action-flows.spec.ts
+++ b/tests/commands/action-flows/export-action-flows.spec.ts
@@ -3,11 +3,11 @@ import * as fs from "fs";
 import { parse, stringify } from "yaml";
 import { mockAxiosGet } from "../../utls/http-requests-mock";
 import { ActionFlowCommandService } from "../../../src/commands/action-flows/action-flow/action-flow-command.service";
-import { mockWriteSync, testTransport } from "../../jest.setup";
+import { loggingTestTransport, mockWriteSync } from "../../jest.setup";
 import { FileService } from "../../../src/core/utils/file-service";
 import { mockExistsSyncOnce, mockReadFileSync } from "../../utls/fs-mock-utils";
-import { mockContext } from "../../utls/context-mock";
 import { ActionFlowService } from "../../../src/commands/action-flows/action-flow/action-flow.service";
+import { testContext } from "../../utls/test-context";
 
 describe("Export action-flows", () => {
 
@@ -79,10 +79,10 @@ describe("Export action-flows", () => {
 
         mockAxiosGet(`https://myTeam.celonis.cloud/ems-automation/api/root/${packageId}/export/assets`, zipExport.toBuffer());
 
-        await new ActionFlowCommandService(mockContext).exportActionFlows(packageId, null);
+        await new ActionFlowCommandService(testContext).exportActionFlows(packageId, null);
 
-        expect(testTransport.logMessages.length).toBe(1);
-        const expectedZipFileName = testTransport.logMessages[0].message.split(FileService.fileDownloadedMessage)[1];
+        expect(loggingTestTransport.logMessages.length).toBe(1);
+        const expectedZipFileName = loggingTestTransport.logMessages[0].message.split(FileService.fileDownloadedMessage)[1];
         expect(fs.openSync).toHaveBeenCalledWith(expectedZipFileName, expect.anything(), expect.anything());
         expect(mockWriteSync).toHaveBeenCalled();
 
@@ -137,10 +137,10 @@ describe("Export action-flows", () => {
         zipExport.addFile(actionFlowFileName, Buffer.from(stringify(actionFlowConfig)));
 
         mockAxiosGet(`https://myTeam.celonis.cloud/ems-automation/api/root/${packageId}/export/assets`, zipExport.toBuffer());
-        await new ActionFlowCommandService(mockContext).exportActionFlows(packageId, ActionFlowService.METADATA_FILE_NAME);
+        await new ActionFlowCommandService(testContext).exportActionFlows(packageId, ActionFlowService.METADATA_FILE_NAME);
 
-        expect(testTransport.logMessages.length).toBe(1);
-        const expectedZipFileName = testTransport.logMessages[0].message.split(FileService.fileDownloadedMessage)[1];
+        expect(loggingTestTransport.logMessages.length).toBe(1);
+        const expectedZipFileName = loggingTestTransport.logMessages[0].message.split(FileService.fileDownloadedMessage)[1];
         expect(fs.openSync).toHaveBeenCalledWith(expectedZipFileName, expect.anything(), expect.anything());
         expect(mockWriteSync).toHaveBeenCalled();
 
@@ -172,7 +172,7 @@ describe("Export action-flows", () => {
         });
 
         try {
-            await new ActionFlowCommandService(mockContext).exportActionFlows(packageId, ActionFlowService.METADATA_FILE_NAME);
+            await new ActionFlowCommandService(testContext).exportActionFlows(packageId, ActionFlowService.METADATA_FILE_NAME);
         } catch (e) {
             expect(e).toBe(error);
             expect(process.exit).toHaveBeenCalledWith(1);

--- a/tests/commands/action-flows/import-action-flows.spec.ts
+++ b/tests/commands/action-flows/import-action-flows.spec.ts
@@ -3,9 +3,9 @@ import * as AdmZip from "adm-zip";
 import { mockedAxiosInstance } from "../../utls/http-requests-mock";
 import { mockCreateReadStream } from "../../utls/fs-mock-utils";
 import { ActionFlowCommandService } from "../../../src/commands/action-flows/action-flow/action-flow-command.service";
-import { mockContext } from "../../utls/context-mock";
-import { mockWriteFileSync, testTransport } from "../../jest.setup";
+import { loggingTestTransport, mockWriteFileSync } from "../../jest.setup";
 import { FileService } from "../../../src/core/utils/file-service";
+import { testContext } from "../../utls/test-context";
 
 describe("Import action-flows", () => {
 
@@ -30,10 +30,10 @@ describe("Import action-flows", () => {
         const zip = new AdmZip();
         mockCreateReadStream(zip.toBuffer());
 
-        await new ActionFlowCommandService(mockContext).importActionFlows(packageId, "tmp", true, false);
+        await new ActionFlowCommandService(testContext).importActionFlows(packageId, "tmp", true, false);
 
-        expect(testTransport.logMessages.length).toBe(1);
-        expect(testTransport.logMessages[0].message).toContain(JSON.stringify(mockImportResponse, null, 4));
+        expect(loggingTestTransport.logMessages.length).toBe(1);
+        expect(loggingTestTransport.logMessages[0].message).toContain(JSON.stringify(mockImportResponse, null, 4));
 
         expect(mockedAxiosInstance.post).toHaveBeenCalledWith(`https://myTeam.celonis.cloud/ems-automation/api/root/${packageId}/import/assets`, expect.anything(), expect.anything());
     });
@@ -44,11 +44,11 @@ describe("Import action-flows", () => {
         const zip = new AdmZip();
         mockCreateReadStream(zip.toBuffer());
 
-        await new ActionFlowCommandService(mockContext).importActionFlows(packageId, "tmp", true, true);
+        await new ActionFlowCommandService(testContext).importActionFlows(packageId, "tmp", true, true);
 
-        expect(testTransport.logMessages.length).toBe(1);
-        expect(testTransport.logMessages[0].message).toContain(FileService.fileDownloadedMessage);
-        const expectedFileName = testTransport.logMessages[0].message.split(FileService.fileDownloadedMessage)[1];
+        expect(loggingTestTransport.logMessages.length).toBe(1);
+        expect(loggingTestTransport.logMessages[0].message).toContain(FileService.fileDownloadedMessage);
+        const expectedFileName = loggingTestTransport.logMessages[0].message.split(FileService.fileDownloadedMessage)[1];
 
         expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), JSON.stringify(mockImportResponse, null, 4), { encoding: "utf-8" });
         expect(mockedAxiosInstance.post).toHaveBeenCalledWith(`https://myTeam.celonis.cloud/ems-automation/api/root/${packageId}/import/assets`, expect.anything(), expect.anything());

--- a/tests/commands/action-flows/import-action-flows.spec.ts
+++ b/tests/commands/action-flows/import-action-flows.spec.ts
@@ -1,0 +1,56 @@
+import * as path from "path";
+import * as AdmZip from "adm-zip";
+import { mockedAxiosInstance } from "../../utls/http-requests-mock";
+import { mockCreateReadStream } from "../../utls/fs-mock-utils";
+import { ActionFlowCommandService } from "../../../src/commands/action-flows/action-flow/action-flow-command.service";
+import { mockContext } from "../../utls/context-mock";
+import { mockWriteFileSync, testTransport } from "../../jest.setup";
+import { FileService } from "../../../src/core/utils/file-service";
+
+describe("Import action-flows", () => {
+
+    const packageId = "123-456-789";
+    const mockImportResponse = {
+        "status": "SUCCESS",
+        "eventLog": [
+            {
+                "status": "SUCCESS",
+                "assetType": "SCENARIO",
+                "assetId": "asset-id-automation",
+                "eventType": "IMPORT",
+                "log": "updated action flow with key [asset-id-automation]",
+                "mapping": null,
+            },
+        ],
+    };
+
+    it("Should call import API and return non-json response", async () => {
+        const resp = { data: mockImportResponse };
+        (mockedAxiosInstance.post as jest.Mock).mockResolvedValue(resp);
+        const zip = new AdmZip();
+        mockCreateReadStream(zip.toBuffer());
+
+        await new ActionFlowCommandService(mockContext).importActionFlows(packageId, "tmp", true, false);
+
+        expect(testTransport.logMessages.length).toBe(1);
+        expect(testTransport.logMessages[0].message).toContain(JSON.stringify(mockImportResponse, null, 4));
+
+        expect(mockedAxiosInstance.post).toHaveBeenCalledWith(`https://myTeam.celonis.cloud/ems-automation/api/root/${packageId}/import/assets`, expect.anything(), expect.anything());
+    });
+
+    it("Should call import API and return json response", async () => {
+        const resp = { data: mockImportResponse };
+        (mockedAxiosInstance.post as jest.Mock).mockResolvedValue(resp);
+        const zip = new AdmZip();
+        mockCreateReadStream(zip.toBuffer());
+
+        await new ActionFlowCommandService(mockContext).importActionFlows(packageId, "tmp", true, true);
+
+        expect(testTransport.logMessages.length).toBe(1);
+        expect(testTransport.logMessages[0].message).toContain(FileService.fileDownloadedMessage);
+        const expectedFileName = testTransport.logMessages[0].message.split(FileService.fileDownloadedMessage)[1];
+
+        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), JSON.stringify(mockImportResponse, null, 4), { encoding: "utf-8" });
+        expect(mockedAxiosInstance.post).toHaveBeenCalledWith(`https://myTeam.celonis.cloud/ems-automation/api/root/${packageId}/import/assets`, expect.anything(), expect.anything());
+    });
+});


### PR DESCRIPTION
#### Description

- Migrated Action Flows commands into the new structure, based on this [doc](https://docs.google.com/document/d/1KXVD0Fom6si36vZFN1xfeUhGKI09YtaBiK0bK8TDBWs/edit?tab=t.0#heading=h.5kyydlavdev2).
- The code logic is copy-pasted, besides some things like e.g. restructuring, command definition format.
- Removed profile management logic from the services.
- Removed profile management logic from base manager in skills. This is now provided by the tool.
  - This is not an ideal state, but wanted to keep the existing pattern and leave it to the command owners to decide if they want to change it.
- Migrated existing tests as they are, with only some minor changes in the test config setup to fit the new test config of the tool.

#### Relevant links
Jira issue: https://celonis.atlassian.net/browse/TA-3768

#### Notes
I would suggest to review the code along with some functional testing of the commands. This will make easier reviewing the large number of added lines here.

#### Checklist

- [x] I have self-reviewed this PR
- [x] I have tested the change and proved that it works in different scenarios
- [ ] I have updated docs if needed
