### PR TITLE
TA-3971: Add option to export packages by versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celonis/content-cli",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "CLI Tool to help manage content in Celonis Platform",
   "main": "content-cli.js",
   "bin": {

--- a/src/commands/configuration-management/api/batch-import-export-api.ts
+++ b/src/commands/configuration-management/api/batch-import-export-api.ts
@@ -62,9 +62,9 @@ export class BatchImportExportApi {
         });
     }
 
-    public async exportPackagesByVersions(packageKeysByVersion: string[], withDependencies: boolean = false): Promise<Buffer> {
+    public async exportPackagesByVersions(packageKeysWithVersion: string[], withDependencies: boolean = false): Promise<Buffer> {
         const queryParams = new URLSearchParams();
-        packageKeysByVersion.forEach(packageKeyByVersion => queryParams.append("packageKeysWithVersion", packageKeyByVersion));
+        packageKeysWithVersion.forEach(packageKeyByVersion => queryParams.append("packageKeysWithVersion", packageKeyByVersion));
         queryParams.set("withDependencies", withDependencies.toString());
 
         return this.httpClient().getFile(`/package-manager/api/core/packages/versions/export/batch?${queryParams.toString()}`).catch(e => {

--- a/src/commands/configuration-management/api/batch-import-export-api.ts
+++ b/src/commands/configuration-management/api/batch-import-export-api.ts
@@ -62,6 +62,16 @@ export class BatchImportExportApi {
         });
     }
 
+    public async exportPackagesByVersions(packageKeysByVersion: string[], withDependencies: boolean = false): Promise<Buffer> {
+        const queryParams = new URLSearchParams();
+        packageKeysByVersion.forEach(packageKeyByVersion => queryParams.append("packageKeysWithVersion", packageKeyByVersion));
+        queryParams.set("withDependencies", withDependencies.toString());
+
+        return this.httpClient().getFile(`/package-manager/api/core/packages/versions/export/batch?${queryParams.toString()}`).catch(e => {
+            throw new FatalError(`Problem exporting packages by versions: ${e}`);
+        });
+    }
+
     public async batchExportPackagesMetadata(packageKeys: string[]): Promise<PackageMetadataExportTransport[]> {
         const queryParams = new URLSearchParams();
         packageKeys.forEach(packageKey => queryParams.append("packageKeys", packageKey));

--- a/src/commands/configuration-management/batch-import-export.service.ts
+++ b/src/commands/configuration-management/batch-import-export.service.ts
@@ -51,8 +51,14 @@ export class BatchImportExportService {
         this.exportListOfPackages(packagesToExport);
     }
 
-    public async batchExportPackages(packageKeys: string[], withDependencies: boolean = false): Promise<void> {
-        const exportedPackagesData: Buffer = await this.batchImportExportApi.exportPackages(packageKeys, withDependencies);
+    public async batchExportPackages(packageKeys: string[], packageKeysByVersion: string[], withDependencies: boolean = false): Promise<void> {
+        let exportedPackagesData: Buffer;
+        if (packageKeys) {
+            exportedPackagesData = await this.batchImportExportApi.exportPackages(packageKeys, withDependencies);
+        } else {
+            exportedPackagesData = await this.batchImportExportApi.exportPackagesByVersions(packageKeysByVersion, withDependencies);
+        }
+
         const exportedPackagesZip: AdmZip = new AdmZip(exportedPackagesData);
 
         const manifest: PackageManifestTransport[] = parse(

--- a/src/commands/configuration-management/config-command.service.ts
+++ b/src/commands/configuration-management/config-command.service.ts
@@ -36,8 +36,8 @@ export class ConfigCommandService {
         }
     }
 
-    public batchExportPackages(packageKeys: string[], withDependencies: boolean = false): Promise<void> {
-        return this.batchImportExportService.batchExportPackages(packageKeys, withDependencies);
+    public batchExportPackages(packageKeys: string[], packageKeysByVersion: string[], withDependencies: boolean = false): Promise<void> {
+        return this.batchImportExportService.batchExportPackages(packageKeys, packageKeysByVersion, withDependencies);
     }
 
     public batchExportPackagesMetadata(packageKeys: string[], jsonResponse: boolean): Promise<void> {

--- a/src/commands/configuration-management/module.ts
+++ b/src/commands/configuration-management/module.ts
@@ -27,12 +27,7 @@ class Module extends IModule {
             .option("--packageKeys <packageKeys...>", "Keys of packages to export. Exports the latest deployed version only")
             .option("--keysByVersion <keysByVersion...>", "Keys of packages to export by version")
             .option("--withDependencies", "Include variables and dependencies", "")
-            .action(async (context: Context, command: Command, options: OptionValues): Promise<void> => {
-                if ((options.packageKeys && options.keysByVersion) || (!options.packageKeys && !options.keysByVersion)) {
-                    throw new Error("Please provide either --packageKeys or --keysByVersion, but not both.");
-                }
-                await this.batchExportPackages(context, command, options);
-            });
+            .action(this.batchExportPackages);
 
         const metadataCommand = configCommand.command("metadata")
             .description("Commands related to package metadata")
@@ -81,6 +76,9 @@ class Module extends IModule {
     }
 
     private async batchExportPackages(context: Context, command: Command, options: OptionValues): Promise<void> {
+        if ((options.packageKeys && options.keysByVersion) || (!options.packageKeys && !options.keysByVersion)) {
+            throw new Error("Please provide either --packageKeys or --keysByVersion, but not both.");
+        }
         await new ConfigCommandService(context).batchExportPackages(options.packageKeys, options.keysByVersion, options.withDependencies);
     }
 

--- a/src/commands/configuration-management/module.ts
+++ b/src/commands/configuration-management/module.ts
@@ -24,9 +24,15 @@ class Module extends IModule {
 
         configCommand.command("export")
             .description("Command to export package configs")
-            .requiredOption("--packageKeys <packageKeys...>", "Keys of packages to export")
+            .option("--packageKeys <packageKeys...>", "Keys of packages to export. Exports the latest deployed version only")
+            .option("--keysByVersion <keysByVersion...>", "Keys of packages to export by version")
             .option("--withDependencies", "Include variables and dependencies", "")
-            .action(this.batchExportPackages);
+            .action(async (context: Context, command: Command, options: OptionValues): Promise<void> => {
+                if ((options.packageKeys && options.keysByVersion) || (!options.packageKeys && !options.keysByVersion)) {
+                    throw new Error("Please provide either --packageKeys or --keysByVersion, but not both.");
+                }
+                await this.batchExportPackages(context, command, options);
+            });
 
         const metadataCommand = configCommand.command("metadata")
             .description("Commands related to package metadata")
@@ -75,7 +81,7 @@ class Module extends IModule {
     }
 
     private async batchExportPackages(context: Context, command: Command, options: OptionValues): Promise<void> {
-        await new ConfigCommandService(context).batchExportPackages(options.packageKeys, options.withDependencies);
+        await new ConfigCommandService(context).batchExportPackages(options.packageKeys, options.keysByVersion, options.withDependencies);
     }
 
     private async batchExportPackagesMetadata(context: Context, command: Command, options: OptionValues): Promise<void> {

--- a/tests/commands/configuration-management/config-export.spec.ts
+++ b/tests/commands/configuration-management/config-export.spec.ts
@@ -54,7 +54,59 @@ describe("Config export", () => {
         mockAxiosGet(`https://myTeam.celonis.cloud/package-manager/api/nodes/by-package-key/${firstStudioPackage.key}/variables/runtime-values?appMode=VIEWER`, [firstPackageRuntimeVariable]);
         mockAxiosGet(`https://myTeam.celonis.cloud/package-manager/api/nodes/by-package-key/${secondStudioPackage.key}/variables/runtime-values?appMode=VIEWER`, []);
 
-        await new ConfigCommandService(testContext).batchExportPackages(["key-1", "key-2", "key-3"], true);
+        await new ConfigCommandService(testContext).batchExportPackages(["key-1", "key-2", "key-3"], undefined, true);
+
+        const expectedFileName = loggingTestTransport.logMessages[0].message.split(FileService.fileDownloadedMessage)[1];
+        expect(fs.openSync).toHaveBeenCalledWith(expectedFileName, expect.anything(), expect.anything());
+        expect(mockWriteSync).toHaveBeenCalled();
+
+        const fileBuffer = mockWriteSync.mock.calls[0][1];
+        const actualZip = new AdmZip(fileBuffer);
+
+        const studioManifest: StudioPackageManifest[] = parse(actualZip.getEntry(BatchExportImportConstants.STUDIO_FILE_NAME).getData().toString());
+        expect(studioManifest).toHaveLength(2);
+        expect(studioManifest).toContainEqual({
+            packageKey: firstStudioPackage.key,
+            space: {
+                name: firstSpace.name,
+                iconReference: firstSpace.iconReference
+            },
+            runtimeVariableAssignments: [firstPackageRuntimeVariable]
+        });
+        expect(studioManifest).toContainEqual({
+            packageKey: secondStudioPackage.key,
+            space: {
+                name: secondSpace.name,
+                iconReference: secondSpace.iconReference
+            },
+            runtimeVariableAssignments: []
+        });
+    })
+
+    it("Should export studio file for studio packageKeys and versions", async () => {
+        const manifest: PackageManifestTransport[] = [];
+        manifest.push(ConfigUtils.buildManifestForKeyAndFlavorAndVersion("key-1", BatchExportImportConstants.STUDIO, "1.0.1"));
+        manifest.push(ConfigUtils.buildManifestForKeyAndFlavorAndVersion("key-2", BatchExportImportConstants.STUDIO, "1.0.4"));
+        manifest.push(ConfigUtils.buildManifestForKeyAndFlavorAndVersion("key-3", "TEST", "1.2.0"));
+        const exportedPackagesZip = ConfigUtils.buildBatchExportZip(manifest, []);
+
+        const firstStudioPackage = PacmanApiUtils.buildContentNodeTransport("key-1", "space-1");
+        const firstPackageRuntimeVariable: VariablesAssignments = {
+            key: "varKey",
+            type: PackageManagerVariableType.PLAIN_TEXT,
+            value: "default-value" as unknown as object
+        };
+
+        const secondStudioPackage = PacmanApiUtils.buildContentNodeTransport("key-2", "space-2");
+
+        mockAxiosGet("https://myTeam.celonis.cloud/package-manager/api/core/packages/versions/export/batch?packageKeysWithVersion=key-1.1.0.1&packageKeysWithVersion=key-2.1.0.4&packageKeysWithVersion=key-3.1.2.0&withDependencies=true", exportedPackagesZip.toBuffer());
+        mockAxiosPost("https://myTeam.celonis.cloud/package-manager/api/core/packages/export/batch/variables-with-assignments", []);
+        mockAxiosGet(`https://myTeam.celonis.cloud/package-manager/api/nodes/${firstStudioPackage.key}/${firstStudioPackage.key}`, firstStudioPackage);
+        mockAxiosGet(`https://myTeam.celonis.cloud/package-manager/api/nodes/${secondStudioPackage.key}/${secondStudioPackage.key}`, secondStudioPackage);
+        mockAxiosGet(`https://myTeam.celonis.cloud/package-manager/api/nodes/by-package-key/${firstStudioPackage.key}/variables/runtime-values?appMode=VIEWER`, [firstPackageRuntimeVariable]);
+        mockAxiosGet(`https://myTeam.celonis.cloud/package-manager/api/nodes/by-package-key/${secondStudioPackage.key}/variables/runtime-values?appMode=VIEWER`, []);
+
+        await new ConfigCommandService(testContext).batchExportPackages(undefined, ["key-1.1.0.1", "key-2.1.0.4", "key-3.1.2.0"], true);
 
         const expectedFileName = loggingTestTransport.logMessages[0].message.split(FileService.fileDownloadedMessage)[1];
         expect(fs.openSync).toHaveBeenCalledWith(expectedFileName, expect.anything(), expect.anything());
@@ -180,7 +232,7 @@ describe("Config export", () => {
         mockAxiosGet(`https://myTeam.celonis.cloud/package-manager/api/nodes/by-package-key/${firstPackageNode.key}/variables/runtime-values?appMode=VIEWER`, []);
         mockAxiosGet(`https://myTeam.celonis.cloud/package-manager/api/nodes/by-package-key/${secondPackageNode.key}/variables/runtime-values?appMode=VIEWER`, []);
 
-        await new ConfigCommandService(testContext).batchExportPackages(["key-1", "key-2"], true);
+        await new ConfigCommandService(testContext).batchExportPackages(["key-1", "key-2"], undefined, true);
 
         const expectedFileName = loggingTestTransport.logMessages[0].message.split(FileService.fileDownloadedMessage)[1];
         expect(fs.openSync).toHaveBeenCalledWith(expectedFileName, expect.anything(), expect.anything());
@@ -252,6 +304,170 @@ describe("Config export", () => {
         });
     })
 
+    it("Should export variables file with connection variables fixed when package keys are sent with versions", async () => {
+        const firstPackageDependencies = new Map<string, DependencyTransport[]>();
+        firstPackageDependencies.set("1.0.2", []);
+
+        const secondPackageDependencies = new Map<string, DependencyTransport[]>();
+        secondPackageDependencies.set("1.0.3", []);
+
+        const manifest: PackageManifestTransport[] = [];
+        manifest.push(ConfigUtils.buildManifestForKeyAndFlavorAndVersion("key-1", BatchExportImportConstants.STUDIO, "1.0.2", firstPackageDependencies));
+        manifest.push(ConfigUtils.buildManifestForKeyAndFlavorAndVersion("key-2", BatchExportImportConstants.STUDIO, "1.0.3", secondPackageDependencies));
+
+        const firstPackageVariableDefinition: VariableDefinition[] = [
+            {
+                key: "key1-var",
+                type: PackageManagerVariableType.DATA_MODEL,
+                runtime: false
+            },
+            {
+                key: "key-1-connection",
+                type: PackageManagerVariableType.CONNECTION,
+                runtime: false
+            }
+        ];
+
+        const firstPackageNode = ConfigUtils.buildPackageNode("key-1", {variables: firstPackageVariableDefinition});
+        const firstPackageZip = ConfigUtils.buildExportPackageZip(firstPackageNode, [], "1.0.2");
+
+        const secondPackageVariableDefinition: VariableDefinition[] = [
+            {
+                key: "key2-var",
+                type: PackageManagerVariableType.DATA_MODEL,
+                runtime: false
+            },
+            {
+                key: "key-2-connection",
+                type: PackageManagerVariableType.CONNECTION,
+                runtime: false
+            }
+        ];
+
+        const secondPackageNode = ConfigUtils.buildPackageNode("key-2", {variables: secondPackageVariableDefinition});
+        const secondPackageZip = ConfigUtils.buildExportPackageZip(secondPackageNode, [], "1.0.3");
+
+        const exportedPackagesZip = ConfigUtils.buildBatchExportZip(manifest, [firstPackageZip, secondPackageZip]);
+
+        const exportedVariables: VariableManifestTransport[] = [
+            {
+                packageKey: "key-1",
+                version: "1.0.2",
+                variables: [
+                    {
+                        key: "key1-var",
+                        type: PackageManagerVariableType.DATA_MODEL,
+                        value: "dm-id" as unknown as object,
+                        metadata: {}
+                    },
+                    {
+                        key: "key-1-connection",
+                        type: PackageManagerVariableType.CONNECTION,
+                        value: {
+                            appName: "celonis",
+                            connectionId: "connection-id"
+                        } as unknown as object,
+                        metadata: null
+                    }
+                ]
+            },
+            {
+                packageKey: "key-2",
+                version: "1.0.3",
+                variables: [
+                    {
+                        key: "key2-var",
+                        type: PackageManagerVariableType.DATA_MODEL,
+                        value: "dm-id" as unknown as object,
+                        metadata: {}
+                    },
+                    {
+                        key: "key-2-connection",
+                        type: PackageManagerVariableType.CONNECTION,
+                        value: "connection-id",
+                        metadata: {
+                            appName: "nameOfApp"
+                        }
+                    }
+                ]
+            },
+        ];
+
+        mockAxiosGet("https://myTeam.celonis.cloud/package-manager/api/core/packages/versions/export/batch?packageKeysWithVersion=key-1.1.0.2&packageKeysWithVersion=key-2.1.0.3&withDependencies=true", exportedPackagesZip.toBuffer());
+        mockAxiosPost("https://myTeam.celonis.cloud/package-manager/api/core/packages/export/batch/variables-with-assignments", [...exportedVariables]);
+        mockAxiosGet(`https://myTeam.celonis.cloud/package-manager/api/nodes/${firstPackageNode.key}/${firstPackageNode.key}`, {...firstPackageNode, spaceId: "space-1"});
+        mockAxiosGet(`https://myTeam.celonis.cloud/package-manager/api/nodes/${secondPackageNode.key}/${secondPackageNode.key}`, {...secondPackageNode, spaceId: "space-2"});
+        mockAxiosGet(`https://myTeam.celonis.cloud/package-manager/api/nodes/by-package-key/${firstPackageNode.key}/variables/runtime-values?appMode=VIEWER`, []);
+        mockAxiosGet(`https://myTeam.celonis.cloud/package-manager/api/nodes/by-package-key/${secondPackageNode.key}/variables/runtime-values?appMode=VIEWER`, []);
+
+        await new ConfigCommandService(testContext).batchExportPackages(undefined, ["key-1.1.0.2", "key-2.1.0.3"], true);
+
+        const expectedFileName = loggingTestTransport.logMessages[0].message.split(FileService.fileDownloadedMessage)[1];
+        expect(fs.openSync).toHaveBeenCalledWith(expectedFileName, expect.anything(), expect.anything());
+        expect(mockWriteSync).toHaveBeenCalled();
+
+        const fileBuffer = mockWriteSync.mock.calls[0][1];
+        const actualZip = new AdmZip(fileBuffer);
+
+        const exportedVariablesFileContent: VariableManifestTransport[] = parse(actualZip.getEntry(BatchExportImportConstants.VARIABLES_FILE_NAME).getData().toString());
+        expect(exportedVariablesFileContent).toHaveLength(2);
+        expect(exportedVariablesFileContent).toContainEqual({
+            packageKey: "key-1",
+            version: "1.0.2",
+            variables: [
+                {
+                    key: "key1-var",
+                    type: PackageManagerVariableType.DATA_MODEL,
+                    value: "dm-id",
+                    metadata: {}
+                },
+                {
+                    key: "key-1-connection",
+                    type: PackageManagerVariableType.CONNECTION,
+                    value: {
+                        appName: "celonis",
+                        connectionId: "connection-id"
+                    },
+                    metadata: {
+                        appName: "celonis"
+                    }
+                }
+            ]
+        });
+        expect(exportedVariablesFileContent).toContainEqual({
+            packageKey: "key-2",
+            version: "1.0.3",
+            variables: [
+                {
+                    key: "key2-var",
+                    type: PackageManagerVariableType.DATA_MODEL,
+                    value: "dm-id",
+                    metadata: {}
+                },
+                {
+                    key: "key-2-connection",
+                    type: PackageManagerVariableType.CONNECTION,
+                    value: "connection-id",
+                    metadata: {
+                        appName: "nameOfApp"
+                    }
+                }
+            ]
+        });
+
+        const variableExportRequest = parse(mockedPostRequestBodyByUrl.get("https://myTeam.celonis.cloud/package-manager/api/core/packages/export/batch/variables-with-assignments"));
+        expect(variableExportRequest).toBeTruthy();
+        expect(variableExportRequest).toHaveLength(2);
+        expect(variableExportRequest).toContainEqual({
+            packageKey: "key-1",
+            version: "1.0.2"
+        });
+        expect(variableExportRequest).toContainEqual({
+            packageKey: "key-2",
+            version: "1.0.3"
+        });
+    })
+
     it("Should remove SCENARIO asset files of packages", async () => {
         const manifest: PackageManifestTransport[] = [];
         manifest.push(ConfigUtils.buildManifestForKeyAndFlavor("key-1", BatchExportImportConstants.STUDIO));
@@ -276,7 +492,7 @@ describe("Config export", () => {
         mockAxiosGet(`https://myTeam.celonis.cloud/package-manager/api/nodes/by-package-key/${firstPackageNode.key}/variables/runtime-values?appMode=VIEWER`, []);
         mockAxiosGet(`https://myTeam.celonis.cloud/package-manager/api/nodes/by-package-key/${secondPackageNode.key}/variables/runtime-values?appMode=VIEWER`, []);
 
-        await new ConfigCommandService(testContext).batchExportPackages(["key-1", "key-2"], true);
+        await new ConfigCommandService(testContext).batchExportPackages(["key-1", "key-2"], undefined, true);
 
         const expectedFileName = loggingTestTransport.logMessages[0].message.split(FileService.fileDownloadedMessage)[1];
         expect(fs.openSync).toHaveBeenCalledWith(expectedFileName, expect.anything(), expect.anything());
@@ -290,6 +506,48 @@ describe("Config export", () => {
         expect(firstPackageExportedZip.getEntry("nodes/child-2.json").getData().toString()).toEqual(stringify(firstPackageTestChild));
 
         const secondPackageExportedZip = new AdmZip(actualZip.getEntry("key-2_1.0.0.zip").getData());
+        expect(secondPackageExportedZip.getEntry("nodes/child-3-scenario.json")).toBeNull();
+        expect(secondPackageExportedZip.getEntry("nodes/child-4.json").getData().toString()).toEqual(stringify(secondPackageTestChild));
+    })
+
+    it("Should remove SCENARIO asset files of package keys that are sent with versions", async () => {
+        const manifest: PackageManifestTransport[] = [];
+        manifest.push(ConfigUtils.buildManifestForKeyAndFlavorAndVersion("key-1", BatchExportImportConstants.STUDIO, "1.0.2"));
+        manifest.push(ConfigUtils.buildManifestForKeyAndFlavorAndVersion("key-2", BatchExportImportConstants.STUDIO, "1.0.3"));
+
+        const firstPackageNode = ConfigUtils.buildPackageNode("key-1", {});
+        const firstPackageScenarioChild = ConfigUtils.buildChildNode("child-1-scenario", firstPackageNode.key, "SCENARIO");
+        const firstPackageTestChild = ConfigUtils.buildChildNode("child-2", firstPackageNode.key, "TEST");
+        const firstPackageZip = ConfigUtils.buildExportPackageZip(firstPackageNode, [firstPackageScenarioChild, firstPackageTestChild], "1.0.2");
+
+        const secondPackageNode = ConfigUtils.buildPackageNode("key-2", {});
+        const secondPackageScenarioChild = ConfigUtils.buildChildNode("child-3-scenario", secondPackageNode.key, "SCENARIO");
+        const secondPackageTestChild = ConfigUtils.buildChildNode("child-4", secondPackageNode.key, "TEST");
+        const secondPackageZip = ConfigUtils.buildExportPackageZip(secondPackageNode, [secondPackageScenarioChild, secondPackageTestChild], "1.0.3");
+
+        const exportedPackagesZip = ConfigUtils.buildBatchExportZip(manifest, [firstPackageZip, secondPackageZip]);
+
+        mockAxiosGet("https://myTeam.celonis.cloud/package-manager/api/core/packages/versions/export/batch?packageKeysWithVersion=key-1.1.0.2&packageKeysWithVersion=key-2.1.0.3&withDependencies=true", exportedPackagesZip.toBuffer());
+        mockAxiosPost("https://myTeam.celonis.cloud/package-manager/api/core/packages/export/batch/variables-with-assignments", []);
+        mockAxiosGet(`https://myTeam.celonis.cloud/package-manager/api/nodes/${firstPackageNode.key}/${firstPackageNode.key}`, {...firstPackageNode, spaceId: "space-1"});
+        mockAxiosGet(`https://myTeam.celonis.cloud/package-manager/api/nodes/${secondPackageNode.key}/${secondPackageNode.key}`, {...secondPackageNode, spaceId: "space-2"});
+        mockAxiosGet(`https://myTeam.celonis.cloud/package-manager/api/nodes/by-package-key/${firstPackageNode.key}/variables/runtime-values?appMode=VIEWER`, []);
+        mockAxiosGet(`https://myTeam.celonis.cloud/package-manager/api/nodes/by-package-key/${secondPackageNode.key}/variables/runtime-values?appMode=VIEWER`, []);
+
+        await new ConfigCommandService(testContext).batchExportPackages(undefined, ["key-1.1.0.2", "key-2.1.0.3"], true);
+
+        const expectedFileName = loggingTestTransport.logMessages[0].message.split(FileService.fileDownloadedMessage)[1];
+        expect(fs.openSync).toHaveBeenCalledWith(expectedFileName, expect.anything(), expect.anything());
+        expect(mockWriteSync).toHaveBeenCalled();
+
+        const fileBuffer = mockWriteSync.mock.calls[0][1];
+        const actualZip = new AdmZip(fileBuffer);
+
+        const firstPackageExportedZip = new AdmZip(actualZip.getEntry("key-1_1.0.2.zip").getData());
+        expect(firstPackageExportedZip.getEntry("nodes/child-1-scenario.json")).toBeNull();
+        expect(firstPackageExportedZip.getEntry("nodes/child-2.json").getData().toString()).toEqual(stringify(firstPackageTestChild));
+
+        const secondPackageExportedZip = new AdmZip(actualZip.getEntry("key-2_1.0.3.zip").getData());
         expect(secondPackageExportedZip.getEntry("nodes/child-3-scenario.json")).toBeNull();
         expect(secondPackageExportedZip.getEntry("nodes/child-4.json").getData().toString()).toEqual(stringify(secondPackageTestChild));
     })
@@ -392,7 +650,7 @@ describe("Config export", () => {
         mockAxiosGet(`https://myTeam.celonis.cloud/package-manager/api/nodes/by-package-key/${firstPackageNode.key}/variables/runtime-values?appMode=VIEWER`, []);
         mockAxiosGet(`https://myTeam.celonis.cloud/package-manager/api/nodes/by-package-key/${secondPackageNode.key}/variables/runtime-values?appMode=VIEWER`, []);
 
-        await new ConfigCommandService(testContext).batchExportPackages(["key-1", "key-2"], true);
+        await new ConfigCommandService(testContext).batchExportPackages(["key-1", "key-2"], undefined, true);
 
         const expectedFileName = loggingTestTransport.logMessages[0].message.split(FileService.fileDownloadedMessage)[1];
         expect(fs.openSync).toHaveBeenCalledWith(expectedFileName, expect.anything(), expect.anything());
@@ -426,6 +684,147 @@ describe("Config export", () => {
         expect(secondPackageContent.variables).toEqual([{
                 ...secondPackageVariableDefinition[0],
             },
+            {
+                ...secondPackageVariableDefinition[1],
+                metadata: {
+                    appName: "nameOfApp"
+                }
+            }
+        ]);
+    })
+
+    it("Should add appName to metadata for CONNECTION variables of package.json files when package keys are sent with versions", async () => {
+        const manifest: PackageManifestTransport[] = [];
+        manifest.push(ConfigUtils.buildManifestForKeyAndFlavorAndVersion("key-1", BatchExportImportConstants.STUDIO, "1.0.4"));
+        manifest.push(ConfigUtils.buildManifestForKeyAndFlavorAndVersion("key-2", BatchExportImportConstants.STUDIO, "1.0.5"));
+
+        const firstPackageVariableDefinition: VariableDefinition[] = [
+            {
+                key: "key1-var",
+                type: PackageManagerVariableType.DATA_MODEL,
+                runtime: false
+            },
+            {
+                key: "key-1-connection",
+                type: PackageManagerVariableType.CONNECTION,
+                runtime: false
+            }
+        ];
+
+        const firstPackageNode = ConfigUtils.buildPackageNode("key-1", {variables: firstPackageVariableDefinition});
+        const firstPackageZip = ConfigUtils.buildExportPackageZip(firstPackageNode, [], "1.0.4");
+
+        const secondPackageVariableDefinition: VariableDefinition[] = [
+            {
+                key: "key2-var",
+                type: PackageManagerVariableType.CONNECTION,
+                runtime: false,
+                metadata: {
+                    appName: "celonis"
+                }
+            },
+            {
+                key: "key-2-connection",
+                type: PackageManagerVariableType.CONNECTION,
+                runtime: false
+            }
+        ];
+
+        const secondPackageNode = ConfigUtils.buildPackageNode("key-2", {variables: secondPackageVariableDefinition});
+        const secondPackageZip = ConfigUtils.buildExportPackageZip(secondPackageNode, [], "1.0.5");
+
+        const exportedPackagesZip = ConfigUtils.buildBatchExportZip(manifest, [firstPackageZip, secondPackageZip]);
+
+        const exportedVariables: VariableManifestTransport[] = [
+            {
+                packageKey: "key-1",
+                version: "1.0.4",
+                variables: [
+                    {
+                        key: "key1-var",
+                        type: PackageManagerVariableType.DATA_MODEL,
+                        value: "dm-id" as unknown as object,
+                        metadata: {}
+                    },
+                    {
+                        key: "key-1-connection",
+                        type: PackageManagerVariableType.CONNECTION,
+                        value: {
+                            appName: "celonis",
+                            connectionId: "connection-id"
+                        } as unknown as object,
+                        metadata: null
+                    }
+                ]
+            },
+            {
+                packageKey: "key-2",
+                version: "1.0.5",
+                variables: [
+                    {
+                        key: "key2-var",
+                        type: PackageManagerVariableType.CONNECTION,
+                        value: {
+                            appName: "celonis",
+                            connectionId: "connection-id"
+                        } as unknown as object,
+                        metadata: {
+                            appName: "celonis"
+                        }
+                    },
+                    {
+                        key: "key-2-connection",
+                        type: PackageManagerVariableType.CONNECTION,
+                        value: "connection-id",
+                        metadata: {
+                            appName: "nameOfApp"
+                        }
+                    }
+                ]
+            },
+        ];
+
+        mockAxiosGet("https://myTeam.celonis.cloud/package-manager/api/core/packages/versions/export/batch?packageKeysWithVersion=key-1.1.0.4&packageKeysWithVersion=key-2.1.0.5&withDependencies=true", exportedPackagesZip.toBuffer());
+        mockAxiosPost("https://myTeam.celonis.cloud/package-manager/api/core/packages/export/batch/variables-with-assignments", exportedVariables);
+        mockAxiosGet(`https://myTeam.celonis.cloud/package-manager/api/nodes/${firstPackageNode.key}/${firstPackageNode.key}`, {...firstPackageNode, spaceId: "space-1"});
+        mockAxiosGet(`https://myTeam.celonis.cloud/package-manager/api/nodes/${secondPackageNode.key}/${secondPackageNode.key}`, {...secondPackageNode, spaceId: "space-2"});
+        mockAxiosGet(`https://myTeam.celonis.cloud/package-manager/api/nodes/by-package-key/${firstPackageNode.key}/variables/runtime-values?appMode=VIEWER`, []);
+        mockAxiosGet(`https://myTeam.celonis.cloud/package-manager/api/nodes/by-package-key/${secondPackageNode.key}/variables/runtime-values?appMode=VIEWER`, []);
+
+        await new ConfigCommandService(testContext).batchExportPackages(undefined, ["key-1.1.0.4", "key-2.1.0.5"], true);
+
+        const expectedFileName = loggingTestTransport.logMessages[0].message.split(FileService.fileDownloadedMessage)[1];
+        expect(fs.openSync).toHaveBeenCalledWith(expectedFileName, expect.anything(), expect.anything());
+        expect(mockWriteSync).toHaveBeenCalled();
+
+        const fileBuffer = mockWriteSync.mock.calls[0][1];
+        const actualZip = new AdmZip(fileBuffer);
+
+        const firstPackageExportedZip = new AdmZip(actualZip.getEntry("key-1_1.0.4.zip").getData());
+        const firstPackageExportedNode: NodeExportTransport = parse(firstPackageExportedZip.getEntry("package.json").getData().toString());
+        expect(firstPackageExportedNode).toBeTruthy();
+        const firstPackageContent: NodeConfiguration = firstPackageExportedNode.configuration;
+        expect(firstPackageContent.variables).toHaveLength(2);
+        expect(firstPackageContent.variables).toEqual([
+            {
+                ...firstPackageVariableDefinition[0],
+            },
+            {
+                ...firstPackageVariableDefinition[1],
+                metadata: {
+                    appName: "celonis"
+                }
+            }
+        ]);
+
+        const secondPackageExportedZip = new AdmZip(actualZip.getEntry("key-2_1.0.5.zip").getData());
+        const secondPackageExportedNode: NodeExportTransport = parse(secondPackageExportedZip.getEntry("package.json").getData().toString());
+        expect(secondPackageExportedNode).toBeTruthy();
+        const secondPackageContent: NodeConfiguration = secondPackageExportedNode.configuration;
+        expect(secondPackageContent.variables).toHaveLength(2);
+        expect(secondPackageContent.variables).toEqual([{
+            ...secondPackageVariableDefinition[0],
+        },
             {
                 ...secondPackageVariableDefinition[1],
                 metadata: {
@@ -500,7 +899,7 @@ describe("Config export", () => {
         mockAxiosGet(`https://myTeam.celonis.cloud/package-manager/api/nodes/${firstPackageNode.key}/${firstPackageNode.key}`, {...firstPackageNode, spaceId: "space-1"});
         mockAxiosGet(`https://myTeam.celonis.cloud/package-manager/api/nodes/by-package-key/${firstPackageNode.key}/variables/runtime-values?appMode=VIEWER`, []);
 
-        await new ConfigCommandService(testContext).batchExportPackages(["key_with_underscores_1"], true);
+        await new ConfigCommandService(testContext).batchExportPackages(["key_with_underscores_1"], undefined, true);
 
         const expectedFileName = loggingTestTransport.logMessages[0].message.split(FileService.fileDownloadedMessage)[1];
         expect(fs.openSync).toHaveBeenCalledWith(expectedFileName, expect.anything(), expect.anything());
@@ -534,6 +933,105 @@ describe("Config export", () => {
         expect(firstPackageExportedZip.getEntry("nodes/child-1-scenario.json")).toBeNull();
     })
 
+    it("Should export with SCENARIO nodes removed and CONNECTION variables fixed for package key with multiple underscores and version", async () => {
+        const manifest: PackageManifestTransport[] = [];
+        manifest.push(ConfigUtils.buildManifestForKeyAndFlavorAndVersion("key_with_underscores_1", BatchExportImportConstants.STUDIO, "1.0.6"));
+
+        const firstPackageVariableDefinition: VariableDefinition[] = [
+            {
+                key: "key1-var",
+                type: PackageManagerVariableType.DATA_MODEL,
+                runtime: false
+            },
+            {
+                key: "key-1-connection",
+                type: PackageManagerVariableType.CONNECTION,
+                runtime: false
+            },
+            {
+                key: "key-1-another-connection",
+                type: PackageManagerVariableType.CONNECTION,
+                runtime: false
+            }
+        ];
+
+        const firstPackageNode = ConfigUtils.buildPackageNode("key_with_underscores_1", {variables: firstPackageVariableDefinition});
+        const firstPackageScenarioChild = ConfigUtils.buildChildNode("child-1-scenario", firstPackageNode.key, "SCENARIO");
+        const firstPackageZip = ConfigUtils.buildExportPackageZip(firstPackageNode, [firstPackageScenarioChild], "1.0.6");
+
+        const exportedPackagesZip = ConfigUtils.buildBatchExportZip(manifest, [firstPackageZip]);
+
+        const exportedVariables: VariableManifestTransport[] = [
+            {
+                packageKey: "key_with_underscores_1",
+                version: "1.0.6",
+                variables: [
+                    {
+                        key: "key1-var",
+                        type: PackageManagerVariableType.DATA_MODEL,
+                        value: "dm-id" as unknown as object,
+                        metadata: {}
+                    },
+                    {
+                        key: "key-1-connection",
+                        type: PackageManagerVariableType.CONNECTION,
+                        value: {
+                            appName: "celonis",
+                            connectionId: "connection-id"
+                        } as unknown as object,
+                        metadata: null
+                    },
+                    {
+                        key: "key-1-another-connection",
+                        type: PackageManagerVariableType.CONNECTION,
+                        value: "connection-id",
+                        metadata: {
+                            appName: "nameOfApp"
+                        }
+                    }
+                ]
+            }
+        ];
+
+        mockAxiosGet("https://myTeam.celonis.cloud/package-manager/api/core/packages/versions/export/batch?packageKeysWithVersion=key_with_underscores_1.1.0.6&withDependencies=true", exportedPackagesZip.toBuffer());
+        mockAxiosPost("https://myTeam.celonis.cloud/package-manager/api/core/packages/export/batch/variables-with-assignments", exportedVariables);
+        mockAxiosGet(`https://myTeam.celonis.cloud/package-manager/api/nodes/${firstPackageNode.key}/${firstPackageNode.key}`, {...firstPackageNode, spaceId: "space-1"});
+        mockAxiosGet(`https://myTeam.celonis.cloud/package-manager/api/nodes/by-package-key/${firstPackageNode.key}/variables/runtime-values?appMode=VIEWER`, []);
+
+        await new ConfigCommandService(testContext).batchExportPackages(undefined, ["key_with_underscores_1.1.0.6"], true);
+
+        const expectedFileName = loggingTestTransport.logMessages[0].message.split(FileService.fileDownloadedMessage)[1];
+        expect(fs.openSync).toHaveBeenCalledWith(expectedFileName, expect.anything(), expect.anything());
+        expect(mockWriteSync).toHaveBeenCalled();
+
+        const fileBuffer = mockWriteSync.mock.calls[0][1];
+        const actualZip = new AdmZip(fileBuffer);
+
+        const firstPackageExportedZip = new AdmZip(actualZip.getEntry("key_with_underscores_1_1.0.6.zip").getData());
+        const firstPackageExportedNode: NodeExportTransport = parse(firstPackageExportedZip.getEntry("package.json").getData().toString());
+        expect(firstPackageExportedNode).toBeTruthy();
+        const firstPackageContent: NodeConfiguration = firstPackageExportedNode.configuration;
+        expect(firstPackageContent.variables).toHaveLength(3);
+        expect(firstPackageContent.variables).toEqual([
+            {
+                ...firstPackageVariableDefinition[0],
+            },
+            {
+                ...firstPackageVariableDefinition[1],
+                metadata: {
+                    appName: "celonis"
+                }
+            }, {
+                ...firstPackageVariableDefinition[2],
+                metadata: {
+                    appName: "nameOfApp"
+                }
+            }
+        ]);
+
+        expect(firstPackageExportedZip.getEntry("nodes/child-1-scenario.json")).toBeNull();
+    })
+
     it("Should export by packageKeys without dependencies", async () => {
         const manifest: PackageManifestTransport[] = [];
         manifest.push(ConfigUtils.buildManifestForKeyAndFlavor("key-1", "TEST"));
@@ -543,7 +1041,23 @@ describe("Config export", () => {
         mockAxiosGet("https://myTeam.celonis.cloud/package-manager/api/core/packages/export/batch?packageKeys=key-1&packageKeys=key-2&packageKeys=key-3&withDependencies=false", exportedPackagesZip.toBuffer());
         mockAxiosPost("https://myTeam.celonis.cloud/package-manager/api/core/packages/export/batch/variables-with-assignments", []);
 
-        await new ConfigCommandService(testContext).batchExportPackages(["key-1", "key-2", "key-3"], false);
+        await new ConfigCommandService(testContext).batchExportPackages(["key-1", "key-2", "key-3"], undefined, false);
+
+        const expectedFileName = loggingTestTransport.logMessages[0].message.split(FileService.fileDownloadedMessage)[1];
+        expect(fs.openSync).toHaveBeenCalledWith(expectedFileName, expect.anything(), expect.anything());
+        expect(mockWriteSync).toHaveBeenCalled();
+    })
+
+    it("Should export by packageKeys without dependencies when packages are sent with keys and versions", async () => {
+        const manifest: PackageManifestTransport[] = [];
+        manifest.push(ConfigUtils.buildManifestForKeyAndFlavorAndVersion("key-1", "TEST", "1.0.3"));
+        manifest.push(ConfigUtils.buildManifestForKeyAndFlavorAndVersion("key-2", "TEST", "1.0.4"));
+        const exportedPackagesZip = ConfigUtils.buildBatchExportZip(manifest, []);
+
+        mockAxiosGet("https://myTeam.celonis.cloud/package-manager/api/core/packages/versions/export/batch?packageKeysWithVersion=key-1.1.0.3&packageKeysWithVersion=key-2.1.0.4&packageKeysWithVersion=key-3.1.0.5&withDependencies=false", exportedPackagesZip.toBuffer());
+        mockAxiosPost("https://myTeam.celonis.cloud/package-manager/api/core/packages/export/batch/variables-with-assignments", []);
+
+        await new ConfigCommandService(testContext).batchExportPackages(undefined, ["key-1.1.0.3", "key-2.1.0.4", "key-3.1.0.5"], false);
 
         const expectedFileName = loggingTestTransport.logMessages[0].message.split(FileService.fileDownloadedMessage)[1];
         expect(fs.openSync).toHaveBeenCalledWith(expectedFileName, expect.anything(), expect.anything());

--- a/tests/utls/config-utils.ts
+++ b/tests/utls/config-utils.ts
@@ -59,6 +59,15 @@ export class ConfigUtils {
         };
     }
 
+    public static buildManifestForKeyAndFlavorAndVersion(key: string, flavor: string, version: string, dependenciesByVersion?: Map<string, DependencyTransport[]>): PackageManifestTransport {
+        return {
+            packageKey: key,
+            flavor: flavor,
+            activeVersion: version,
+            dependenciesByVersion: dependenciesByVersion ?? {} as Map<string, DependencyTransport[]>
+        };
+    }
+
     public static buildPackageNode(key: string, configuration: NodeConfiguration): NodeExportTransport {
         return {
             key,


### PR DESCRIPTION
#### Description

- Added an option to the existing `config export` command `--keysByVersion` which exports the packages by the specific received versions.
- Added logic to check if both versions are being sent or neither of them isn't sent, so the command fails with a message.
- Used the same batch export logic, just added a check that controls which batch export endpoint will be called based on the received option.
- Added test cases that are the same as batch export cases.
- Updated CLI version.

#### Checklist

- [x] I have self-reviewed this PR
- [x] I have tested the change and proved that it works in different scenarios
- [x] I have updated docs if needed
