### PR TITLE
TA-3920: Bump version to 1.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celonis/content-cli",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "CLI Tool to help manage content in Celonis Platform",
   "main": "content-cli.js",
   "bin": {


### PR DESCRIPTION
#### Description

The unpublishing of 1.0.1 didn't work. That means we have a faulty version there. Will bump the patch again here. 

#### Checklist

- [x] I have self-reviewed this PR
- [ ] I have tested the change and proved that it works in different scenarios
- [ ] I have updated docs if needed
