### PR TITLE
Ta 3754 fix publish action

### DIFF
--- a/.github/action/bump-npm-version/action.yml
+++ b/.github/action/bump-npm-version/action.yml
@@ -5,20 +5,12 @@ inputs:
   bump:
     description: 'Which version bump (patch, minor, major)'
     required: true
-    default: 'patch'
-    type: choice
-    options:
-      - patch
-      - minor
-      - major
   token:
     description: 'GitHub token for authentication'
     required: true
-    type: string
   repository:
     description: 'GitHub repository to push changes to'
     required: true
-    type: string
 
 jobs:
   bump:

--- a/.github/action/bump-npm-version/action.yml
+++ b/.github/action/bump-npm-version/action.yml
@@ -11,6 +11,14 @@ inputs:
       - patch
       - minor
       - major
+  token:
+    description: 'GitHub token for authentication'
+    required: true
+    type: string
+  repository:
+    description: 'GitHub repository to push changes to'
+    required: true
+    type: string
 
 jobs:
   bump:
@@ -28,7 +36,7 @@ jobs:
         run: |
           git config user.name 'celobot'
           git config user.email 'github-celobot@celonis.com'
-          git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}
+          git remote set-url origin https://x-access-token:${{ inputs.token }}@github.com/${{ inputs.repository }}
 
       - name: Run npm version
         run: |

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -24,6 +24,8 @@ jobs:
         uses: ./.github/action/bump-npm-version
         with:
           bump: ${{ inputs.bump }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          repository: ${{ github.repository }}
 
   build:
     needs: version-bump

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -17,6 +17,9 @@ jobs:
   version-bump:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: Bump NPM version
         uses: ./.github/action/bump-npm-version
         with:


### PR DESCRIPTION
#### Description

Checked other implementations of the `inputs` object inside an action, and it seems that details like `type` and `options` are never inside the action, but are only left in the triggering workflow. This might be some semantic restriction, since it's failing the action. Removed them here, the type and options will now be handled directly by the publish workflow. 

#### Checklist

- [x] I have self-reviewed this PR
- [ ] I have tested the change and proved that it works in different scenarios
- [ ] I have updated docs if needed
