### PR TITLE
TA-4307: Make packageKey option required in the getTargets command.

### DIFF
--- a/src/commands/deployment/deployment-api.ts
+++ b/src/commands/deployment/deployment-api.ts
@@ -80,13 +80,10 @@ export class DeploymentApi {
             });
     }
 
-    public async getTargets(deployableType: string, packageKey?: string): Promise<TargetTransport[]> {
+    public async getTargets(deployableType: string, packageKey: string): Promise<TargetTransport[]> {
         const queryParams = new URLSearchParams();
         queryParams.set("deployableType", deployableType);
-
-        if (packageKey) {
-            queryParams.set("packageKey", packageKey);
-        }
+        queryParams.set("packageKey", packageKey);
 
         return this.httpClient()
             .get(`/pacman/api/deployments/targets?${queryParams.toString()}`)

--- a/src/commands/deployment/deployment.service.ts
+++ b/src/commands/deployment/deployment.service.ts
@@ -85,7 +85,7 @@ export class DeploymentService {
         }
     }
 
-    public async getTargets(jsonResponse: boolean, deployableType: string, packageKey?: string): Promise<void> {
+    public async getTargets(jsonResponse: boolean, deployableType: string, packageKey: string): Promise<void> {
         const targets = await this.deploymentApi.getTargets(deployableType, packageKey);
 
         if (jsonResponse) {

--- a/tests/commands/deployment/deployment-list-targets.spec.ts
+++ b/tests/commands/deployment/deployment-list-targets.spec.ts
@@ -18,28 +18,19 @@ describe("Deployment list targets", () => {
     }
 
     it("Should list targets", async () => {
-        mockAxiosGet("https://myTeam.celonis.cloud/pacman/api/deployments/targets?deployableType=app-package", [firstTarget, secondTarget]);
+        mockAxiosGet("https://myTeam.celonis.cloud/pacman/api/deployments/targets?deployableType=app-package&packageKey=package-key", [firstTarget, secondTarget]);
 
-        await new DeploymentService(testContext).getTargets(false, "app-package");
+        await new DeploymentService(testContext).getTargets(false, "app-package", "package-key");
 
         expect(loggingTestTransport.logMessages.length).toBe(2);
         expect(loggingTestTransport.logMessages[0].message).toContain(`ID: ${firstTarget.id}, Name: ${firstTarget.name}`);
         expect(loggingTestTransport.logMessages[1].message).toContain(`ID: ${secondTarget.id}, Name: ${secondTarget.name}`);
     });
 
-    it("Should list targets with package key filter", async () => {
-        mockAxiosGet("https://myTeam.celonis.cloud/pacman/api/deployments/targets?deployableType=app-package&packageKey=package-key", [firstTarget]);
-
-        await new DeploymentService(testContext).getTargets(false, "app-package", "package-key");
-
-        expect(loggingTestTransport.logMessages.length).toBe(1);
-        expect(loggingTestTransport.logMessages[0].message).toContain(`ID: ${firstTarget.id}, Name: ${firstTarget.name}`);
-    });
-
     it("Should list targets as JSON", async () => {
-        mockAxiosGet("https://myTeam.celonis.cloud/pacman/api/deployments/targets?deployableType=app-package", [firstTarget, secondTarget]);
+        mockAxiosGet("https://myTeam.celonis.cloud/pacman/api/deployments/targets?deployableType=app-package&packageKey=package-key", [firstTarget, secondTarget]);
 
-        await new DeploymentService(testContext).getTargets(true, "app-package");
+        await new DeploymentService(testContext).getTargets(true, "app-package","package-key");
 
         const expectedFileName = loggingTestTransport.logMessages[0].message.split(FileService.fileDownloadedMessage)[1];
 


### PR DESCRIPTION
#### Description

Made packageKey option requires in the getTargets commands to match the API.

#### Relevant links

- Jira: https://celonis.atlassian.net/browse/TA-4307

#### Checklist

- [ ] I have self-reviewed this PR
- [ ] I have tested the change and proved that it works in different scenarios
- [ ] I have updated docs if needed
