### PR TITLE
TA-4128: Handle client errors in downloadFile

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celonis/content-cli",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "CLI Tool to help manage content in Celonis Platform",
   "main": "content-cli.js",
   "bin": {


### PR DESCRIPTION
#### Description

Handled the response manually for different scenarios.
- When the response is 200, then the response type is `application/octet-stream` which requires handling differently, but in the case of 404 or 403, the response was json or plain text so the data was being treated as if its a file and getting zipped, hence why the response was unreadable.
- Now the data handling is done manually

#### Checklist

- [x] I have self-reviewed this PR
- [x] I have tested the change and proved that it works in different scenarios
- [ ] I have updated docs if needed

### Changes

Before:
<img width="2461" height="332" alt="image" src="https://github.com/user-attachments/assets/cd2b0da6-8e4d-4517-9f22-bff024286443" />
Note: the full output is way longer than the screenshot

After:
<img width="1157" height="79" alt="image" src="https://github.com/user-attachments/assets/ed578078-e54f-4a66-9d89-4e8d1bf1ffe9" />
