### PR TITLE
TA-3752: Deprecate Studio export/import commands

### DIFF
--- a/src/commands/studio/module.ts
+++ b/src/commands/studio/module.ts
@@ -19,6 +19,8 @@ class Module extends IModule {
             .requiredOption("--packageKeys <packageKeys...>", "Exports only given package keys")
             .option("--includeDependencies", "Include variables and dependencies", "")
             .option("--excludeActionFlows", "Don't export action flows")
+            .deprecationNotice("`content-cli export packages` is deprecated and is expected to be removed in subsequent updates around: 01-09-2025.\n" +
+                "Please use `content-cli config export` instead.\n")
             .action(this.batchExportPackages);
 
         const importCommand = configurator.command("import");
@@ -32,6 +34,8 @@ class Module extends IModule {
             .option("--excludeActionFlows", "Skip overwrite of action flows of package")
             .option("--dataModelMappingsFile <dataModelMappingsFile>", "DataModel variable mappings file path. If missing, variables will be mapped from manifest file.")
             .requiredOption("-f, --file <file>", "Exported packages file (relative path)")
+            .deprecationNotice("`content-cli import packages` is deprecated and is expected to be removed in subsequent updates around: 01-09-2025.\n" +
+                "Please use `content-cli config import` instead.\n")
             .action(this.batchImportPackages);
 
         const listCommand = configurator.command("list");

--- a/src/core/command/module-handler.ts
+++ b/src/core/command/module-handler.ts
@@ -153,6 +153,8 @@ export class Configurator {
  * executed.
  */
 export class CommandConfig {
+    private deprecationMessage: string;
+
     constructor(
         private cmd: Command,
         private ctx: Context
@@ -188,13 +190,25 @@ export class CommandConfig {
         return this;
     }
 
+    public deprecationNotice(deprecationMessage: string): CommandConfig {
+        this.deprecationMessage = deprecationMessage;
+        return this;
+    }
+
     public action(handler: CommandHandler): void {
         this.cmd.action(async (): Promise<void> => {
             try {
+                this.printDeprecationNoticeIfDeprecated();
                 await handler(this.ctx, this.cmd, this.cmd.opts());
             } catch (error) {
                 logger.error(`An unexpected error occured executing a command: ${error}`);
             }
         });
+    }
+
+    private printDeprecationNoticeIfDeprecated(): void {
+        if (this.deprecationMessage) {
+            logger.warn("⚠️  [DEPRECATION NOTICE] \n" + this.deprecationMessage);
+        }
     }
 }


### PR DESCRIPTION
#### Description

- Added deprecation notice for batch export/import commands in Studio.
- The deprecation notice has been set to ~2 months later (1st of September)
- The notices points to the `config export/import` commands.
- Deprecation done based on this [sheet](https://docs.google.com/spreadsheets/d/1aZ5D4_ss412lI8jAoOZstqAen2Od8pBwlAPpCmhgYW8/edit?gid=0#gid=0).

Example of a deprecation message:
```
warn:    ⚠️  [DEPRECATION NOTICE] 
`content-cli import packages` is deprecated and is expected to be removed in subsequent updates around: 01-09-2025.
Please use `content-cli config import` instead.
```

Implemented a built-in deprecation notice printer which can be reused. 

#### Checklist

- [x] I have self-reviewed this PR
- [x] I have tested the change and proved that it works in different scenarios
- [ ] I have updated docs if needed
