### PR TITLE
TA-3754: Fix publish action

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -17,6 +17,9 @@ jobs:
   version-bump:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: Bump NPM version
         uses: ./.github/action/bump-npm-version
         with:


### PR DESCRIPTION
#### Description

The publish action can't find the `bump-npm-version` action because it's not getting checked out in the branch on which it's executed (`master`). Added the checkout step to it.

#### Checklist

- [x] I have self-reviewed this PR
- [ ] I have tested the change and proved that it works in different scenarios
  - Will test after merging 
- [ ] I have updated docs if needed
