### PR TITLE
Manually publish Content CLI

### DIFF
--- a/.github/workflows/build-and-publish-automatic.yml
+++ b/.github/workflows/build-and-publish-automatic.yml
@@ -1,0 +1,58 @@
+name: Build and Publish Workflow
+
+on:
+  push:
+    branches: [ master ]
+    paths-ignore:
+      - '.github/**'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    name: Npm install and npm build
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup Node with Github Registry
+        uses: actions/setup-node@v1
+        with:
+          node-version: '20'
+          registry-url: https://npm.pkg.github.com/celonis
+          scope: '@celonis'
+
+      - name: Yarn Install
+        run: yarn install
+
+      - name: Yarn Build
+        run: yarn build
+
+      - name: Yarn Test
+        run: yarn test
+
+      - name: Move files to build
+        run: |
+          cp README.md dist/README.md
+          cp LICENSE dist/LICENSE
+
+      - name: Publish to Github Registry
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: cd dist/ && npm publish
+
+      - name: Setup publish to Npm Registry
+        uses: actions/setup-node@v1
+        with:
+          node-version: '16'
+          registry-url: https://registry.npmjs.org/
+          scope: '@celonis'
+
+      - name: Publish to Npm Registry
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: cd dist/ && npm publish --access public
+
+      - uses: actions/checkout@master
+        name: Checkout Master
+        with:
+          fetch-depth: '0'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celonis/content-cli",
-  "version": "0.13.5",
+  "version": "1.0.0",
   "description": "CLI Tool to help manage content in Celonis EMS",
   "main": "content-cli.js",
   "bin": {


### PR DESCRIPTION
#### Description

Bumping and Publishing via workflow is not working right now due to celobot access tokens not having permissions on the public repo. I created a request for a new celonis organization token with access only on Content CLI, but the request is still pending.

In the meantime, will publish it like it used to:
- Manual bump
- Automatic publish on merge

#### Checklist

- [ ] I have self-reviewed this PR
- [ ] I have tested the change and proved that it works in different scenarios
- [ ] I have updated docs if needed
