### PR TITLE
TA-4077: Handle null connection variables during export

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celonis/content-cli",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "CLI Tool to help manage content in Celonis Platform",
   "main": "content-cli.js",
   "bin": {

--- a/src/commands/configuration-management/studio.service.ts
+++ b/src/commands/configuration-management/studio.service.ts
@@ -142,7 +142,7 @@ export class StudioService {
     }
 
     private fixConnectionVariable(variable: VariableExportTransport): VariableExportTransport {
-        if (!variable.value.appName) {
+        if (!variable.value?.appName) {
             return variable;
         }
 


### PR DESCRIPTION
#### Description

Connection variables can have null value. Added a check that skips fixing a connection variable if it has null value.
Ticket: https://celonis.atlassian.net/browse/TA-4077

#### Checklist

- [x] I have self-reviewed this PR
- [x] I have tested the change and proved that it works in different scenarios
- [ ] I have updated docs if needed
