### PR TITLE
SP-10: Add config validate command and --validate flag on config import

### DIFF
--- a/src/commands/configuration-management/api/batch-import-export-api.ts
+++ b/src/commands/configuration-management/api/batch-import-export-api.ts
@@ -92,11 +92,11 @@ export class BatchImportExportApi {
         })
     }
 
-    public async importPackages(data: FormData, overwrite: boolean): Promise<PostPackageImportData[]> {
+    public async importPackages(data: FormData, overwrite: boolean, performValidation: boolean): Promise<PostPackageImportData[]> {
         return this.httpClient().postFile(
             "/package-manager/api/core/packages/import/batch",
             data,
-            {overwrite}
+            {overwrite, performValidation}
         );
     }
 

--- a/src/commands/configuration-management/api/package-validation-api.ts
+++ b/src/commands/configuration-management/api/package-validation-api.ts
@@ -13,7 +13,7 @@ export class PackageValidationApi {
 
     public async validatePackage(packageKey: string, request: PackageValidationRequest): Promise<SchemaValidationResponse> {
         return this.httpClient().post(
-            `/package-manager/api/core/packages/${encodeURIComponent(packageKey)}/validate`,
+            `/pacman/api/core/packages/${packageKey}/validate`,
             request
         ).catch(e => {
             throw new FatalError(`Problem validating package "${packageKey}": ${e}`);

--- a/src/commands/configuration-management/api/package-validation-api.ts
+++ b/src/commands/configuration-management/api/package-validation-api.ts
@@ -1,0 +1,22 @@
+import { HttpClient } from "../../../core/http/http-client";
+import { Context } from "../../../core/command/cli-context";
+import { FatalError } from "../../../core/utils/logger";
+import { PackageValidationRequest, SchemaValidationResponse } from "../interfaces/package-validation.interfaces";
+
+export class PackageValidationApi {
+
+    private httpClient: () => HttpClient;
+
+    constructor(context: Context) {
+        this.httpClient = () => context.httpClient;
+    }
+
+    public async validatePackage(packageKey: string, request: PackageValidationRequest): Promise<SchemaValidationResponse> {
+        return this.httpClient().post(
+            `/package-manager/api/core/packages/${encodeURIComponent(packageKey)}/validate`,
+            request
+        ).catch(e => {
+            throw new FatalError(`Problem validating package "${packageKey}": ${e}`);
+        });
+    }
+}

--- a/src/commands/configuration-management/batch-import-export.service.ts
+++ b/src/commands/configuration-management/batch-import-export.service.ts
@@ -124,7 +124,7 @@ export class BatchImportExportService {
         }
     }
 
-    public async batchImportPackages(sourcePath: string, overwrite: boolean, gitBranch: string): Promise<void> {
+    public async batchImportPackages(sourcePath: string, overwrite: boolean, gitBranch: string, performValidation: boolean = false): Promise<void> {
         let sourceToBeImported: string;
         if (gitBranch) {
             sourceToBeImported = await this.gitService.pullFromBranch(gitBranch);
@@ -143,7 +143,7 @@ export class BatchImportExportService {
         const existingStudioPackages = await this.studioPackageApi.findAllPackages();
 
         const formData = this.buildBodyForImport(configs, sourceToBeImported, variablesManifests);
-        const postPackageImportData = await this.batchImportExportApi.importPackages(formData, overwrite);
+        const postPackageImportData = await this.batchImportExportApi.importPackages(formData, overwrite, performValidation);
         await this.studioService.processImportedPackages(configs, existingStudioPackages, studioManifests);
 
         if (gitBranch) {

--- a/src/commands/configuration-management/config-command.service.ts
+++ b/src/commands/configuration-management/config-command.service.ts
@@ -58,7 +58,7 @@ export class ConfigCommandService {
         return this.batchImportExportService.batchExportPackagesMetadata(packageKeys, jsonResponse);
     }
 
-    public batchImportPackages(file: string, directory: string, overwrite: boolean, gitBranch: string): Promise<void> {
+    public batchImportPackages(file: string, directory: string, overwrite: boolean, gitBranch: string, performValidation: boolean = false): Promise<void> {
         if ((directory || file) && gitBranch) {
             throw new Error("You cannot use both file/directory and gitBranch options at the same time. Only one import source can be defined.");
         }
@@ -75,7 +75,7 @@ export class ConfigCommandService {
             throw new Error("The directory option accepts only directories.");
         }
         const sourcePath = file ?? directory;
-        return this.batchImportExportService.batchImportPackages(sourcePath, overwrite, gitBranch);
+        return this.batchImportExportService.batchImportPackages(sourcePath, overwrite, gitBranch, performValidation);
     }
 
     public diffPackages(file: string, hasChanges: boolean, jsonResponse: boolean): Promise<void> {

--- a/src/commands/configuration-management/interfaces/package-validation.interfaces.ts
+++ b/src/commands/configuration-management/interfaces/package-validation.interfaces.ts
@@ -1,0 +1,28 @@
+export interface PackageValidationRequest {
+    layers: string[];
+    nodeKeys?: string[];
+}
+
+export interface SchemaValidationResponse {
+    packageKey: string;
+    valid: boolean;
+    summary: SchemaValidationSummary;
+    results: SchemaValidationResult[];
+}
+
+export interface SchemaValidationSummary {
+    errors: number;
+    warnings: number;
+    info: number;
+}
+
+export interface SchemaValidationResult {
+    layer: string;
+    severity: string;
+    nodeKey: string;
+    assetType: string;
+    path: string;
+    code: string;
+    message: string;
+    suggestion?: string;
+}

--- a/src/commands/configuration-management/module.ts
+++ b/src/commands/configuration-management/module.ts
@@ -51,7 +51,7 @@ class Module extends IModule {
         configCommand.command("import")
             .description("Command to import package configs")
             .option("--overwrite", "Flag to allow overwriting of packages")
-            .option("--performValidation", "Validate node configurations before import", false)
+            .option("--validate", "Validate node configurations before import", false)
             .option("--gitProfile <gitProfile>", "Git profile which you want to use for the Git operations")
             .option("--gitBranch <gitBranch>", "Git branch from which you want to pull the exported file and import")
             .option("-f, --file <file>", "Exported packages file (relative path)")
@@ -206,7 +206,7 @@ class Module extends IModule {
         if (options.gitProfile && !options.gitBranch) {
             throw new Error("Please specify a branch using --gitBranch when using a Git profile.");
         }
-        await new ConfigCommandService(context).batchImportPackages(options.file, options.directory, options.overwrite, options.gitBranch, options.performValidation);
+        await new ConfigCommandService(context).batchImportPackages(options.file, options.directory, options.overwrite, options.gitBranch, options.validate);
     }
 
     private async diffPackages(context: Context, command: Command, options: OptionValues): Promise<void> {

--- a/src/commands/configuration-management/module.ts
+++ b/src/commands/configuration-management/module.ts
@@ -11,6 +11,7 @@ import { NodeService } from "./node.service";
 import { NodeDiffService } from "./node-diff.service";
 import { NodeDependencyService } from "./node-dependency.service";
 import { PackageVersionCommandService } from "./package-version-command.service";
+import { PackageValidationService } from "./package-validation.service";
 
 class Module extends IModule {
 
@@ -50,11 +51,20 @@ class Module extends IModule {
         configCommand.command("import")
             .description("Command to import package configs")
             .option("--overwrite", "Flag to allow overwriting of packages")
+            .option("--performValidation", "Validate node configurations before import", false)
             .option("--gitProfile <gitProfile>", "Git profile which you want to use for the Git operations")
             .option("--gitBranch <gitBranch>", "Git branch from which you want to pull the exported file and import")
             .option("-f, --file <file>", "Exported packages file (relative path)")
             .option("-d, --directory <directory>", "Exported packages directory (relative path)")
             .action(this.batchImportPackages);
+
+        configCommand.command("validate")
+            .description("Validate package node configurations")
+            .requiredOption("--packageKey <packageKey>", "Key of the package to validate")
+            .option("--layers <layers...>", "Validation layers to run", ["SCHEMA"])
+            .option("--nodeKeys <nodeKeys...>", "Specific node keys to validate (default: all nodes)")
+            .option("--json", "Return the response as a JSON file")
+            .action(this.validatePackage);
 
         configCommand.command("diff")
             .description("Command to diff configs of packages")
@@ -196,11 +206,15 @@ class Module extends IModule {
         if (options.gitProfile && !options.gitBranch) {
             throw new Error("Please specify a branch using --gitBranch when using a Git profile.");
         }
-        await new ConfigCommandService(context).batchImportPackages(options.file, options.directory, options.overwrite, options.gitBranch);
+        await new ConfigCommandService(context).batchImportPackages(options.file, options.directory, options.overwrite, options.gitBranch, options.performValidation);
     }
 
     private async diffPackages(context: Context, command: Command, options: OptionValues): Promise<void> {
         await new ConfigCommandService(context).diffPackages(options.file, options.hasChanges, options.json);
+    }
+
+    private async validatePackage(context: Context, command: Command, options: OptionValues): Promise<void> {
+        await new PackageValidationService(context).validatePackage(options.packageKey, options.layers, options.nodeKeys, options.json);
     }
 
     private async listVariables(context: Context, command: Command, options: OptionValues): Promise<void> {

--- a/src/commands/configuration-management/package-validation.service.ts
+++ b/src/commands/configuration-management/package-validation.service.ts
@@ -1,0 +1,49 @@
+import { v4 as uuidv4 } from "uuid";
+import { Context } from "../../core/command/cli-context";
+import { PackageValidationApi } from "./api/package-validation-api";
+import { PackageValidationRequest, SchemaValidationResponse, SchemaValidationResult } from "./interfaces/package-validation.interfaces";
+import { logger } from "../../core/utils/logger";
+import { fileService } from "../../core/utils/file-service";
+
+export class PackageValidationService {
+
+    private packageValidationApi: PackageValidationApi;
+
+    constructor(context: Context) {
+        this.packageValidationApi = new PackageValidationApi(context);
+    }
+
+    public async validatePackage(packageKey: string, layers: string[], nodeKeys: string[], jsonOutput: boolean): Promise<void> {
+        logger.info(`Validating package "${packageKey}" with layers: ${layers.join(", ")}...`);
+
+        const request: PackageValidationRequest = { layers };
+        if (nodeKeys && nodeKeys.length > 0) {
+            request.nodeKeys = nodeKeys;
+        }
+
+        const response = await this.packageValidationApi.validatePackage(packageKey, request);
+
+        if (jsonOutput) {
+            const reportFileName = "config_validate_report_" + uuidv4() + ".json";
+            fileService.writeToFileWithGivenName(JSON.stringify(response), reportFileName);
+            logger.info("Validation report file: " + reportFileName);
+        } else {
+            this.printValidationResult(response);
+        }
+    }
+
+    private printValidationResult(response: SchemaValidationResponse): void {
+        const status = response.valid ? "VALID" : "INVALID";
+        logger.info("");
+        logger.info(`Validation result: ${status}`);
+        logger.info(`Errors: ${response.summary.errors} | Warnings: ${response.summary.warnings} | Info: ${response.summary.info}`);
+
+        if (response.results.length > 0) {
+            logger.info("");
+            response.results.forEach((result: SchemaValidationResult) => {
+                const prefix = result.severity.toUpperCase().padEnd(7);
+                logger.info(`  ${prefix} ${result.nodeKey} (${result.assetType}) - ${result.message} [${result.code}]`);
+            });
+        }
+    }
+}

--- a/src/commands/configuration-management/package-validation.service.ts
+++ b/src/commands/configuration-management/package-validation.service.ts
@@ -24,6 +24,7 @@ export class PackageValidationService {
         if (jsonOutput) {
             const reportFileName = "config_validate_report_" + uuidv4() + ".json";
             fileService.writeToFileWithGivenName(JSON.stringify(response), reportFileName);
+            logger.info("Validation report file: " + reportFileName);
         } else {
             this.printValidationResult(response);
         }

--- a/src/commands/configuration-management/package-validation.service.ts
+++ b/src/commands/configuration-management/package-validation.service.ts
@@ -14,8 +14,6 @@ export class PackageValidationService {
     }
 
     public async validatePackage(packageKey: string, layers: string[], nodeKeys: string[], jsonOutput: boolean): Promise<void> {
-        logger.info(`Validating package "${packageKey}" with layers: ${layers.join(", ")}...`);
-
         const request: PackageValidationRequest = { layers };
         if (nodeKeys && nodeKeys.length > 0) {
             request.nodeKeys = nodeKeys;
@@ -26,7 +24,6 @@ export class PackageValidationService {
         if (jsonOutput) {
             const reportFileName = "config_validate_report_" + uuidv4() + ".json";
             fileService.writeToFileWithGivenName(JSON.stringify(response), reportFileName);
-            logger.info("Validation report file: " + reportFileName);
         } else {
             this.printValidationResult(response);
         }

--- a/tests/commands/configuration-management/config-import.spec.ts
+++ b/tests/commands/configuration-management/config-import.spec.ts
@@ -420,4 +420,34 @@ describe("Config import", () => {
 
         expect(mockedPostRequestBodyByUrl.get(assignVariablesUrl)).toEqual(JSON.stringify([variableAssignment]));
     })
+
+    it("Should pass performValidation param when flag is set", async () => {
+        const manifest: PackageManifestTransport[] = [];
+        manifest.push(ConfigUtils.buildManifestForKeyAndFlavor("key-1", "TEST"));
+        const exportedPackagesZip = ConfigUtils.buildBatchExportZip(manifest, []);
+
+        mockReadFileSync(exportedPackagesZip.toBuffer());
+        mockCreateReadStream(exportedPackagesZip.toBuffer());
+        mockAxiosGet("https://myTeam.celonis.cloud/package-manager/api/packages", []);
+
+        const importResponse: PostPackageImportData[] = [{
+            packageKey: "key-1",
+            importedVersions: [{
+                oldVersion: "1.0.2",
+                newVersion: "1.0.0"
+            }]
+        }];
+
+        mockAxiosPost("https://myTeam.celonis.cloud/package-manager/api/core/packages/import/batch", importResponse);
+
+        await new ConfigCommandService(testContext).batchImportPackages("./export_file.zip", null, false, null, true);
+
+        expect(mockedAxiosInstance.post).toHaveBeenCalledWith(
+            expect.stringContaining("/package-manager/api/core/packages/import/batch"),
+            expect.anything(),
+            expect.objectContaining({
+                params: expect.objectContaining({ performValidation: true })
+            })
+        );
+    })
 })

--- a/tests/commands/configuration-management/config-validate.spec.ts
+++ b/tests/commands/configuration-management/config-validate.spec.ts
@@ -1,0 +1,112 @@
+import {
+    mockAxiosPost,
+    mockedPostRequestBodyByUrl,
+} from "../../utls/http-requests-mock";
+import { PackageValidationService } from "../../../src/commands/configuration-management/package-validation.service";
+import { testContext } from "../../utls/test-context";
+import { loggingTestTransport, mockWriteFileSync } from "../../jest.setup";
+import { SchemaValidationResponse } from "../../../src/commands/configuration-management/interfaces/package-validation.interfaces";
+import * as path from "path";
+
+describe("Config validate", () => {
+
+    const VALIDATE_URL = "https://myTeam.celonis.cloud/package-manager/api/core/packages/my-package/validate";
+
+    it("Should call validate API with correct body", async () => {
+        const response: SchemaValidationResponse = {
+            packageKey: "my-package",
+            valid: true,
+            summary: { errors: 0, warnings: 0, info: 0 },
+            results: []
+        };
+
+        mockAxiosPost(VALIDATE_URL, response);
+
+        await new PackageValidationService(testContext).validatePackage("my-package", ["SCHEMA"], null, false);
+
+        expect(mockedPostRequestBodyByUrl.get(VALIDATE_URL)).toEqual(JSON.stringify({ layers: ["SCHEMA"] }));
+    })
+
+    it("Should include nodeKeys in request body when specified", async () => {
+        const response: SchemaValidationResponse = {
+            packageKey: "my-package",
+            valid: true,
+            summary: { errors: 0, warnings: 0, info: 0 },
+            results: []
+        };
+
+        mockAxiosPost(VALIDATE_URL, response);
+
+        await new PackageValidationService(testContext).validatePackage("my-package", ["SCHEMA"], ["node-1", "node-2"], false);
+
+        expect(mockedPostRequestBodyByUrl.get(VALIDATE_URL)).toEqual(
+            JSON.stringify({ layers: ["SCHEMA"], nodeKeys: ["node-1", "node-2"] })
+        );
+    })
+
+    it("Should log human-readable output when json flag is not set", async () => {
+        const response: SchemaValidationResponse = {
+            packageKey: "my-package",
+            valid: false,
+            summary: { errors: 1, warnings: 0, info: 0 },
+            results: [{
+                layer: "SCHEMA",
+                severity: "ERROR",
+                nodeKey: "node-1",
+                assetType: "ANALYSIS",
+                path: "$.requiredField",
+                code: "REQUIRED_PROPERTY_MISSING",
+                message: "$.requiredField: is missing but it is required"
+            }]
+        };
+
+        mockAxiosPost(VALIDATE_URL, response);
+
+        await new PackageValidationService(testContext).validatePackage("my-package", ["SCHEMA"], null, false);
+
+        const allMessages = loggingTestTransport.logMessages.map(m => m.message).join("\n");
+        expect(allMessages).toContain("Validation result: INVALID");
+        expect(allMessages).toContain("Errors: 1");
+        expect(allMessages).toContain("REQUIRED_PROPERTY_MISSING");
+    })
+
+    it("Should write JSON file when json flag is set", async () => {
+        const response: SchemaValidationResponse = {
+            packageKey: "my-package",
+            valid: true,
+            summary: { errors: 0, warnings: 0, info: 0 },
+            results: []
+        };
+
+        mockAxiosPost(VALIDATE_URL, response);
+
+        await new PackageValidationService(testContext).validatePackage("my-package", ["SCHEMA"], null, true);
+
+        const reportMessage = loggingTestTransport.logMessages.find(m => m.message.includes("Validation report file:"));
+        expect(reportMessage).toBeDefined();
+
+        const reportFileName = reportMessage.message.split("Validation report file: ")[1];
+        expect(mockWriteFileSync).toHaveBeenCalledWith(
+            path.resolve(process.cwd(), reportFileName),
+            JSON.stringify(response),
+            { encoding: "utf-8" }
+        );
+    })
+
+    it("Should log VALID when package has no errors", async () => {
+        const response: SchemaValidationResponse = {
+            packageKey: "my-package",
+            valid: true,
+            summary: { errors: 0, warnings: 0, info: 0 },
+            results: []
+        };
+
+        mockAxiosPost(VALIDATE_URL, response);
+
+        await new PackageValidationService(testContext).validatePackage("my-package", ["SCHEMA"], null, false);
+
+        const allMessages = loggingTestTransport.logMessages.map(m => m.message).join("\n");
+        expect(allMessages).toContain("Validation result: VALID");
+        expect(allMessages).toContain("Errors: 0");
+    })
+})

--- a/tests/commands/configuration-management/config-validate.spec.ts
+++ b/tests/commands/configuration-management/config-validate.spec.ts
@@ -9,7 +9,7 @@ import { SchemaValidationResponse } from "../../../src/commands/configuration-ma
 
 describe("Config validate", () => {
 
-    const VALIDATE_URL = "https://myTeam.celonis.cloud/package-manager/api/core/packages/my-package/validate";
+    const VALIDATE_URL = "https://myTeam.celonis.cloud/pacman/api/core/packages/my-package/validate";
 
     it("Should call validate API with correct body", async () => {
         const response: SchemaValidationResponse = {

--- a/tests/commands/configuration-management/config-validate.spec.ts
+++ b/tests/commands/configuration-management/config-validate.spec.ts
@@ -6,7 +6,6 @@ import { PackageValidationService } from "../../../src/commands/configuration-ma
 import { testContext } from "../../utls/test-context";
 import { loggingTestTransport, mockWriteFileSync } from "../../jest.setup";
 import { SchemaValidationResponse } from "../../../src/commands/configuration-management/interfaces/package-validation.interfaces";
-import * as path from "path";
 
 describe("Config validate", () => {
 
@@ -82,12 +81,8 @@ describe("Config validate", () => {
 
         await new PackageValidationService(testContext).validatePackage("my-package", ["SCHEMA"], null, true);
 
-        const reportMessage = loggingTestTransport.logMessages.find(m => m.message.includes("Validation report file:"));
-        expect(reportMessage).toBeDefined();
-
-        const reportFileName = reportMessage.message.split("Validation report file: ")[1];
         expect(mockWriteFileSync).toHaveBeenCalledWith(
-            path.resolve(process.cwd(), reportFileName),
+            expect.stringMatching(/config_validate_report_.+\.json$/),
             JSON.stringify(response),
             { encoding: "utf-8" }
         );

--- a/tests/commands/configuration-management/module.spec.ts
+++ b/tests/commands/configuration-management/module.spec.ts
@@ -312,7 +312,8 @@ describe("Configuration Management Module - Action Validations", () => {
                     "export.zip",
                     undefined,
                     undefined,
-                    "main"
+                    "main",
+                    undefined
                 );
             });
 
@@ -328,7 +329,8 @@ describe("Configuration Management Module - Action Validations", () => {
                     undefined,
                     "./exported",
                     undefined,
-                    "develop"
+                    "develop",
+                    undefined
                 );
             });
 
@@ -341,6 +343,7 @@ describe("Configuration Management Module - Action Validations", () => {
 
                 expect(mockConfigCommandService.batchImportPackages).toHaveBeenCalledWith(
                     "export.zip",
+                    undefined,
                     undefined,
                     undefined,
                     undefined
@@ -360,6 +363,7 @@ describe("Configuration Management Module - Action Validations", () => {
                     "my-export.zip",
                     undefined,
                     undefined,
+                    undefined,
                     undefined
                 );
             });
@@ -374,6 +378,7 @@ describe("Configuration Management Module - Action Validations", () => {
                 expect(mockConfigCommandService.batchImportPackages).toHaveBeenCalledWith(
                     undefined,
                     "./my-exports",
+                    undefined,
                     undefined,
                     undefined
                 );
@@ -391,6 +396,7 @@ describe("Configuration Management Module - Action Validations", () => {
                     "export.zip",
                     undefined,
                     true,
+                    undefined,
                     undefined
                 );
             });
@@ -408,7 +414,8 @@ describe("Configuration Management Module - Action Validations", () => {
                     undefined,
                     "./exports",
                     true,
-                    "feature-branch"
+                    "feature-branch",
+                    undefined
                 );
             });
         });


### PR DESCRIPTION
#### Description

- Add `--validate` option to `config import` that passes `performValidation=true` query param to pacman's batch import endpoint, enabling schema validation during import
- Add new `config validate` command (`content-cli config validate --packageKey <key>`) that calls `POST /api/core/packages/{packageKey}/validate` with configurable `--layers` (default: SCHEMA) and optional `--nodeKeys` scoping
- Human-readable output by default; `--json` flag writes the full validation response to a report file

#### Relevant links

- Jira: https://celonis.atlassian.net/browse/SP-10

#### Checklist

- [x] I have self-reviewed this PR
- [x] I have tested the change and proved that it works in different scenarios
- [ ] I have updated docs if needed

Made with [Cursor](https://cursor.com)