### PR TITLE
TA-3754: Make used secrets and variables parametrized in the action

### DIFF
--- a/.github/action/bump-npm-version/action.yml
+++ b/.github/action/bump-npm-version/action.yml
@@ -11,6 +11,14 @@ inputs:
       - patch
       - minor
       - major
+  token:
+    description: 'GitHub token for authentication'
+    required: true
+    type: string
+  repository:
+    description: 'GitHub repository to push changes to'
+    required: true
+    type: string
 
 jobs:
   bump:
@@ -28,7 +36,7 @@ jobs:
         run: |
           git config user.name 'celobot'
           git config user.email 'github-celobot@celonis.com'
-          git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}
+          git remote set-url origin https://x-access-token:${{ inputs.token }}@github.com/${{ inputs.repository }}
 
       - name: Run npm version
         run: |

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -24,6 +24,8 @@ jobs:
         uses: ./.github/action/bump-npm-version
         with:
           bump: ${{ inputs.bump }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          repository: ${{ github.repository }}
 
   build:
     needs: version-bump

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -17,6 +17,9 @@ jobs:
   version-bump:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: Bump NPM version
         uses: ./.github/action/bump-npm-version
         with:


### PR DESCRIPTION
#### Description

When an action is used inside another workflow, you cannot access the secrets and variables directly. Should pass them as action inputs instead. Made them parameters and sent from the main workflow.

#### Checklist

- [x] I have self-reviewed this PR
- [ ] I have tested the change and proved that it works in different scenarios
- [ ] I have updated docs if needed
