### PR TITLE
TA-3920: Fix package.json path

### DIFF
--- a/src/core/utils/version.ts
+++ b/src/core/utils/version.ts
@@ -1,5 +1,5 @@
 // tslint:disable-next-line:no-var-requires
-const { version } = require("../../../package.json");
+const { version } = require("../../package.json");
 
 export class VersionUtils {
     public static getCurrentCliVersion(): string {


### PR DESCRIPTION
#### Description

The VersionUtils which logs the version of the CLI in the console, has the path of the required `package.json` wrong when trying to install it globally. The reason this is working locally is because of the fact that the directory locally is structured that way that when you go up in the tree from `dist`, you will also find the original `package.json` there. 

#### Special notes

Unpublished the 1.0.1 version that was published with a faulty path.

#### Checklist

- [ ] I have self-reviewed this PR
- [ ] I have tested the change and proved that it works in different scenarios
- [ ] I have updated docs if needed
