### PR TITLE
TA-3973: Add package has unpublished changes command

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celonis/content-cli",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "CLI Tool to help manage content in Celonis Platform",
   "main": "content-cli.js",
   "bin": {

--- a/src/commands/configuration-management/api/batch-import-export-api.ts
+++ b/src/commands/configuration-management/api/batch-import-export-api.ts
@@ -1,7 +1,7 @@
 import * as FormData from "form-data";
 import {
     PackageExportTransport,
-    PackageKeyAndVersionPair,
+    PackageKeyAndVersionPair, PackageMetadataExportTransport,
     PostPackageImportData, VariableManifestTransport,
 } from "../interfaces/package-export.interfaces";
 import { FatalError } from "../../../core/utils/logger";
@@ -60,6 +60,15 @@ export class BatchImportExportApi {
         return this.httpClient().getFile(`/package-manager/api/core/packages/export/batch?${queryParams.toString()}`).catch(e => {
             throw new FatalError(`Problem exporting packages: ${e}`);
         });
+    }
+
+    public async batchExportPackagesMetadata(packageKeys: string[]): Promise<PackageMetadataExportTransport[]> {
+        const queryParams = new URLSearchParams();
+        packageKeys.forEach(packageKey => queryParams.append("packageKeys", packageKey));
+
+        return this.httpClient().get(`/package-manager/api/core/packages/metadata/export?${queryParams.toString()}`).catch(e => {
+            throw new FatalError(`Problem exporting packages metadata: ${e}`);
+        })
     }
 
     public async importPackages(data: FormData, overwrite: boolean): Promise<PostPackageImportData[]> {

--- a/src/commands/configuration-management/config-command.service.ts
+++ b/src/commands/configuration-management/config-command.service.ts
@@ -40,6 +40,10 @@ export class ConfigCommandService {
         return this.batchImportExportService.batchExportPackages(packageKeys, withDependencies);
     }
 
+    public batchExportPackagesMetadata(packageKeys: string[], jsonResponse: boolean): Promise<void> {
+        return this.batchImportExportService.batchExportPackagesMetadata(packageKeys, jsonResponse);
+    }
+
     public batchImportPackages(file: string, overwrite: boolean): Promise<void> {
         return this.batchImportExportService.batchImportPackages(file, overwrite);
     }

--- a/src/commands/configuration-management/interfaces/package-export.interfaces.ts
+++ b/src/commands/configuration-management/interfaces/package-export.interfaces.ts
@@ -24,6 +24,11 @@ export interface PackageExportTransport {
     datamodels?: StudioComputeNodeDescriptor[];
 }
 
+export interface PackageMetadataExportTransport {
+    key: string;
+    hasUnpublishedChanges: boolean;
+}
+
 export interface PackageManifestTransport {
     packageKey: string;
     flavor: string;

--- a/src/commands/configuration-management/module.ts
+++ b/src/commands/configuration-management/module.ts
@@ -34,7 +34,7 @@ class Module extends IModule {
         metadataCommand
             .command("export")
             .description("Command to show whether packages have unpublished changes")
-            .option("--packageKeys <packageKeys...>", "Keys of packages to find the metadata of")
+            .requiredOption("--packageKeys <packageKeys...>", "Keys of packages to find the metadata of")
             .option("--json", "Return response as json type", "")
             .action(this.batchExportPackagesMetadata);
 

--- a/src/commands/configuration-management/module.ts
+++ b/src/commands/configuration-management/module.ts
@@ -28,6 +28,16 @@ class Module extends IModule {
             .option("--withDependencies", "Include variables and dependencies", "")
             .action(this.batchExportPackages);
 
+        const metadataCommand = configCommand.command("metadata")
+            .description("Commands related to package metadata")
+
+        metadataCommand
+            .command("export")
+            .description("Command to show whether packages have unpublished changes")
+            .option("--packageKeys <packageKeys...>", "Keys of packages to find the metadata of")
+            .option("--json", "Return response as json type", "")
+            .action(this.batchExportPackagesMetadata);
+
         configCommand.command("import")
             .description("Command to import package configs")
             .option("--overwrite", "Flag to allow overwriting of packages")
@@ -66,6 +76,10 @@ class Module extends IModule {
 
     private async batchExportPackages(context: Context, command: Command, options: OptionValues): Promise<void> {
         await new ConfigCommandService(context).batchExportPackages(options.packageKeys, options.withDependencies);
+    }
+
+    private async batchExportPackagesMetadata(context: Context, command: Command, options: OptionValues): Promise<void> {
+        await new ConfigCommandService(context).batchExportPackagesMetadata(options.packageKeys, options.json);
     }
 
     private async batchImportPackages(context: Context, command: Command, options: OptionValues): Promise<void> {

--- a/tests/commands/configuration-management/config-metadata-export.spec.ts
+++ b/tests/commands/configuration-management/config-metadata-export.spec.ts
@@ -1,0 +1,63 @@
+import { mockExistsSync } from "../../utls/fs-mock-utils";
+import { mockAxiosGet } from "../../utls/http-requests-mock";
+import {
+    PackageMetadataExportTransport
+} from "../../../src/commands/configuration-management/interfaces/package-export.interfaces";
+import { ConfigCommandService } from "../../../src/commands/configuration-management/config-command.service";
+import { testContext } from "../../utls/test-context";
+import { loggingTestTransport, mockWriteFileSync } from "../../jest.setup";
+import { FileService } from "../../../src/core/utils/file-service";
+import * as path from "path";
+
+describe("Config metadata export", () => {
+
+    beforeEach(() => {
+        mockExistsSync();
+    });
+
+    it("Should show on terminal if packages have unpublished changes", async () => {
+        const packageKeys: string[] = ["package-key-1", "package-key-2"];
+
+        const response: PackageMetadataExportTransport[] = [
+            { key: "package-key-1", hasUnpublishedChanges: true },
+            { key: "package-key-2", hasUnpublishedChanges: false }
+        ]
+
+        const expectedFirstString: string = "package-key-1 - Has Unpublished Changes: true";
+        const expectedSecondString: string = "package-key-2 - Has Unpublished Changes: false";
+
+        mockAxiosGet("https://myTeam.celonis.cloud/package-manager/api/core/packages/metadata/export?packageKeys=package-key-1&packageKeys=package-key-2", response);
+
+        await new ConfigCommandService(testContext).batchExportPackagesMetadata(packageKeys, false);
+
+        expect(loggingTestTransport.logMessages.length).toBe(2);
+        expect(loggingTestTransport.logMessages[0].message).toContain(
+            expectedFirstString
+        );
+        expect(loggingTestTransport.logMessages[1].message).toContain(
+            expectedSecondString
+        );
+    });
+
+    it("Should create file if packages have unpublished changes and json option is sent as true", async () => {
+        const packageKeys: string[] = ["package-key-1", "package-key-2"];
+
+        const response: PackageMetadataExportTransport[] = [
+            { key: "package-key-1", hasUnpublishedChanges: true },
+            { key: "package-key-2", hasUnpublishedChanges: false }
+        ]
+
+        mockAxiosGet("https://myTeam.celonis.cloud/package-manager/api/core/packages/metadata/export?packageKeys=package-key-1&packageKeys=package-key-2", response);
+
+        await new ConfigCommandService(testContext).batchExportPackagesMetadata(packageKeys, true);
+
+        const expectedFileName = loggingTestTransport.logMessages[0].message.split(FileService.fileDownloadedMessage)[1];
+
+        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), expect.any(String), {encoding: "utf-8"});
+        const exportedPackagesMetadataTransports = JSON.parse(mockWriteFileSync.mock.calls[0][1]) as PackageMetadataExportTransport[];
+        expect(exportedPackagesMetadataTransports.length).toBe(2);
+
+        expect(exportedPackagesMetadataTransports).toEqual(response);
+    });
+
+});


### PR DESCRIPTION
#### Description

Added a new command `config metadata export`, which shows whether the packages with the received keys have any unpublished changes. 

#### Checklist

- [x] I have self-reviewed this PR
- [x] I have tested the change and proved that it works in different scenarios
- [x] I have updated docs if needed
