### PR TITLE
TA-3902: Include Package ID in Studio's `list packages` command response

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celonis/content-cli",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "CLI Tool to help manage content in Celonis EMS",
   "main": "content-cli.js",
   "bin": {

--- a/src/commands/studio/service/package.service.ts
+++ b/src/commands/studio/service/package.service.ts
@@ -54,7 +54,7 @@ export class PackageService {
     }
 
     public async findAndExportListOfAllPackages(includeDependencies: boolean, packageKeys: string[]): Promise<void> {
-        const fieldsToInclude = ["key", "name", "changeDate", "activatedDraftId", "workingDraftId", "spaceId"];
+        const fieldsToInclude = ["key", "name", "changeDate", "activatedDraftId", "workingDraftId", "spaceId", "id"];
 
         let nodesListToExport: BatchExportNodeTransport[] = await this.packageApi.findAllPackages();
         if (packageKeys.length > 0) {
@@ -62,7 +62,7 @@ export class PackageService {
         }
 
         if (includeDependencies) {
-            fieldsToInclude.push("type", "value", "dependencies", "id", "updateAvailable", "version", "poolId", "node", "dataModelId", "dataPool", "datamodels");
+            fieldsToInclude.push("type", "value", "dependencies", "updateAvailable", "version", "poolId", "node", "dataModelId", "dataPool", "datamodels");
             const unPublishedNodes = nodesListToExport.filter(node => !node.activatedDraftId);
             let publishedNodes = nodesListToExport.filter(node => node.activatedDraftId);
             publishedNodes = await this.getNodesWithActiveVersion(publishedNodes);


### PR DESCRIPTION
#### Description

The `list packages` command in Studio doesn't return the Package ID, when being called without the `includeDependencies` flag. This decision seems to have been made because of the fact that the ID was never used in the cases when it was called without the flag.

In a recent case (detailed in the linked ticket), we're using the command in order to get the ID, which gets used for the `action-flows` import. Proposing to add the ID field in the response file by default, not conditional on the `includeDependencies` parameter.

#### Checklist

- [x] I have self-reviewed this PR
- [x] I have tested the change and proved that it works in different scenarios
  - Tested the response for both staging and published packages. All included correct IDs (as verified from the frontend response of those Packages). 
- [ ] I have updated docs if needed
