### PR TITLE
TA-3745: Provide default profile-setting option

### DIFF
--- a/src/commands/action-flows/module.ts
+++ b/src/commands/action-flows/module.ts
@@ -14,7 +14,6 @@ class Module extends IModule {
         const analyzeCommand = configurator.command("analyze");
         analyzeCommand.command("action-flows")
             .description("Analyze Action Flows dependencies for a certain package")
-            .option("-p, --profile <profile>", "Profile which you want to use to analyze Action Flows")
             .requiredOption("--packageId <packageId>", "ID of the package from which you want to export Action Flows")
             .option("-o, --outputToJsonFile", "Output the analyze result in a JSON file")
             .action(this.analyzeActionFlows);
@@ -22,7 +21,6 @@ class Module extends IModule {
         const exportCommand = configurator.command("export");
         exportCommand.command("action-flows")
             .description("Command to export all Action Flows in a package with their objects and dependencies")
-            .option("-p, --profile <profile>", "Profile which you want to use to export Action Flows")
             .requiredOption("--packageId <packageId>", "ID of the package from which you want to export Action Flows")
             .option("-f, --file <file>", "Action flows metadata file (relative path)")
             .action(this.exportActionFlows);
@@ -30,7 +28,6 @@ class Module extends IModule {
         const importCommand = configurator.command("import");
         importCommand.command("action-flows")
             .description("Command to import all Action Flows in a package with their objects and dependencies")
-            .option("-p, --profile <profile>", "Profile which you want to use to import Action Flows")
             .requiredOption("--packageId <packageId>", "ID of the package to which you want to export Action Flows")
             .requiredOption("-f, --file <file>", "Exported Action Flows file (relative path)")
             .requiredOption("-d, --dryRun <dryRun>", "Execute the import on dry run mode")
@@ -40,7 +37,6 @@ class Module extends IModule {
         const pullCommand = configurator.command("pull");
         pullCommand.command("skill")
             .description("Command to pull a skill")
-            .option("-p, --profile <profile>", "Profile which you want to use to pull the skill")
             .requiredOption("--projectId <projectId>", "Id of the project you want to pull")
             .requiredOption("--skillId <skillId>", "Id of the skill you want to pull")
             .action(this.pullSkill);
@@ -48,7 +44,6 @@ class Module extends IModule {
         const pushCommand = configurator.command("push");
         pushCommand.command("skill")
             .description("Command to push a skill to a project")
-            .option("-p, --profile <profile>", "Profile which you want to use to push the skill")
             .requiredOption("--projectId <projectId>", "Id of the project you want to push")
             .requiredOption("-f, --file <file>", "The file you want to push")
             .action(this.pushSkill);

--- a/src/commands/analysis/module.ts
+++ b/src/commands/analysis/module.ts
@@ -13,7 +13,6 @@ class Module extends IModule {
         const pullCommand = configurator.command("pull");
         pullCommand.command("bookmarks")
             .description("Command to pull an analysis bookmarks")
-            .option("-p, --profile <profile>", "Profile which you want to use to pull the analysis bookmarks")
             .option("--type <type>", "Pull shared/all Analysis Bookmarks, else by default get user bookmarks")
             .requiredOption("--id <id>", "Id of the analysis you want to pull")
             .action(this.pullAnalysisBookmarks);
@@ -21,7 +20,6 @@ class Module extends IModule {
         const pushCommand = configurator.command("push");
         pushCommand.command("bookmarks")
             .description("Command to push an analysis to a workspace")
-            .option("-p, --profile <profile>", "Profile which you want to use to push the analysis")
             .requiredOption("--id <id>", "Id of the Analysis to which you want to push the analysis bookmarks")
             .requiredOption("-f, --file <file>", "The file you want to push")
             .action(this.pushAnalysisBookmarks);

--- a/src/commands/configuration-management/module.ts
+++ b/src/commands/configuration-management/module.ts
@@ -14,7 +14,6 @@ class Module extends IModule {
         const configCommand = configurator.command("config");
         configCommand.command("list")
             .description("Command to list active packages that can be exported")
-            .option("-p, --profile <profile>", "Profile which you want to use to list possible variable assignments")
             .option("--json", "Return response as json type", "")
             .option("--flavors <flavors...>", "Lists only active packages of the given flavors")
             .option("--withDependencies", "Include dependencies", "")
@@ -25,21 +24,18 @@ class Module extends IModule {
 
         configCommand.command("export")
             .description("Command to export package configs")
-            .option("-p, --profile <profile>", "Profile which you want to use to export packages")
             .requiredOption("--packageKeys <packageKeys...>", "Keys of packages to export")
             .option("--withDependencies", "Include variables and dependencies", "")
             .action(this.batchExportPackages);
 
         configCommand.command("import")
             .description("Command to import package configs")
-            .option("-p, --profile <profile>", "Profile which you want to use to import packages")
             .option("--overwrite", "Flag to allow overwriting of packages")
             .requiredOption("-f, --file <file>", "Exported packages file (relative path)")
             .action(this.batchImportPackages);
 
         configCommand.command("diff")
             .description("Command to diff configs of packages")
-            .option("-p, --profile <profile>", "Profile of the team/realm which you want to use to diff the packages with")
             .option("--hasChanges", "Flag to return only the information if the package has changes without the actual changes")
             .option("--json", "Return the response as a JSON file")
             .requiredOption("-f, --file <file>", "Exported packages file (relative or absolute path)")
@@ -50,7 +46,6 @@ class Module extends IModule {
 
         variablesCommand.command("list")
             .description("Command to list versioned variables of packages")
-            .option("-p, --profile <profile>", "Profile which you want to use to list packages")
             .option("--json", "Return response as json type", "")
             .option("--keysByVersion <keysByVersion...>", "Mapping of package keys and versions", "")
             .option("--keysByVersionFile <keysByVersionFile>", "Package keys by version mappings file path.", "")
@@ -59,7 +54,6 @@ class Module extends IModule {
         const listCommand = configurator.command("list");
         listCommand.command("assignments")
             .description("Command to list possible variable assignments for a type")
-            .option("-p, --profile <profile>", "Profile which you want to use to list possible variable assignments")
             .option("--json", "Return response as json type", "")
             .requiredOption("--type <type>", "Type of variable")
             .option("--params <params>", "Variable query params")

--- a/src/commands/cpm4/module.ts
+++ b/src/commands/cpm4/module.ts
@@ -13,7 +13,6 @@ class Module extends IModule {
         const pushCommand = configurator.command("push")
         pushCommand.command("ctp")
             .description("Command to push a .ctp (Celonis 4 transport file) to create a package")
-            .option("-p, --profile <profile>", "Profile which you want to use to push the analysis")
             .option("-a, --pushAnalysis", "Specify this option if you want to push analysis from the CTP file")
             .option("-d, --pushDataModels", "Specify this option if you want to push data models from the CTP file")
             .option(

--- a/src/commands/data-pipeline/connection/connection.commands.ts
+++ b/src/commands/data-pipeline/connection/connection.commands.ts
@@ -13,14 +13,12 @@ export class ConnectionCommands {
         const listCommand = configurator.command("list");
         listCommand.command("connection")
             .description("Command to list all connections in a Data Pool")
-            .option("-p, --profile <profile>", "Profile which you want to use to list connections")
             .requiredOption("--dataPoolId <dataPoolId>", "ID of the data pool")
             .action(this.listConnections);
 
         const getCommand = configurator.command("get");
         getCommand.command("connection")
             .description("Programmatically read properties of your connections")
-            .option("-p, --profile <profile>", "Profile which you want to use to update the data pool configuration")
             .requiredOption("--dataPoolId <dataPoolId>", "Id of the data pool you want to update")
             .requiredOption("--connectionId <connectionId>", "Id of the connection you want to update")
             .action(this.getCommandProperties);
@@ -28,7 +26,6 @@ export class ConnectionCommands {
         const setCommand = configurator.command("set");
         setCommand.command("connection")
             .description("Programmatically update properties of your connections")
-            .option("-p, --profile <profile>", "Profile which you want to use to update the data pool configuration")
             .requiredOption("--dataPoolId <dataPoolId>", "Id of the data pool you want to update")
             .requiredOption("--connectionId <connectionId>", "Id of the connection you want to update")
             .requiredOption("--property <property>", "The property you want to update")

--- a/src/commands/data-pipeline/data-pool/data-pool.commands.ts
+++ b/src/commands/data-pipeline/data-pool/data-pool.commands.ts
@@ -12,7 +12,6 @@ export class DataPoolCommands {
         const exportCommand = configurator.command("export");
         exportCommand.command("data-pool")
             .description("Command to export a data pool")
-            .option("-p, --profile <profile>", "Profile which you want to use to export the data pool")
             .requiredOption("--id <id>", "ID of the data pool you want to export")
             .option("--outputToJsonFile", "Output the exported data pool to a JSON file")
             .action(this.exportDataPool);
@@ -20,7 +19,6 @@ export class DataPoolCommands {
         const importCommand = configurator.command("import");
         importCommand.command("data-pools")
             .description("Command to batch import multiple data pools with their objects and dependencies")
-            .option("-p, --profile <profile>", "Profile which you want to use to import the data pools")
             .requiredOption("-f, --jsonFile <file>", "The file with the JSON data pool batch import request")
             .option("--outputToJsonFile", "Output the batch import result in a JSON file")
             .action(this.batchImportDataPools);
@@ -28,33 +26,28 @@ export class DataPoolCommands {
         const listCommand = configurator.command("list");
         listCommand.command("data-pools")
             .description("Command to list all Data Pools")
-            .option("-p, --profile <profile>", "Profile which you want to use to list data pools")
             .option("--json", "Return response as json type", "")
             .action(this.listDataPools);
 
         const pullCommand = configurator.command("pull");
         pullCommand.command("data-pool")
             .description("Command to pull a data pool")
-            .option("-p, --profile <profile>", "Profile which you want to use to pull the data pool")
             .requiredOption("--id <id>", "Id of the data pool you want to pull")
             .action(this.pullDataPool);
 
         const pushCommand = configurator.command("push");
         pushCommand.command("data-pool")
             .description("Command to push a data pool")
-            .option("-p, --profile <profile>", "Profile which you want to use to push the data pool")
             .requiredOption("-f, --file <file>", "The file you want to push")
             .action(this.pushDataPool);
 
         pushCommand.command("data-pools")
             .description("Command to push data pools")
-            .option("-p, --profile <profile>", "Profile which you want to use to push the data pools")
             .action(this.pushDataPools);
 
         const updateCommand = configurator.command("update");
         updateCommand.command("data-pool")
             .description("Command to update a data pool using a data pool configuration file")
-            .option("-p, --profile <profile>", "Profile which you want to use to update the data pool configuration")
             .requiredOption("--id <id>", "Id of the data pool you want to update")
             .requiredOption("-f, --file <file>", "The file you want to push")
             .action(this.updateDataPool);

--- a/src/commands/studio/module.ts
+++ b/src/commands/studio/module.ts
@@ -16,7 +16,6 @@ class Module extends IModule {
         const exportCommand = configurator.command("export");
         exportCommand.command("packages")
             .description("Command to export all given packages")
-            .option("-p, --profile <profile>", "Profile which you want to use to list packages")
             .requiredOption("--packageKeys <packageKeys...>", "Exports only given package keys")
             .option("--includeDependencies", "Include variables and dependencies", "")
             .option("--excludeActionFlows", "Don't export action flows")
@@ -25,7 +24,6 @@ class Module extends IModule {
         const importCommand = configurator.command("import");
         importCommand.command("packages")
             .description("Command to import all given packages")
-            .option("-p, --profile <profile>", "Profile which you want to use to list packages")
             .option(
                 "--spaceMappings <spaceMappings...>",
                 "List of mappings for importing packages to different target spaces. Mappings should follow format 'packageKey:targetSpaceKey'"
@@ -39,7 +37,6 @@ class Module extends IModule {
         const listCommand = configurator.command("list");
         listCommand.command("packages")
             .description("Command to list all packages")
-            .option("-p, --profile <profile>", "Profile which you want to use to list packages")
             .option("--json", "Return response as json type", "")
             .option("--includeDependencies", "Include variables and dependencies", "")
             .option("--packageKeys <packageKeys...>", "Lists only given package keys")
@@ -47,13 +44,11 @@ class Module extends IModule {
 
         listCommand.command("spaces")
             .description("Command to list all spaces")
-            .option("-p, --profile <profile>", "Profile which you want to use to list spaces")
             .option("--json", "Return response as json type", "")
             .action(this.listSpaces);
 
         listCommand.command("assets")
             .description("Command to list all assets")
-            .option("-p, --profile <profile>", "Profile which you want to use to list assets")
             .option("--json", "Return response as json type", "")
             .option("--assetType <assetType>", "type of assets")
             .action(this.listAssets);
@@ -61,13 +56,11 @@ class Module extends IModule {
         const pullCommand = configurator.command("pull");
         pullCommand.command("asset")
             .description("Command to pull an asset from Studio")
-            .option("-p, --profile <profile>", "Profile which you want to use to pull the asset")
             .requiredOption("--key <key>", "Key of asset you want to pull")
             .action(this.pullAsset);
 
         pullCommand.command("package")
             .description("Command to pull a package")
-            .option("-p, --profile <profile>", "Profile which you want to use to pull the package")
             .requiredOption("--key <key>", "Key of the package you want to pull")
             .option("--store", "Pull package with store deployment metadata")
             .option("--newKey <newKey>", "Define a new key for your package")
@@ -77,20 +70,17 @@ class Module extends IModule {
         const pushCommand = configurator.command("push");
         pushCommand.command("asset")
             .description("Command to push an asset to Studio")
-            .option("-p, --profile <profile>", "Profile which you want to use to push the asset")
             .requiredOption("-f, --file <file>", "The file you want to push")
             .requiredOption("--package <packageKey>", "Key of the package you want to push asset to")
             .action(this.pushAsset);
 
         pushCommand.command("assets")
             .description("Command to push assets to Studio")
-            .option("-p, --profile <profile>", "Profile which you want to use to push the assets")
             .requiredOption("--package <packageKey>", "Key of the package you want to push assets to")
             .action(this.pushAssets);
 
         pushCommand.command("package")
             .description("Command to push a package to Studio")
-            .option("-p, --profile <profile>", "Profile which you want to use to push the package")
             .option("--newKey <newKey>", "Define a new key for your package")
             .option("--overwrite", "Overwrite package and its assets")
             .requiredOption("-f, --file <file>", "The file you want to push")
@@ -99,13 +89,11 @@ class Module extends IModule {
 
         pushCommand.command("packages")
             .description("Command to push packages to Studio")
-            .option("-p, --profile <profile>", "Profile which you want to use to push the packages")
             .requiredOption("--spaceKey <spaceKey>", "The key of the destination space")
             .action(this.pushPackages);
 
         pushCommand.command("widget")
             .description("Command to push a widget")
-            .option("-p, --profile <profile>", "Profile which you want to use to push the widget")
             .option("--tenantIndependent", "Upload widget tenant independently")
             .option("--userSpecific", "Upload widget only for the user in the provided api token")
             .option("--packageManager", "Upload widget to package manager (deprecated)") // Deprecated

--- a/src/core/command/module-handler.ts
+++ b/src/core/command/module-handler.ts
@@ -155,10 +155,9 @@ export class Configurator {
 export class CommandConfig {
     constructor(private cmd: Command, private ctx: Context) {
 
-    }
-
-    command(nameAndArgs: string, opts?: CommandOptions) : CommandConfig {
-        return new CommandConfig(this.cmd.command(nameAndArgs, opts), this.ctx);
+    public command(nameAndArgs: string, opts?: CommandOptions): CommandConfig {
+        return new CommandConfig(this.cmd.command(nameAndArgs, opts), this.ctx)
+            .option("-p, --profile <profile>", "Profile which you want to use");
     }
 
     alias(alias: string) {

--- a/src/core/command/module-handler.ts
+++ b/src/core/command/module-handler.ts
@@ -154,6 +154,7 @@ export class Configurator {
  */
 export class CommandConfig {
     constructor(private cmd: Command, private ctx: Context) {
+    }
 
     public command(nameAndArgs: string, opts?: CommandOptions): CommandConfig {
         return new CommandConfig(this.cmd.command(nameAndArgs, opts), this.ctx)


### PR DESCRIPTION
#### Description

Provided the `--profile` option for all the commands centrally. Removed all of the redundant definitions from commands. 

#### Relevant links

Jira issue: https://celonis.atlassian.net/browse/TA-3754

#### Checklist

- [x] I have self-reviewed this PR
- [x] I have tested the change and proved that it works in different scenarios
- [ ] I have updated docs if needed
