### PR TITLE
Add `links` section in the PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,6 +2,8 @@
 
 Please include a description of the change and why the change was made.
 
+#### Relevant links
+
 #### Checklist
 
 - [ ] I have self-reviewed this PR

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,6 +4,8 @@ Please include a description of the change and why the change was made.
 
 #### Relevant links
 
+- Jira: 
+
 #### Checklist
 
 - [ ] I have self-reviewed this PR


### PR DESCRIPTION
#### Description

A `relevant links` section is missing in the PR template making most PRs to not have a quick link to the ticket without going on Jira with the task ID in the PR title.

#### Checklist

- [x] I have self-reviewed this PR
- [ ] I have tested the change and proved that it works in different scenarios
- [ ] I have updated docs if needed
