### PR TITLE
TA-4275: Fix zipping when the source is a directory on config import

### DIFF
--- a/src/commands/configuration-management/batch-import-export.service.ts
+++ b/src/commands/configuration-management/batch-import-export.service.ts
@@ -121,9 +121,9 @@ export class BatchImportExportService {
             sourceToBeImported = await this.gitService.pullFromBranch(gitBranch);
         } else {
             sourceToBeImported = sourcePath;
-            if (fileService.isDirectory(sourcePath)) {
-                sourceToBeImported = fileService.zipDirectoryInBatchExportFormat(sourceToBeImported);
-            }
+        }
+        if (fileService.isDirectory(sourceToBeImported)) {
+            sourceToBeImported = fileService.zipDirectoryInBatchExportFormat(sourceToBeImported);
         }
 
         let configs = new AdmZip(sourceToBeImported);


### PR DESCRIPTION
#### Description

We're currently zipping the source files when the source is a directory but only on non-git config imports. Changed it.

#### Relevant links

- Jira: https://celonis.atlassian.net/browse/TA-4275

#### Checklist

- [x] I have self-reviewed this PR
- [x] I have tested the change and proved that it works in different scenarios
- [ ] I have updated docs if needed
