### PR TITLE
Add test coverage configuration

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,8 +1,14 @@
 import type { Config } from "@jest/types"
 const config: Config.InitialOptions = {
     verbose: true,
+    preset: "ts-jest",
+    testEnvironment: "node",
     transform: {
-        "^.+\\.tsx?$": "ts-jest",
+        "^.+\\.tsx?$": ["ts-jest", {
+            tsconfig: {
+                sourceMap: true
+            }
+        }],
     },
     testMatch: ["<rootDir>/tests/**/*.spec.ts"],
     moduleNameMapper: {
@@ -11,13 +17,22 @@ const config: Config.InitialOptions = {
     setupFilesAfterEnv: [
         "<rootDir>/tests/jest.setup.ts",
     ],
-    globals: {
-        "ts-jest": {
-            tsconfig: {
-                sourceMap: true
-            }
-        }
-    }
+    // Coverage configuration
+    collectCoverageFrom: [
+        "src/**/*.{ts,tsx}",
+        "!src/**/*.d.ts",
+        "!src/**/*.spec.ts",
+        "!src/**/index.ts"
+    ],
+    coverageDirectory: "coverage",
+    coverageReporters: ["text", "lcov", "html"],
+    coverageProvider: "v8",
+    coveragePathIgnorePatterns: [
+        "/node_modules/",
+        "/tests/",
+        "/coverage/",
+        "jest.setup.ts"
+    ]
 }
 
 export default config


### PR DESCRIPTION
#### Description

The current test configurations were failing to collect coverage when running the commands locally, because of missing test configs on coverage collection. Added them here.

#### Relevant links

N/A

#### Checklist

- [x] I have self-reviewed this PR
- [x] I have tested the change and proved that it works in different scenarios
- [ ] I have updated docs if needed
