### PR TITLE
TA-4732: restrict file permissions created by content-cli

### DIFF
--- a/src/commands/action-flows/action-flow/action-flow.service.ts
+++ b/src/commands/action-flows/action-flow/action-flow.service.ts
@@ -6,6 +6,7 @@ import { Context } from "../../../core/command/cli-context";
 import { ActionFlowApi } from "./action-flow-api";
 import { fileService, FileService } from "../../../core/utils/file-service";
 import { logger } from "../../../core/utils/logger";
+import { FileConstants } from "../../../core/utils/file.constants";
 
 export class ActionFlowService {
     public static readonly METADATA_FILE_NAME = "metadata.json";
@@ -22,7 +23,7 @@ export class ActionFlowService {
 
         const zip = new AdmZip();
         tmpZip.getEntries().forEach(entry => {
-            zip.addFile(entry.entryName, entry.getData(), "", 0o600);
+            zip.addFile(entry.entryName, entry.getData(), "", FileConstants.DEFAULT_FILE_PERMISSIONS);
         });
 
         if (metadataFilePath) {
@@ -30,7 +31,7 @@ export class ActionFlowService {
         }
 
         const fileName = "action-flows_export_" + uuidv4() + ".zip";
-        zip.writeZip(fileName, () => fs.chmodSync(fileName, 0o600));
+        zip.writeZip(fileName, () => fs.chmodSync(fileName, FileConstants.DEFAULT_FILE_PERMISSIONS));
         logger.info(FileService.fileDownloadedMessage + fileName);
     }
 
@@ -74,6 +75,6 @@ export class ActionFlowService {
         fileName = fileName + (fileName.endsWith(".json") ? "" : ".json");
         const metadata = fileService.readFile(fileName);
 
-        zip.addFile(ActionFlowService.METADATA_FILE_NAME, Buffer.from(metadata), "", 0o600);
+        zip.addFile(ActionFlowService.METADATA_FILE_NAME, Buffer.from(metadata), "", FileConstants.DEFAULT_FILE_PERMISSIONS);
     }
 }

--- a/src/commands/action-flows/action-flow/action-flow.service.ts
+++ b/src/commands/action-flows/action-flow/action-flow.service.ts
@@ -30,7 +30,7 @@ export class ActionFlowService {
         }
 
         const fileName = "action-flows_export_" + uuidv4() + ".zip";
-        zip.writeZip(fileName);
+        zip.writeZip(fileName, () => fs.chmodSync(fileName, 0o600));
         logger.info(FileService.fileDownloadedMessage + fileName);
     }
 

--- a/src/commands/action-flows/action-flow/action-flow.service.ts
+++ b/src/commands/action-flows/action-flow/action-flow.service.ts
@@ -22,7 +22,7 @@ export class ActionFlowService {
 
         const zip = new AdmZip();
         tmpZip.getEntries().forEach(entry => {
-            zip.addFile(entry.entryName, entry.getData());
+            zip.addFile(entry.entryName, entry.getData(), "", 0o600);
         });
 
         if (metadataFilePath) {
@@ -74,6 +74,6 @@ export class ActionFlowService {
         fileName = fileName + (fileName.endsWith(".json") ? "" : ".json");
         const metadata = fileService.readFile(fileName);
 
-        zip.addFile(ActionFlowService.METADATA_FILE_NAME, Buffer.from(metadata));
+        zip.addFile(ActionFlowService.METADATA_FILE_NAME, Buffer.from(metadata), "", 0o600);
     }
 }

--- a/src/commands/configuration-management/batch-import-export.service.ts
+++ b/src/commands/configuration-management/batch-import-export.service.ts
@@ -17,6 +17,7 @@ import { BatchImportExportApi } from "./api/batch-import-export-api";
 import { StudioService } from "./studio.service";
 import { GitService } from "../../core/git-profile/git/git.service";
 import * as fs from "fs";
+import { FileConstants } from "../../core/utils/file.constants";
 
 export class BatchImportExportService {
 
@@ -82,13 +83,13 @@ export class BatchImportExportService {
 
         let exportedVariables = await this.getVersionedVariablesForPackagesWithKeys(versionsByPackageKey);
         exportedVariables = this.studioService.fixConnectionVariables(exportedVariables);
-        exportedPackagesZip.addFile(BatchExportImportConstants.VARIABLES_FILE_NAME, Buffer.from(stringify(exportedVariables), "utf8"), "", 0o600);
+        exportedPackagesZip.addFile(BatchExportImportConstants.VARIABLES_FILE_NAME, Buffer.from(stringify(exportedVariables), "utf8"), "", FileConstants.DEFAULT_FILE_PERMISSIONS);
 
         const studioPackageKeys = manifest.filter(packageManifest => packageManifest.flavor === BatchExportImportConstants.STUDIO)
             .map(packageManifest => packageManifest.packageKey);
 
         const studioData = await this.studioService.getStudioPackageManifests(studioPackageKeys);
-        exportedPackagesZip.addFile(BatchExportImportConstants.STUDIO_FILE_NAME, Buffer.from(stringify(studioData), "utf8"), "", 0o600);
+        exportedPackagesZip.addFile(BatchExportImportConstants.STUDIO_FILE_NAME, Buffer.from(stringify(studioData), "utf8"), "", FileConstants.DEFAULT_FILE_PERMISSIONS);
 
         exportedPackagesZip.getEntries().forEach(entry => {
             if (entry.name.endsWith(BatchExportImportConstants.ZIP_EXTENSION)) {
@@ -261,7 +262,7 @@ export class BatchImportExportService {
         } else {
             const fileDownloadedMessage = "File downloaded successfully. New filename: ";
             const filename = `export_${uuidv4()}.zip`;
-            exportedZip.writeZip(filename, () => fs.chmodSync(filename, 0o600));
+            exportedZip.writeZip(filename, () => fs.chmodSync(filename, FileConstants.DEFAULT_FILE_PERMISSIONS));
             logger.info(fileDownloadedMessage + filename);
         }
     }

--- a/src/commands/configuration-management/batch-import-export.service.ts
+++ b/src/commands/configuration-management/batch-import-export.service.ts
@@ -258,7 +258,7 @@ export class BatchImportExportService {
         } else {
             const fileDownloadedMessage = "File downloaded successfully. New filename: ";
             const filename = `export_${uuidv4()}.zip`;
-            exportedZip.writeZip(filename);
+            exportedZip.writeZip(filename, () => fs.chmodSync(filename, 0o600));
             logger.info(fileDownloadedMessage + filename);
         }
     }

--- a/src/commands/configuration-management/batch-import-export.service.ts
+++ b/src/commands/configuration-management/batch-import-export.service.ts
@@ -126,8 +126,10 @@ export class BatchImportExportService {
 
     public async batchImportPackages(sourcePath: string, overwrite: boolean, gitBranch: string, performValidation: boolean = false): Promise<void> {
         let sourceToBeImported: string;
+        let temporaryGitFolder: string;
         if (gitBranch) {
             sourceToBeImported = await this.gitService.pullFromBranch(gitBranch);
+            temporaryGitFolder = sourceToBeImported;
         } else {
             sourceToBeImported = sourcePath;
         }
@@ -147,8 +149,9 @@ export class BatchImportExportService {
         await this.studioService.processImportedPackages(configs, existingStudioPackages, studioManifests);
 
         if (gitBranch) {
-            fs.rmSync(sourceToBeImported);
+            fs.rmSync(temporaryGitFolder, { recursive: true });
         }
+        fs.rmSync(sourceToBeImported);
 
         const reportFileName = "config_import_report_" + uuidv4() + ".json";
         fileService.writeToFileWithGivenName(JSON.stringify(postPackageImportData), reportFileName);

--- a/src/commands/configuration-management/batch-import-export.service.ts
+++ b/src/commands/configuration-management/batch-import-export.service.ts
@@ -82,13 +82,13 @@ export class BatchImportExportService {
 
         let exportedVariables = await this.getVersionedVariablesForPackagesWithKeys(versionsByPackageKey);
         exportedVariables = this.studioService.fixConnectionVariables(exportedVariables);
-        exportedPackagesZip.addFile(BatchExportImportConstants.VARIABLES_FILE_NAME, Buffer.from(stringify(exportedVariables), "utf8"));
+        exportedPackagesZip.addFile(BatchExportImportConstants.VARIABLES_FILE_NAME, Buffer.from(stringify(exportedVariables), "utf8"), "", 0o600);
 
         const studioPackageKeys = manifest.filter(packageManifest => packageManifest.flavor === BatchExportImportConstants.STUDIO)
             .map(packageManifest => packageManifest.packageKey);
 
         const studioData = await this.studioService.getStudioPackageManifests(studioPackageKeys);
-        exportedPackagesZip.addFile(BatchExportImportConstants.STUDIO_FILE_NAME, Buffer.from(stringify(studioData), "utf8"));
+        exportedPackagesZip.addFile(BatchExportImportConstants.STUDIO_FILE_NAME, Buffer.from(stringify(studioData), "utf8"), "", 0o600);
 
         exportedPackagesZip.getEntries().forEach(entry => {
             if (entry.name.endsWith(BatchExportImportConstants.ZIP_EXTENSION)) {

--- a/src/commands/studio/manager/widget.manager-factory.ts
+++ b/src/commands/studio/manager/widget.manager-factory.ts
@@ -34,7 +34,7 @@ export class WidgetManagerFactory {
         const zip = new AdmZip();
         const zipFileName = path.resolve(process.cwd(), "output.zip");
         zip.addLocalFolder(path.resolve(process.cwd()));
-        zip.writeZip(zipFileName);
+        zip.writeZip(zipFileName, () => fs.chmodSync(zipFileName, 0o600));
         return fs.createReadStream(path.resolve(process.cwd(), "output.zip"));
     }
 

--- a/src/commands/studio/manager/widget.manager-factory.ts
+++ b/src/commands/studio/manager/widget.manager-factory.ts
@@ -5,6 +5,7 @@ import { FatalError, logger } from "../../../core/utils/logger";
 import { Context } from "../../../core/command/cli-context";
 import * as AdmZip from "adm-zip";
 import { parse } from "../../../core/utils/yaml";
+import { FileConstants } from "../../../core/utils/file.constants";
 
 export class WidgetManagerFactory {
 
@@ -34,7 +35,7 @@ export class WidgetManagerFactory {
         const zip = new AdmZip();
         const zipFileName = path.resolve(process.cwd(), "output.zip");
         zip.addLocalFolder(path.resolve(process.cwd()));
-        zip.writeZip(zipFileName, () => fs.chmodSync(zipFileName, 0o600));
+        zip.writeZip(zipFileName, () => fs.chmodSync(zipFileName, FileConstants.DEFAULT_FILE_PERMISSIONS));
         return fs.createReadStream(path.resolve(process.cwd(), "output.zip"));
     }
 

--- a/src/core/git-profile/git-profile.service.ts
+++ b/src/core/git-profile/git-profile.service.ts
@@ -63,6 +63,7 @@ export class GitProfileService {
         const newProfileFileName = this.constructProfileFileName(profile.name);
         fs.writeFileSync(path.resolve(this.gitProfileContainerPath, newProfileFileName), JSON.stringify(profile), {
             encoding: "utf-8",
+            mode: "0600",
         });
     }
 
@@ -88,12 +89,12 @@ export class GitProfileService {
     }
 
     private storeConfig(config: GitConfig): void {
-        fs.writeFileSync(this.configContainer, JSON.stringify(config), { encoding: "utf-8" });
+        fs.writeFileSync(this.configContainer, JSON.stringify(config), { encoding: "utf-8", mode: "0600" });
     }
 
     private createProfileContainerIfNotExists(): void {
         if (!fs.existsSync(this.gitProfileContainerPath)) {
-            fs.mkdirSync(this.gitProfileContainerPath);
+            fs.mkdirSync(this.gitProfileContainerPath, 0o700);
         }
     }
 

--- a/src/core/git-profile/git-profile.service.ts
+++ b/src/core/git-profile/git-profile.service.ts
@@ -4,6 +4,7 @@ import { FatalError, logger } from "../utils/logger";
 import os = require("os");
 import { AuthenticationType, GitProfile } from "./git-profile.interface";
 import { GitProfileValidator } from "./git-profile.validator";
+import { FileConstants } from "../utils/file.constants";
 
 export interface GitConfig {
     defaultProfile: string;
@@ -63,7 +64,7 @@ export class GitProfileService {
         const newProfileFileName = this.constructProfileFileName(profile.name);
         fs.writeFileSync(path.resolve(this.gitProfileContainerPath, newProfileFileName), JSON.stringify(profile), {
             encoding: "utf-8",
-            mode: "0600",
+            mode: FileConstants.DEFAULT_FILE_PERMISSIONS,
         });
     }
 
@@ -89,12 +90,12 @@ export class GitProfileService {
     }
 
     private storeConfig(config: GitConfig): void {
-        fs.writeFileSync(this.configContainer, JSON.stringify(config), { encoding: "utf-8", mode: "0600" });
+        fs.writeFileSync(this.configContainer, JSON.stringify(config), { encoding: "utf-8", mode: FileConstants.DEFAULT_FILE_PERMISSIONS });
     }
 
     private createProfileContainerIfNotExists(): void {
         if (!fs.existsSync(this.gitProfileContainerPath)) {
-            fs.mkdirSync(this.gitProfileContainerPath, 0o700);
+            fs.mkdirSync(this.gitProfileContainerPath, FileConstants.DEFAULT_FOLDER_PERMISSIONS);
         }
     }
 

--- a/src/core/git-profile/git/git.service.ts
+++ b/src/core/git-profile/git/git.service.ts
@@ -20,7 +20,7 @@ export class GitService {
         const repoUrl = this.getRepoUrl();
 
         const targetDir = path.join(os.tmpdir(), `content-cli-${uuid()}`);
-        fs.mkdirSync(targetDir, { recursive: true });
+        fs.mkdirSync(targetDir, { recursive: true, mode: 0o700 });
 
         const git = simpleGit();
         try {
@@ -36,7 +36,7 @@ export class GitService {
         this.validateGitProfileExistence();
 
         const workingDir = path.join(os.tmpdir(), `content-cli-${uuid()}`);
-        fs.mkdirSync(workingDir, { recursive: true });
+        fs.mkdirSync(workingDir, { recursive: true, mode: 0o700 });
 
         const repoUrl = this.getRepoUrl();
         const git = simpleGit();

--- a/src/core/git-profile/git/git.service.ts
+++ b/src/core/git-profile/git/git.service.ts
@@ -6,6 +6,7 @@ import { Context } from "../../command/cli-context";
 import { v4 as uuid } from "uuid";
 import { SimpleGit } from "simple-git/dist/typings/simple-git";
 import { GitProfile } from "../git-profile.interface";
+import { FileConstants } from "../../utils/file.constants";
 
 export class GitService {
 
@@ -20,7 +21,7 @@ export class GitService {
         const repoUrl = this.getRepoUrl();
 
         const targetDir = path.join(os.tmpdir(), `content-cli-${uuid()}`);
-        fs.mkdirSync(targetDir, { recursive: true, mode: 0o700 });
+        fs.mkdirSync(targetDir, { recursive: true, mode: FileConstants.DEFAULT_FOLDER_PERMISSIONS });
 
         const git = simpleGit();
         try {
@@ -36,7 +37,7 @@ export class GitService {
         this.validateGitProfileExistence();
 
         const workingDir = path.join(os.tmpdir(), `content-cli-${uuid()}`);
-        fs.mkdirSync(workingDir, { recursive: true, mode: 0o700 });
+        fs.mkdirSync(workingDir, { recursive: true, mode: FileConstants.DEFAULT_FOLDER_PERMISSIONS });
 
         const repoUrl = this.getRepoUrl();
         const git = simpleGit();

--- a/src/core/http/http-shared/base.manager.ts
+++ b/src/core/http/http-shared/base.manager.ts
@@ -103,13 +103,14 @@ export abstract class BaseManager {
 
     protected writeStreamToFile(data: any): string {
         const filename = this.getConfig().exportFileName;
-        fs.writeFileSync(filename, data);
+        fs.writeFileSync(filename, data, { mode: "0600" });
         return filename;
     }
 
     protected writeToFileWithGivenName(data: any, filename: string): void {
         fs.writeFileSync(path.resolve(process.cwd(), filename), this.getSerializedFileContent(data), {
             encoding: "utf-8",
+            mode: "0600",
         });
     }
 

--- a/src/core/http/http-shared/base.manager.ts
+++ b/src/core/http/http-shared/base.manager.ts
@@ -4,6 +4,7 @@ import { FatalError, logger } from "../../utils/logger";
 import { ManagerConfig } from "./manager-config.interface";
 import { HttpClient } from "../http-client";
 import { Context } from "../../command/cli-context";
+import { FileConstants } from "../../utils/file.constants";
 
 export abstract class BaseManager {
     private httpClient: () => HttpClient;
@@ -103,14 +104,14 @@ export abstract class BaseManager {
 
     protected writeStreamToFile(data: any): string {
         const filename = this.getConfig().exportFileName;
-        fs.writeFileSync(filename, data, { mode: "0600" });
+        fs.writeFileSync(filename, data, { mode: FileConstants.DEFAULT_FILE_PERMISSIONS });
         return filename;
     }
 
     protected writeToFileWithGivenName(data: any, filename: string): void {
         fs.writeFileSync(path.resolve(process.cwd(), filename), this.getSerializedFileContent(data), {
             encoding: "utf-8",
-            mode: "0600",
+            mode: FileConstants.DEFAULT_FILE_PERMISSIONS,
         });
     }
 

--- a/src/core/profile/profile.service.ts
+++ b/src/core/profile/profile.service.ts
@@ -117,6 +117,7 @@ export class ProfileService {
 
         fs.writeFileSync(path.resolve(this.profileContainerPath, newProfileFileName), JSON.stringify(profileToStore), {
             encoding: "utf-8",
+            mode: "0600",
         });
     }
 
@@ -134,12 +135,12 @@ export class ProfileService {
     }
 
     private storeConfig(config: Config): void {
-        fs.writeFileSync(this.configContainer, JSON.stringify(config), { encoding: "utf-8" });
+        fs.writeFileSync(this.configContainer, JSON.stringify(config), { encoding: "utf-8", mode: "0600" });
     }
 
     private createProfileContainerIfNotExists(): void {
         if (!fs.existsSync(this.profileContainerPath)) {
-            fs.mkdirSync(this.profileContainerPath);
+            fs.mkdirSync(this.profileContainerPath, 0o700);
         }
     }
 

--- a/src/core/profile/profile.service.ts
+++ b/src/core/profile/profile.service.ts
@@ -10,6 +10,7 @@ import { Client, Issuer } from "openid-client";
 import axios from "axios";
 import os = require("os");
 import { SecureSecretStorageService } from "./secret-storage.service";
+import { FileConstants } from "../utils/file.constants";
 
 const homedir = os.homedir();
 // use 5 seconds buffer to avoid rare cases when accessToken is just about to expire before the command is sent
@@ -117,7 +118,7 @@ export class ProfileService {
 
         fs.writeFileSync(path.resolve(this.profileContainerPath, newProfileFileName), JSON.stringify(profileToStore), {
             encoding: "utf-8",
-            mode: "0600",
+            mode: FileConstants.DEFAULT_FILE_PERMISSIONS,
         });
     }
 
@@ -135,12 +136,12 @@ export class ProfileService {
     }
 
     private storeConfig(config: Config): void {
-        fs.writeFileSync(this.configContainer, JSON.stringify(config), { encoding: "utf-8", mode: "0600" });
+        fs.writeFileSync(this.configContainer, JSON.stringify(config), { encoding: "utf-8", mode: FileConstants.DEFAULT_FILE_PERMISSIONS });
     }
 
     private createProfileContainerIfNotExists(): void {
         if (!fs.existsSync(this.profileContainerPath)) {
-            fs.mkdirSync(this.profileContainerPath, 0o700);
+            fs.mkdirSync(this.profileContainerPath, FileConstants.DEFAULT_FOLDER_PERMISSIONS);
         }
     }
 

--- a/src/core/utils/file-service.ts
+++ b/src/core/utils/file-service.ts
@@ -11,6 +11,7 @@ export class FileService {
     public writeToFileWithGivenName(data: any, filename: string): void {
         fs.writeFileSync(path.resolve(process.cwd(), filename), this.getSerializedFileContent(data), {
             encoding: "utf-8",
+            mode: "0600",
         });
     }
 
@@ -29,13 +30,13 @@ export class FileService {
 
     public extractExportedZipWithNestedZips(zipFile: AdmZip): string {
         const tempDir = path.join(os.tmpdir(), `${uuidv4()}`);
-        fs.mkdirSync(tempDir, { recursive: true });
 
         return this.extractExportedZipWithNestedZipsToDir(zipFile, tempDir);
     }
 
     public extractExportedZipWithNestedZipsToDir(zipFile: AdmZip, targetDir: string): string {
-        zipFile.extractAllTo(targetDir, true);
+        fs.mkdirSync(targetDir, { recursive: true, mode: 0o700 });
+        zipFile.extractAllTo(targetDir, true, true);
 
         const files = fs.readdirSync(targetDir);
         for (const file of files) {
@@ -44,8 +45,8 @@ export class FileService {
                 const nestedZip = new AdmZip(innerZipPath);
                 const nestedDir = innerZipPath.replace(/\.zip$/, "");
 
-                fs.mkdirSync(nestedDir, { recursive: true });
-                nestedZip.extractAllTo(nestedDir, true);
+                fs.mkdirSync(nestedDir, { recursive: true, mode: 0o700 });
+                nestedZip.extractAllTo(nestedDir, true, true);
                 fs.rmSync(innerZipPath); // Optionally remove the inner zip
             }
         }
@@ -73,17 +74,16 @@ export class FileService {
                 zip.addLocalFolder(fullPath);
                 const zippedBuffer = zip.toBuffer();
 
-                finalZip.addFile(`${file}.zip`, zippedBuffer);
+                finalZip.addFile(`${file}.zip`, zippedBuffer, "", 0x600);
             } else if (stat.isFile()) {
                 finalZip.addLocalFile(fullPath);
             }
         });
 
         const tempDir = path.join(os.tmpdir(), "content-cli-exports");
-        fs.mkdirSync(tempDir, { recursive: true });
-
+        fs.mkdirSync(tempDir, { recursive: true, mode: 0o700 });
         const zipFilePath = path.join(tempDir, `export_${uuidv4()}.zip`);
-        finalZip.writeZip(zipFilePath);
+        finalZip.writeZip(zipFilePath, () => fs.chmodSync(zipFilePath, 0o600));
 
         return zipFilePath;
     }

--- a/src/core/utils/file-service.ts
+++ b/src/core/utils/file-service.ts
@@ -4,6 +4,7 @@ import {FatalError, logger} from "./logger";
 import AdmZip = require("adm-zip");
 import { v4 as uuidv4 } from "uuid";
 import * as os from "node:os";
+import { FileConstants } from "./file.constants";
 
 export class FileService {
     public static readonly fileDownloadedMessage = "File downloaded successfully. New filename: ";
@@ -11,7 +12,7 @@ export class FileService {
     public writeToFileWithGivenName(data: any, filename: string): void {
         fs.writeFileSync(path.resolve(process.cwd(), filename), this.getSerializedFileContent(data), {
             encoding: "utf-8",
-            mode: "0600",
+            mode: FileConstants.DEFAULT_FILE_PERMISSIONS,
         });
     }
 
@@ -35,7 +36,7 @@ export class FileService {
     }
 
     public extractExportedZipWithNestedZipsToDir(zipFile: AdmZip, targetDir: string): string {
-        fs.mkdirSync(targetDir, { recursive: true, mode: 0o700 });
+        fs.mkdirSync(targetDir, { recursive: true, mode: FileConstants.DEFAULT_FOLDER_PERMISSIONS });
         zipFile.extractAllTo(targetDir, true, true);
 
         const files = fs.readdirSync(targetDir);
@@ -45,7 +46,7 @@ export class FileService {
                 const nestedZip = new AdmZip(innerZipPath);
                 const nestedDir = innerZipPath.replace(/\.zip$/, "");
 
-                fs.mkdirSync(nestedDir, { recursive: true, mode: 0o700 });
+                fs.mkdirSync(nestedDir, { recursive: true, mode: FileConstants.DEFAULT_FOLDER_PERMISSIONS });
                 nestedZip.extractAllTo(nestedDir, true, true);
                 fs.rmSync(innerZipPath); // Optionally remove the inner zip
             }
@@ -75,16 +76,16 @@ export class FileService {
                 zip.addLocalFolder(fullPath);
                 const zippedBuffer = zip.toBuffer();
 
-                finalZip.addFile(`${file}.zip`, zippedBuffer, "", 0x600);
+                finalZip.addFile(`${file}.zip`, zippedBuffer, "", FileConstants.DEFAULT_FILE_PERMISSIONS);
             } else if (stat.isFile()) {
                 finalZip.addLocalFile(fullPath);
             }
         });
 
         const tempDir = path.join(os.tmpdir(), "content-cli-exports");
-        fs.mkdirSync(tempDir, { recursive: true, mode: 0o700 });
+        fs.mkdirSync(tempDir, { recursive: true, mode: FileConstants.DEFAULT_FOLDER_PERMISSIONS });
         const zipFilePath = path.join(tempDir, `export_${uuidv4()}.zip`);
-        finalZip.writeZip(zipFilePath, () => fs.chmodSync(zipFilePath, 0o600));
+        finalZip.writeZip(zipFilePath, () => fs.chmodSync(zipFilePath, FileConstants.DEFAULT_FILE_PERMISSIONS));
 
         return zipFilePath;
     }
@@ -99,10 +100,10 @@ export class FileService {
         for (const file of files) {
             const filePath = path.join(targetDir, file);
             if (fs.statSync(filePath)?.isDirectory()) {
-                fs.chmodSync(filePath, 0o700);
+                fs.chmodSync(filePath, FileConstants.DEFAULT_FOLDER_PERMISSIONS);
                 this.restrictFilePermissions(filePath);
             } else {
-                fs.chmodSync(filePath, 0o600);
+                fs.chmodSync(filePath, FileConstants.DEFAULT_FILE_PERMISSIONS);
             }
         }
     }

--- a/src/core/utils/file-service.ts
+++ b/src/core/utils/file-service.ts
@@ -98,8 +98,7 @@ export class FileService {
         const files = fs.readdirSync(targetDir);
         for (const file of files) {
             const filePath = path.join(targetDir, file);
-            const fileStats = fs.statSync(filePath);
-            if (fileStats.isDirectory()) {
+            if (fs.statSync(filePath)?.isDirectory()) {
                 fs.chmodSync(filePath, 0o700);
                 this.restrictFilePermissions(filePath);
             } else {

--- a/src/core/utils/file-service.ts
+++ b/src/core/utils/file-service.ts
@@ -50,6 +50,7 @@ export class FileService {
                 fs.rmSync(innerZipPath); // Optionally remove the inner zip
             }
         }
+        this.restrictFilePermissions(targetDir);
         return targetDir;
     }
 
@@ -91,6 +92,20 @@ export class FileService {
 
     private getSerializedFileContent(data: any): string {
         return data;
+    }
+
+    private restrictFilePermissions(targetDir: string): void {
+        const files = fs.readdirSync(targetDir);
+        for (const file of files) {
+            const filePath = path.join(targetDir, file);
+            const fileStats = fs.statSync(filePath);
+            if (fileStats.isDirectory()) {
+                fs.chmodSync(filePath, 0o700);
+                this.restrictFilePermissions(filePath);
+            } else {
+                fs.chmodSync(filePath, 0o600);
+            }
+        }
     }
 }
 

--- a/src/core/utils/file.constants.ts
+++ b/src/core/utils/file.constants.ts
@@ -1,0 +1,4 @@
+export enum FileConstants {
+    DEFAULT_FILE_PERMISSIONS = 0o600,
+    DEFAULT_FOLDER_PERMISSIONS = 0o700
+}

--- a/src/core/utils/logger.ts
+++ b/src/core/utils/logger.ts
@@ -4,6 +4,7 @@ import { Logger } from "winston";
 import os = require("os");
 import * as path from "path";
 import * as fs from "fs";
+import { FileConstants } from "./file.constants";
 
 class CustomTransport extends Transport {
     constructor(opts: any) {
@@ -37,7 +38,7 @@ const maxSizeBytes = maxLogSizeMB * 1024 * 1024; // 3 MB in bytes
 // --- Ensure log directory exists ---
 try {
     if (!fs.existsSync(logDir)) {
-        fs.mkdirSync(logDir, { recursive: true, mode: 0o700 });
+        fs.mkdirSync(logDir, { recursive: true, mode: FileConstants.DEFAULT_FOLDER_PERMISSIONS });
     }
 } catch (error) {
     console.error(`Error creating log directory: ${logDir}`, error);

--- a/src/core/utils/logger.ts
+++ b/src/core/utils/logger.ts
@@ -37,7 +37,7 @@ const maxSizeBytes = maxLogSizeMB * 1024 * 1024; // 3 MB in bytes
 // --- Ensure log directory exists ---
 try {
     if (!fs.existsSync(logDir)) {
-        fs.mkdirSync(logDir, { recursive: true });
+        fs.mkdirSync(logDir, { recursive: true, mode: 0o700 });
     }
 } catch (error) {
     console.error(`Error creating log directory: ${logDir}`, error);

--- a/tests/commands/action-flows/analyze-action-flows.spec.ts
+++ b/tests/commands/action-flows/analyze-action-flows.spec.ts
@@ -64,7 +64,7 @@ describe("Analyze action-flows", () => {
         expect(loggingTestTransport.logMessages[0].message).toContain(FileService.fileDownloadedMessage);
         const expectedFileName = loggingTestTransport.logMessages[0].message.split(FileService.fileDownloadedMessage)[1];
 
-        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), JSON.stringify(mockAnalyzeResponse, null, 4), { encoding: "utf-8" });
+        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), JSON.stringify(mockAnalyzeResponse, null, 4), { encoding: "utf-8", mode: "0600" });
         expect(mockedAxiosInstance.get).toHaveBeenCalledWith(`https://myTeam.celonis.cloud/ems-automation/api/root/${packageId}/export/assets/analyze`, expect.anything());
     });
 });

--- a/tests/commands/action-flows/analyze-action-flows.spec.ts
+++ b/tests/commands/action-flows/analyze-action-flows.spec.ts
@@ -64,7 +64,7 @@ describe("Analyze action-flows", () => {
         expect(loggingTestTransport.logMessages[0].message).toContain(FileService.fileDownloadedMessage);
         const expectedFileName = loggingTestTransport.logMessages[0].message.split(FileService.fileDownloadedMessage)[1];
 
-        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), JSON.stringify(mockAnalyzeResponse, null, 4), { encoding: "utf-8", mode: "0600" });
+        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), JSON.stringify(mockAnalyzeResponse, null, 4), { encoding: "utf-8", mode: 0o600 });
         expect(mockedAxiosInstance.get).toHaveBeenCalledWith(`https://myTeam.celonis.cloud/ems-automation/api/root/${packageId}/export/assets/analyze`, expect.anything());
     });
 });

--- a/tests/commands/action-flows/import-action-flows.spec.ts
+++ b/tests/commands/action-flows/import-action-flows.spec.ts
@@ -50,7 +50,7 @@ describe("Import action-flows", () => {
         expect(loggingTestTransport.logMessages[0].message).toContain(FileService.fileDownloadedMessage);
         const expectedFileName = loggingTestTransport.logMessages[0].message.split(FileService.fileDownloadedMessage)[1];
 
-        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), JSON.stringify(mockImportResponse, null, 4), { encoding: "utf-8", mode: "0600" });
+        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), JSON.stringify(mockImportResponse, null, 4), { encoding: "utf-8", mode: 0o600 });
         expect(mockedAxiosInstance.post).toHaveBeenCalledWith(`https://myTeam.celonis.cloud/ems-automation/api/root/${packageId}/import/assets`, expect.anything(), expect.anything());
     });
 });

--- a/tests/commands/action-flows/import-action-flows.spec.ts
+++ b/tests/commands/action-flows/import-action-flows.spec.ts
@@ -50,7 +50,7 @@ describe("Import action-flows", () => {
         expect(loggingTestTransport.logMessages[0].message).toContain(FileService.fileDownloadedMessage);
         const expectedFileName = loggingTestTransport.logMessages[0].message.split(FileService.fileDownloadedMessage)[1];
 
-        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), JSON.stringify(mockImportResponse, null, 4), { encoding: "utf-8" });
+        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), JSON.stringify(mockImportResponse, null, 4), { encoding: "utf-8", mode: "0600" });
         expect(mockedAxiosInstance.post).toHaveBeenCalledWith(`https://myTeam.celonis.cloud/ems-automation/api/root/${packageId}/import/assets`, expect.anything(), expect.anything());
     });
 });

--- a/tests/commands/asset-registry/asset-registry-examples.spec.ts
+++ b/tests/commands/asset-registry/asset-registry-examples.spec.ts
@@ -31,7 +31,7 @@ describe("Asset registry examples", () => {
         expect(mockWriteFileSync).toHaveBeenCalledWith(
             path.resolve(process.cwd(), expectedFileName),
             expect.any(String),
-            { encoding: "utf-8" }
+            { encoding: "utf-8", mode: 0o600 }
         );
 
         const written = JSON.parse(mockWriteFileSync.mock.calls[0][1]);

--- a/tests/commands/asset-registry/asset-registry-get.spec.ts
+++ b/tests/commands/asset-registry/asset-registry-get.spec.ts
@@ -50,7 +50,7 @@ describe("Asset registry get", () => {
         expect(mockWriteFileSync).toHaveBeenCalledWith(
             path.resolve(process.cwd(), expectedFileName),
             expect.any(String),
-            { encoding: "utf-8" }
+            { encoding: "utf-8", mode: 0o600 }
         );
 
         const written = JSON.parse(mockWriteFileSync.mock.calls[0][1]) as AssetRegistryDescriptor;

--- a/tests/commands/asset-registry/asset-registry-list.spec.ts
+++ b/tests/commands/asset-registry/asset-registry-list.spec.ts
@@ -64,7 +64,7 @@ describe("Asset registry list", () => {
         expect(mockWriteFileSync).toHaveBeenCalledWith(
             path.resolve(process.cwd(), expectedFileName),
             expect.any(String),
-            { encoding: "utf-8" }
+            { encoding: "utf-8", mode: 0o600 }
         );
 
         const written = JSON.parse(mockWriteFileSync.mock.calls[0][1]) as AssetRegistryMetadata;

--- a/tests/commands/asset-registry/asset-registry-methodology.spec.ts
+++ b/tests/commands/asset-registry/asset-registry-methodology.spec.ts
@@ -34,7 +34,7 @@ describe("Asset registry methodology", () => {
         expect(mockWriteFileSync).toHaveBeenCalledWith(
             path.resolve(process.cwd(), expectedFileName),
             expect.any(String),
-            { encoding: "utf-8" }
+            { encoding: "utf-8", mode: 0o600 }
         );
 
         const written = JSON.parse(mockWriteFileSync.mock.calls[0][1]);

--- a/tests/commands/asset-registry/asset-registry-schema.spec.ts
+++ b/tests/commands/asset-registry/asset-registry-schema.spec.ts
@@ -37,7 +37,7 @@ describe("Asset registry schema", () => {
         expect(mockWriteFileSync).toHaveBeenCalledWith(
             path.resolve(process.cwd(), expectedFileName),
             expect.any(String),
-            { encoding: "utf-8" }
+            { encoding: "utf-8", mode: 0o600 }
         );
 
         const written = JSON.parse(mockWriteFileSync.mock.calls[0][1]);

--- a/tests/commands/configuration-management/config-diff.spec.ts
+++ b/tests/commands/configuration-management/config-diff.spec.ts
@@ -138,7 +138,7 @@ describe("Config diff", () => {
 
         const expectedFileName = loggingTestTransport.logMessages[0].message.split(FileService.fileDownloadedMessage)[1];
 
-        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), expect.any(String), {encoding: "utf-8"});
+        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), expect.any(String), {encoding: "utf-8", mode: "0600"});
         const exportedPackageDiffTransport = JSON.parse(mockWriteFileSync.mock.calls[0][1]) as PackageDiffTransport[];
         expect(exportedPackageDiffTransport.length).toBe(1);
 
@@ -169,7 +169,7 @@ describe("Config diff", () => {
 
         const expectedFileName = loggingTestTransport.logMessages[0].message.split(FileService.fileDownloadedMessage)[1];
 
-        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), expect.any(String), {encoding: "utf-8"});
+        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), expect.any(String), {encoding: "utf-8", mode: "0600"});
         const exportedPackageDiffTransport = JSON.parse(mockWriteFileSync.mock.calls[0][1]) as PackageDiffTransport[];
         expect(exportedPackageDiffTransport.length).toBe(1);
 

--- a/tests/commands/configuration-management/config-diff.spec.ts
+++ b/tests/commands/configuration-management/config-diff.spec.ts
@@ -138,7 +138,7 @@ describe("Config diff", () => {
 
         const expectedFileName = loggingTestTransport.logMessages[0].message.split(FileService.fileDownloadedMessage)[1];
 
-        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), expect.any(String), {encoding: "utf-8", mode: "0600"});
+        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), expect.any(String), {encoding: "utf-8", mode: 0o600});
         const exportedPackageDiffTransport = JSON.parse(mockWriteFileSync.mock.calls[0][1]) as PackageDiffTransport[];
         expect(exportedPackageDiffTransport.length).toBe(1);
 
@@ -169,7 +169,7 @@ describe("Config diff", () => {
 
         const expectedFileName = loggingTestTransport.logMessages[0].message.split(FileService.fileDownloadedMessage)[1];
 
-        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), expect.any(String), {encoding: "utf-8", mode: "0600"});
+        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), expect.any(String), {encoding: "utf-8", mode: 0o600});
         const exportedPackageDiffTransport = JSON.parse(mockWriteFileSync.mock.calls[0][1]) as PackageDiffTransport[];
         expect(exportedPackageDiffTransport.length).toBe(1);
 

--- a/tests/commands/configuration-management/config-export.spec.ts
+++ b/tests/commands/configuration-management/config-export.spec.ts
@@ -132,6 +132,9 @@ describe("Config export", () => {
         const loggedResponse = loggingTestTransport.logMessages[0].message.trim();
 
         expect(loggedResponse).toEqual("Successfully exported packages to branch: my-branch");
+        expect(fs.chmodSync).toHaveBeenCalledWith(expect.stringMatching(/manifest\.json/), 0o600);
+        expect(fs.chmodSync).toHaveBeenCalledWith(expect.stringMatching(/studio\.json/), 0o600);
+        expect(fs.chmodSync).toHaveBeenCalledWith(expect.stringMatching(/variables\.json/), 0o600);
     })
 
     it("Should export studio file for studio packageKeys and versions", async () => {

--- a/tests/commands/configuration-management/config-import.spec.ts
+++ b/tests/commands/configuration-management/config-import.spec.ts
@@ -65,7 +65,7 @@ describe("Config import", () => {
         await new ConfigCommandService(testContext).batchImportPackages("./export_file.zip", null, overwrite, null);
 
         const expectedFileName = loggingTestTransport.logMessages[0].message.split(LOG_MESSAGE)[1];
-        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), JSON.stringify(importResponse), {encoding: "utf-8", mode: "0600"});
+        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), JSON.stringify(importResponse), {encoding: "utf-8", mode: 0o600});
     })
 
     it.each([
@@ -98,7 +98,7 @@ describe("Config import", () => {
         await new ConfigCommandService(testContext).batchImportPackages(null, null, overwrite, branchName);
 
         const expectedFileName = loggingTestTransport.logMessages[0].message.split(LOG_MESSAGE)[1];
-        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), JSON.stringify(importResponse), {encoding: "utf-8", mode: "0600"});
+        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), JSON.stringify(importResponse), {encoding: "utf-8", mode: 0o600});
     })
 
     it.each([
@@ -137,7 +137,7 @@ describe("Config import", () => {
             await new ConfigCommandService(testContext).batchImportPackages(null, null, overwrite, branchName);
 
             const expectedFileName = loggingTestTransport.logMessages[0].message.split(LOG_MESSAGE)[1];
-            expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), JSON.stringify(importResponse), {encoding: "utf-8", mode: "0600"});
+            expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), JSON.stringify(importResponse), {encoding: "utf-8", mode: 0o600});
         })
 
     it("Should batch import configs & map space ID as specified in manifest file for Studio Packages", async () => {
@@ -181,7 +181,7 @@ describe("Config import", () => {
         await new ConfigCommandService(testContext).batchImportPackages("./export_file.zip", null, true, null);
 
         const expectedFileName = loggingTestTransport.logMessages[0].message.split(LOG_MESSAGE)[1];
-        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), JSON.stringify(importResponse), {encoding: "utf-8", mode: "0600"});
+        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), JSON.stringify(importResponse), {encoding: "utf-8", mode: 0o600});
     })
 
     it("Should fail to map space ID as the space id specified in manifest file cannot be found", async () => {
@@ -252,7 +252,7 @@ describe("Config import", () => {
 
         await new ConfigCommandService(testContext).batchImportPackages("./export_file.zip", null, true, null);
         const expectedFileName = loggingTestTransport.logMessages[0].message.split(LOG_MESSAGE)[1];
-        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), JSON.stringify(importResponse), {encoding: "utf-8", mode: "0600"});
+        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), JSON.stringify(importResponse), {encoding: "utf-8", mode: 0o600});
         expect(mockedAxiosInstance.put).toHaveBeenCalledWith("https://myTeam.celonis.cloud/package-manager/api/packages/node-id/move/spaceId", expect.anything(), expect.anything());
     })
 
@@ -290,7 +290,7 @@ describe("Config import", () => {
         await new ConfigCommandService(testContext).batchImportPackages("./export_file.zip", null, true, null);
 
         const expectedFileName = loggingTestTransport.logMessages[0].message.split(LOG_MESSAGE)[1];
-        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), JSON.stringify(importResponse), {encoding: "utf-8", mode: "0600"});
+        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), JSON.stringify(importResponse), {encoding: "utf-8", mode: 0o600});
         expect(mockedAxiosInstance.put).not.toHaveBeenCalledWith("https://myTeam.celonis.cloud/package-manager/api/spaces", expect.anything(), expect.anything());
     })
 
@@ -337,7 +337,7 @@ describe("Config import", () => {
         await new ConfigCommandService(testContext).batchImportPackages("./export_file.zip", null, true, null);
 
         const expectedFileName = loggingTestTransport.logMessages[0].message.split(LOG_MESSAGE)[1];
-        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), JSON.stringify(importResponse), {encoding: "utf-8", mode: "0600"});
+        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), JSON.stringify(importResponse), {encoding: "utf-8", mode: 0o600});
         expect(mockedAxiosInstance.put).not.toHaveBeenCalledWith("https://myTeam.celonis.cloud/package-manager/api/spaces", expect.anything(), expect.anything());
     })
 
@@ -416,7 +416,7 @@ describe("Config import", () => {
         await new ConfigCommandService(testContext).batchImportPackages("./export_file.zip", null, true, null);
 
         const expectedFileName = loggingTestTransport.logMessages[0].message.split(LOG_MESSAGE)[1];
-        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), JSON.stringify(importResponse), {encoding: "utf-8", mode: "0600"});
+        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), JSON.stringify(importResponse), {encoding: "utf-8", mode: 0o600});
 
         expect(mockedPostRequestBodyByUrl.get(assignVariablesUrl)).toEqual(JSON.stringify([variableAssignment]));
     })

--- a/tests/commands/configuration-management/config-import.spec.ts
+++ b/tests/commands/configuration-management/config-import.spec.ts
@@ -65,7 +65,7 @@ describe("Config import", () => {
         await new ConfigCommandService(testContext).batchImportPackages("./export_file.zip", null, overwrite, null);
 
         const expectedFileName = loggingTestTransport.logMessages[0].message.split(LOG_MESSAGE)[1];
-        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), JSON.stringify(importResponse), {encoding: "utf-8"});
+        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), JSON.stringify(importResponse), {encoding: "utf-8", mode: "0600"});
     })
 
     it.each([
@@ -98,7 +98,7 @@ describe("Config import", () => {
         await new ConfigCommandService(testContext).batchImportPackages(null, null, overwrite, branchName);
 
         const expectedFileName = loggingTestTransport.logMessages[0].message.split(LOG_MESSAGE)[1];
-        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), JSON.stringify(importResponse), {encoding: "utf-8"});
+        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), JSON.stringify(importResponse), {encoding: "utf-8", mode: "0600"});
     })
 
     it.each([
@@ -137,7 +137,7 @@ describe("Config import", () => {
             await new ConfigCommandService(testContext).batchImportPackages(null, null, overwrite, branchName);
 
             const expectedFileName = loggingTestTransport.logMessages[0].message.split(LOG_MESSAGE)[1];
-            expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), JSON.stringify(importResponse), {encoding: "utf-8"});
+            expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), JSON.stringify(importResponse), {encoding: "utf-8", mode: "0600"});
         })
 
     it("Should batch import configs & map space ID as specified in manifest file for Studio Packages", async () => {
@@ -181,7 +181,7 @@ describe("Config import", () => {
         await new ConfigCommandService(testContext).batchImportPackages("./export_file.zip", null, true, null);
 
         const expectedFileName = loggingTestTransport.logMessages[0].message.split(LOG_MESSAGE)[1];
-        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), JSON.stringify(importResponse), {encoding: "utf-8"});
+        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), JSON.stringify(importResponse), {encoding: "utf-8", mode: "0600"});
     })
 
     it("Should fail to map space ID as the space id specified in manifest file cannot be found", async () => {
@@ -252,7 +252,7 @@ describe("Config import", () => {
 
         await new ConfigCommandService(testContext).batchImportPackages("./export_file.zip", null, true, null);
         const expectedFileName = loggingTestTransport.logMessages[0].message.split(LOG_MESSAGE)[1];
-        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), JSON.stringify(importResponse), {encoding: "utf-8"});
+        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), JSON.stringify(importResponse), {encoding: "utf-8", mode: "0600"});
         expect(mockedAxiosInstance.put).toHaveBeenCalledWith("https://myTeam.celonis.cloud/package-manager/api/packages/node-id/move/spaceId", expect.anything(), expect.anything());
     })
 
@@ -290,7 +290,7 @@ describe("Config import", () => {
         await new ConfigCommandService(testContext).batchImportPackages("./export_file.zip", null, true, null);
 
         const expectedFileName = loggingTestTransport.logMessages[0].message.split(LOG_MESSAGE)[1];
-        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), JSON.stringify(importResponse), {encoding: "utf-8"});
+        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), JSON.stringify(importResponse), {encoding: "utf-8", mode: "0600"});
         expect(mockedAxiosInstance.put).not.toHaveBeenCalledWith("https://myTeam.celonis.cloud/package-manager/api/spaces", expect.anything(), expect.anything());
     })
 
@@ -337,7 +337,7 @@ describe("Config import", () => {
         await new ConfigCommandService(testContext).batchImportPackages("./export_file.zip", null, true, null);
 
         const expectedFileName = loggingTestTransport.logMessages[0].message.split(LOG_MESSAGE)[1];
-        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), JSON.stringify(importResponse), {encoding: "utf-8"});
+        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), JSON.stringify(importResponse), {encoding: "utf-8", mode: "0600"});
         expect(mockedAxiosInstance.put).not.toHaveBeenCalledWith("https://myTeam.celonis.cloud/package-manager/api/spaces", expect.anything(), expect.anything());
     })
 
@@ -416,7 +416,7 @@ describe("Config import", () => {
         await new ConfigCommandService(testContext).batchImportPackages("./export_file.zip", null, true, null);
 
         const expectedFileName = loggingTestTransport.logMessages[0].message.split(LOG_MESSAGE)[1];
-        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), JSON.stringify(importResponse), {encoding: "utf-8"});
+        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), JSON.stringify(importResponse), {encoding: "utf-8", mode: "0600"});
 
         expect(mockedPostRequestBodyByUrl.get(assignVariablesUrl)).toEqual(JSON.stringify([variableAssignment]));
     })

--- a/tests/commands/configuration-management/config-list-variables.spec.ts
+++ b/tests/commands/configuration-management/config-list-variables.spec.ts
@@ -132,7 +132,7 @@ describe("Config listVariables", () => {
         expect(loggingTestTransport.logMessages[0].message).toContain(FileService.fileDownloadedMessage);
 
         const expectedFileName = loggingTestTransport.logMessages[0].message.split(FileService.fileDownloadedMessage)[1];
-        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), JSON.stringify(fixedVariableManifests), {encoding: "utf-8"});
+        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), JSON.stringify(fixedVariableManifests), {encoding: "utf-8", mode: "0600"});
 
         const variableExportRequest = parse(mockedPostRequestBodyByUrl.get("https://myTeam.celonis.cloud/package-manager/api/core/packages/export/batch/variables-with-assignments"));
         expect(variableExportRequest).toEqual(packageKeyAndVersionPairs);
@@ -163,7 +163,7 @@ describe("Config listVariables", () => {
         expect(loggingTestTransport.logMessages[0].message).toContain(FileService.fileDownloadedMessage);
 
         const expectedFileName = loggingTestTransport.logMessages[0].message.split(FileService.fileDownloadedMessage)[1];
-        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), JSON.stringify(fixedVariableManifests), {encoding: "utf-8"});
+        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), JSON.stringify(fixedVariableManifests), {encoding: "utf-8", mode: "0600"});
 
         const variableExportRequest = parse(mockedPostRequestBodyByUrl.get("https://myTeam.celonis.cloud/package-manager/api/core/packages/export/batch/variables-with-assignments"));
         expect(variableExportRequest).toEqual(packageKeyAndVersionPairs);
@@ -226,7 +226,7 @@ describe("Config listVariables", () => {
             expect(mockWriteFileSync).toHaveBeenCalledWith(
                 path.resolve(process.cwd(), expectedFileName),
                 JSON.stringify(pkgAOnlyResponse),
-                {encoding: "utf-8"}
+                {encoding: "utf-8", mode: "0600"}
             );
 
             const postBody = parse<string[]>(mockedPostRequestBodyByUrl.get(url));

--- a/tests/commands/configuration-management/config-list-variables.spec.ts
+++ b/tests/commands/configuration-management/config-list-variables.spec.ts
@@ -132,7 +132,7 @@ describe("Config listVariables", () => {
         expect(loggingTestTransport.logMessages[0].message).toContain(FileService.fileDownloadedMessage);
 
         const expectedFileName = loggingTestTransport.logMessages[0].message.split(FileService.fileDownloadedMessage)[1];
-        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), JSON.stringify(fixedVariableManifests), {encoding: "utf-8", mode: "0600"});
+        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), JSON.stringify(fixedVariableManifests), {encoding: "utf-8", mode: 0o600});
 
         const variableExportRequest = parse(mockedPostRequestBodyByUrl.get("https://myTeam.celonis.cloud/package-manager/api/core/packages/export/batch/variables-with-assignments"));
         expect(variableExportRequest).toEqual(packageKeyAndVersionPairs);
@@ -163,7 +163,7 @@ describe("Config listVariables", () => {
         expect(loggingTestTransport.logMessages[0].message).toContain(FileService.fileDownloadedMessage);
 
         const expectedFileName = loggingTestTransport.logMessages[0].message.split(FileService.fileDownloadedMessage)[1];
-        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), JSON.stringify(fixedVariableManifests), {encoding: "utf-8", mode: "0600"});
+        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), JSON.stringify(fixedVariableManifests), {encoding: "utf-8", mode: 0o600});
 
         const variableExportRequest = parse(mockedPostRequestBodyByUrl.get("https://myTeam.celonis.cloud/package-manager/api/core/packages/export/batch/variables-with-assignments"));
         expect(variableExportRequest).toEqual(packageKeyAndVersionPairs);
@@ -226,7 +226,7 @@ describe("Config listVariables", () => {
             expect(mockWriteFileSync).toHaveBeenCalledWith(
                 path.resolve(process.cwd(), expectedFileName),
                 JSON.stringify(pkgAOnlyResponse),
-                {encoding: "utf-8", mode: "0600"}
+                {encoding: "utf-8", mode: 0o600}
             );
 
             const postBody = parse<string[]>(mockedPostRequestBodyByUrl.get(url));

--- a/tests/commands/configuration-management/config-list.spec.ts
+++ b/tests/commands/configuration-management/config-list.spec.ts
@@ -53,7 +53,7 @@ describe("Config list", () => {
 
         const expectedFileName = loggingTestTransport.logMessages[0].message.split(FileService.fileDownloadedMessage)[1];
 
-        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), expect.any(String), {encoding: "utf-8", mode: "0600"});
+        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), expect.any(String), {encoding: "utf-8", mode: 0o600});
 
         const exportedTransports = JSON.parse(mockWriteFileSync.mock.calls[0][1]) as PackageExportTransport[];
         expect(exportedTransports.length).toBe(2);
@@ -99,7 +99,7 @@ describe("Config list", () => {
 
         const expectedFileName = loggingTestTransport.logMessages[0].message.split(FileService.fileDownloadedMessage)[1];
 
-        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), expect.any(String), {encoding: "utf-8", mode: "0600"});
+        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), expect.any(String), {encoding: "utf-8", mode: 0o600});
 
         const exportedTransports = JSON.parse(mockWriteFileSync.mock.calls[0][1]) as PackageExportTransport[];
         expect(exportedTransports.length).toBe(2);
@@ -124,7 +124,7 @@ describe("Config list", () => {
 
         const expectedFileName = loggingTestTransport.logMessages[0].message.split(FileService.fileDownloadedMessage)[1];
 
-        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), expect.any(String), {encoding: "utf-8", mode: "0600"});
+        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), expect.any(String), {encoding: "utf-8", mode: 0o600});
 
         const exportedTransports = JSON.parse(mockWriteFileSync.mock.calls[0][1]) as PackageExportTransport[];
         expect(exportedTransports.length).toBe(2);
@@ -170,7 +170,7 @@ describe("Config list", () => {
 
         const expectedFileName = loggingTestTransport.logMessages[0].message.split(FileService.fileDownloadedMessage)[1];
 
-        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), expect.any(String), {encoding: "utf-8", mode: "0600"});
+        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), expect.any(String), {encoding: "utf-8", mode: 0o600});
 
         const exportedTransports = JSON.parse(mockWriteFileSync.mock.calls[0][1]) as PackageExportTransport[];
         expect(exportedTransports.length).toBe(2);
@@ -208,7 +208,7 @@ describe("Config list", () => {
 
         const expectedFileName = loggingTestTransport.logMessages[0].message.split(FileService.fileDownloadedMessage)[1];
 
-        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), expect.any(String), {encoding: "utf-8", mode: "0600"});
+        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), expect.any(String), {encoding: "utf-8", mode: 0o600});
 
         const exportedTransports = JSON.parse(mockWriteFileSync.mock.calls[0][1]) as PackageExportTransport[];
         expect(exportedTransports.length).toBe(2);
@@ -263,7 +263,7 @@ describe("Config list", () => {
 
         const expectedFileName = loggingTestTransport.logMessages[0].message.split(FileService.fileDownloadedMessage)[1];
 
-        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), expect.any(String), {encoding: "utf-8", mode: "0600"});
+        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), expect.any(String), {encoding: "utf-8", mode: 0o600});
 
         const exportedTransports = JSON.parse(mockWriteFileSync.mock.calls[0][1]) as PackageExportTransport[];
         expect(exportedTransports.length).toBe(2);

--- a/tests/commands/configuration-management/config-list.spec.ts
+++ b/tests/commands/configuration-management/config-list.spec.ts
@@ -53,7 +53,7 @@ describe("Config list", () => {
 
         const expectedFileName = loggingTestTransport.logMessages[0].message.split(FileService.fileDownloadedMessage)[1];
 
-        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), expect.any(String), {encoding: "utf-8"});
+        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), expect.any(String), {encoding: "utf-8", mode: "0600"});
 
         const exportedTransports = JSON.parse(mockWriteFileSync.mock.calls[0][1]) as PackageExportTransport[];
         expect(exportedTransports.length).toBe(2);
@@ -99,7 +99,7 @@ describe("Config list", () => {
 
         const expectedFileName = loggingTestTransport.logMessages[0].message.split(FileService.fileDownloadedMessage)[1];
 
-        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), expect.any(String), {encoding: "utf-8"});
+        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), expect.any(String), {encoding: "utf-8", mode: "0600"});
 
         const exportedTransports = JSON.parse(mockWriteFileSync.mock.calls[0][1]) as PackageExportTransport[];
         expect(exportedTransports.length).toBe(2);
@@ -124,7 +124,7 @@ describe("Config list", () => {
 
         const expectedFileName = loggingTestTransport.logMessages[0].message.split(FileService.fileDownloadedMessage)[1];
 
-        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), expect.any(String), {encoding: "utf-8"});
+        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), expect.any(String), {encoding: "utf-8", mode: "0600"});
 
         const exportedTransports = JSON.parse(mockWriteFileSync.mock.calls[0][1]) as PackageExportTransport[];
         expect(exportedTransports.length).toBe(2);
@@ -170,7 +170,7 @@ describe("Config list", () => {
 
         const expectedFileName = loggingTestTransport.logMessages[0].message.split(FileService.fileDownloadedMessage)[1];
 
-        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), expect.any(String), {encoding: "utf-8"});
+        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), expect.any(String), {encoding: "utf-8", mode: "0600"});
 
         const exportedTransports = JSON.parse(mockWriteFileSync.mock.calls[0][1]) as PackageExportTransport[];
         expect(exportedTransports.length).toBe(2);
@@ -208,7 +208,7 @@ describe("Config list", () => {
 
         const expectedFileName = loggingTestTransport.logMessages[0].message.split(FileService.fileDownloadedMessage)[1];
 
-        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), expect.any(String), {encoding: "utf-8"});
+        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), expect.any(String), {encoding: "utf-8", mode: "0600"});
 
         const exportedTransports = JSON.parse(mockWriteFileSync.mock.calls[0][1]) as PackageExportTransport[];
         expect(exportedTransports.length).toBe(2);
@@ -263,7 +263,7 @@ describe("Config list", () => {
 
         const expectedFileName = loggingTestTransport.logMessages[0].message.split(FileService.fileDownloadedMessage)[1];
 
-        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), expect.any(String), {encoding: "utf-8"});
+        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), expect.any(String), {encoding: "utf-8", mode: "0600"});
 
         const exportedTransports = JSON.parse(mockWriteFileSync.mock.calls[0][1]) as PackageExportTransport[];
         expect(exportedTransports.length).toBe(2);

--- a/tests/commands/configuration-management/config-metadata-export.spec.ts
+++ b/tests/commands/configuration-management/config-metadata-export.spec.ts
@@ -53,7 +53,7 @@ describe("Config metadata export", () => {
 
         const expectedFileName = loggingTestTransport.logMessages[0].message.split(FileService.fileDownloadedMessage)[1];
 
-        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), expect.any(String), {encoding: "utf-8", mode: "0600"});
+        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), expect.any(String), {encoding: "utf-8", mode: 0o600});
         const exportedPackagesMetadataTransports = JSON.parse(mockWriteFileSync.mock.calls[0][1]) as PackageMetadataExportTransport[];
         expect(exportedPackagesMetadataTransports.length).toBe(2);
 

--- a/tests/commands/configuration-management/config-metadata-export.spec.ts
+++ b/tests/commands/configuration-management/config-metadata-export.spec.ts
@@ -53,7 +53,7 @@ describe("Config metadata export", () => {
 
         const expectedFileName = loggingTestTransport.logMessages[0].message.split(FileService.fileDownloadedMessage)[1];
 
-        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), expect.any(String), {encoding: "utf-8"});
+        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), expect.any(String), {encoding: "utf-8", mode: "0600"});
         const exportedPackagesMetadataTransports = JSON.parse(mockWriteFileSync.mock.calls[0][1]) as PackageMetadataExportTransport[];
         expect(exportedPackagesMetadataTransports.length).toBe(2);
 

--- a/tests/commands/configuration-management/config-node-dependency.spec.ts
+++ b/tests/commands/configuration-management/config-node-dependency.spec.ts
@@ -57,7 +57,7 @@ describe("Node Dependencies", () => {
         expect(mockWriteFileSync).toHaveBeenCalledWith(
             path.resolve(process.cwd(), expectedFileName),
             expect.any(String),
-            { encoding: "utf-8", mode: "0600" }
+            { encoding: "utf-8", mode: 0o600 }
         );
 
         const dependenciesTransport = JSON.parse(mockWriteFileSync.mock.calls[0][1]) as NodeDependencyTransport[];
@@ -94,7 +94,7 @@ describe("Node Dependencies", () => {
         expect(mockWriteFileSync).toHaveBeenCalledWith(
             path.resolve(process.cwd(), expectedFileName),
             expect.any(String),
-            { encoding: "utf-8", mode: "0600" }
+            { encoding: "utf-8", mode: 0o600 }
         );
 
         const dependenciesTransport = JSON.parse(mockWriteFileSync.mock.calls[0][1]) as NodeDependencyTransport[];
@@ -152,7 +152,7 @@ describe("Node Dependencies", () => {
             expect(mockWriteFileSync).toHaveBeenCalledWith(
                 path.resolve(process.cwd(), expectedFileName),
                 expect.any(String),
-                { encoding: "utf-8", mode: "0600" }
+                { encoding: "utf-8", mode: 0o600 }
             );
 
             const dependenciesTransport = JSON.parse(mockWriteFileSync.mock.calls[0][1]) as NodeDependencyTransport[];
@@ -189,7 +189,7 @@ describe("Node Dependencies", () => {
             expect(mockWriteFileSync).toHaveBeenCalledWith(
                 path.resolve(process.cwd(), expectedFileName),
                 expect.any(String),
-                { encoding: "utf-8", mode: "0600" }
+                { encoding: "utf-8", mode: 0o600 }
             );
 
             const dependenciesTransport = JSON.parse(mockWriteFileSync.mock.calls[0][1]) as NodeDependencyTransport[];

--- a/tests/commands/configuration-management/config-node-dependency.spec.ts
+++ b/tests/commands/configuration-management/config-node-dependency.spec.ts
@@ -57,7 +57,7 @@ describe("Node Dependencies", () => {
         expect(mockWriteFileSync).toHaveBeenCalledWith(
             path.resolve(process.cwd(), expectedFileName),
             expect.any(String),
-            { encoding: "utf-8" }
+            { encoding: "utf-8", mode: "0600" }
         );
 
         const dependenciesTransport = JSON.parse(mockWriteFileSync.mock.calls[0][1]) as NodeDependencyTransport[];
@@ -94,7 +94,7 @@ describe("Node Dependencies", () => {
         expect(mockWriteFileSync).toHaveBeenCalledWith(
             path.resolve(process.cwd(), expectedFileName),
             expect.any(String),
-            { encoding: "utf-8" }
+            { encoding: "utf-8", mode: "0600" }
         );
 
         const dependenciesTransport = JSON.parse(mockWriteFileSync.mock.calls[0][1]) as NodeDependencyTransport[];
@@ -152,7 +152,7 @@ describe("Node Dependencies", () => {
             expect(mockWriteFileSync).toHaveBeenCalledWith(
                 path.resolve(process.cwd(), expectedFileName),
                 expect.any(String),
-                { encoding: "utf-8" }
+                { encoding: "utf-8", mode: "0600" }
             );
 
             const dependenciesTransport = JSON.parse(mockWriteFileSync.mock.calls[0][1]) as NodeDependencyTransport[];
@@ -189,7 +189,7 @@ describe("Node Dependencies", () => {
             expect(mockWriteFileSync).toHaveBeenCalledWith(
                 path.resolve(process.cwd(), expectedFileName),
                 expect.any(String),
-                { encoding: "utf-8" }
+                { encoding: "utf-8", mode: "0600" }
             );
 
             const dependenciesTransport = JSON.parse(mockWriteFileSync.mock.calls[0][1]) as NodeDependencyTransport[];

--- a/tests/commands/configuration-management/config-node-diff.spec.ts
+++ b/tests/commands/configuration-management/config-node-diff.spec.ts
@@ -78,7 +78,7 @@ describe("Node diff", () => {
         expect(mockWriteFileSync).toHaveBeenCalledWith(
             path.resolve(process.cwd(), expectedFileName),
             expect.any(String),
-            { encoding: "utf-8", mode: "0600" }
+            { encoding: "utf-8", mode: 0o600 }
         );
 
         const savedDiff = JSON.parse(mockWriteFileSync.mock.calls[0][1]) as NodeConfigurationDiffTransport;
@@ -223,7 +223,7 @@ describe("Node diff", () => {
         expect(mockWriteFileSync).toHaveBeenCalledWith(
             path.resolve(process.cwd(), expectedFileName),
             expect.any(String),
-            { encoding: "utf-8", mode: "0600" }
+            { encoding: "utf-8", mode: 0o600 }
         );
 
         const savedDiff = JSON.parse(mockWriteFileSync.mock.calls[0][1]) as NodeConfigurationDiffTransport;

--- a/tests/commands/configuration-management/config-node-diff.spec.ts
+++ b/tests/commands/configuration-management/config-node-diff.spec.ts
@@ -78,7 +78,7 @@ describe("Node diff", () => {
         expect(mockWriteFileSync).toHaveBeenCalledWith(
             path.resolve(process.cwd(), expectedFileName),
             expect.any(String),
-            { encoding: "utf-8" }
+            { encoding: "utf-8", mode: "0600" }
         );
 
         const savedDiff = JSON.parse(mockWriteFileSync.mock.calls[0][1]) as NodeConfigurationDiffTransport;
@@ -223,7 +223,7 @@ describe("Node diff", () => {
         expect(mockWriteFileSync).toHaveBeenCalledWith(
             path.resolve(process.cwd(), expectedFileName),
             expect.any(String),
-            { encoding: "utf-8" }
+            { encoding: "utf-8", mode: "0600" }
         );
 
         const savedDiff = JSON.parse(mockWriteFileSync.mock.calls[0][1]) as NodeConfigurationDiffTransport;

--- a/tests/commands/configuration-management/config-node-list.spec.ts
+++ b/tests/commands/configuration-management/config-node-list.spec.ts
@@ -145,7 +145,7 @@ describe("Node list", () => {
 
         const expectedFileName = loggingTestTransport.logMessages[0].message.split(FileService.fileDownloadedMessage)[1];
 
-        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), expect.any(String), {encoding: "utf-8"});
+        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), expect.any(String), {encoding: "utf-8", mode: "0600"});
 
         const nodes = JSON.parse(mockWriteFileSync.mock.calls[0][1]) as NodeTransport[];
 
@@ -187,7 +187,7 @@ describe("Node list", () => {
 
         const expectedFileName = loggingTestTransport.logMessages[0].message.split(FileService.fileDownloadedMessage)[1];
 
-        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), expect.any(String), {encoding: "utf-8"});
+        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), expect.any(String), {encoding: "utf-8", mode: "0600"});
 
         const nodes = JSON.parse(mockWriteFileSync.mock.calls[0][1]) as NodeTransport[];
 
@@ -248,7 +248,7 @@ describe("Node list", () => {
 
         const expectedFileName = loggingTestTransport.logMessages[0].message.split(FileService.fileDownloadedMessage)[1];
 
-        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), expect.any(String), {encoding: "utf-8"});
+        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), expect.any(String), {encoding: "utf-8", mode: "0600"});
 
         const nodes = JSON.parse(mockWriteFileSync.mock.calls[0][1]) as NodeTransport[];
 

--- a/tests/commands/configuration-management/config-node-list.spec.ts
+++ b/tests/commands/configuration-management/config-node-list.spec.ts
@@ -145,7 +145,7 @@ describe("Node list", () => {
 
         const expectedFileName = loggingTestTransport.logMessages[0].message.split(FileService.fileDownloadedMessage)[1];
 
-        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), expect.any(String), {encoding: "utf-8", mode: "0600"});
+        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), expect.any(String), {encoding: "utf-8", mode: 0o600});
 
         const nodes = JSON.parse(mockWriteFileSync.mock.calls[0][1]) as NodeTransport[];
 
@@ -187,7 +187,7 @@ describe("Node list", () => {
 
         const expectedFileName = loggingTestTransport.logMessages[0].message.split(FileService.fileDownloadedMessage)[1];
 
-        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), expect.any(String), {encoding: "utf-8", mode: "0600"});
+        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), expect.any(String), {encoding: "utf-8", mode: 0o600});
 
         const nodes = JSON.parse(mockWriteFileSync.mock.calls[0][1]) as NodeTransport[];
 
@@ -248,7 +248,7 @@ describe("Node list", () => {
 
         const expectedFileName = loggingTestTransport.logMessages[0].message.split(FileService.fileDownloadedMessage)[1];
 
-        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), expect.any(String), {encoding: "utf-8", mode: "0600"});
+        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), expect.any(String), {encoding: "utf-8", mode: 0o600});
 
         const nodes = JSON.parse(mockWriteFileSync.mock.calls[0][1]) as NodeTransport[];
 

--- a/tests/commands/configuration-management/config-node.spec.ts
+++ b/tests/commands/configuration-management/config-node.spec.ts
@@ -105,7 +105,7 @@ describe("Node find", () => {
 
         const expectedFileName = loggingTestTransport.logMessages[0].message.split(FileService.fileDownloadedMessage)[1];
 
-        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), expect.any(String), {encoding: "utf-8"});
+        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), expect.any(String), {encoding: "utf-8", mode: "0600"});
 
         const nodeTransport = JSON.parse(mockWriteFileSync.mock.calls[0][1]) as NodeTransport;
 
@@ -131,7 +131,7 @@ describe("Node find", () => {
 
         const expectedFileName = loggingTestTransport.logMessages[0].message.split(FileService.fileDownloadedMessage)[1];
 
-        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), expect.any(String), {encoding: "utf-8"});
+        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), expect.any(String), {encoding: "utf-8", mode: "0600"});
 
         const nodeTransport = JSON.parse(mockWriteFileSync.mock.calls[0][1]) as NodeTransport;
 
@@ -175,7 +175,7 @@ describe("Node find", () => {
 
         const expectedFileName = loggingTestTransport.logMessages[0].message.split(FileService.fileDownloadedMessage)[1];
 
-        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), expect.any(String), {encoding: "utf-8"});
+        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), expect.any(String), {encoding: "utf-8", mode: "0600"});
 
         const nodeTransport = JSON.parse(mockWriteFileSync.mock.calls[0][1]) as NodeTransport;
 

--- a/tests/commands/configuration-management/config-node.spec.ts
+++ b/tests/commands/configuration-management/config-node.spec.ts
@@ -105,7 +105,7 @@ describe("Node find", () => {
 
         const expectedFileName = loggingTestTransport.logMessages[0].message.split(FileService.fileDownloadedMessage)[1];
 
-        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), expect.any(String), {encoding: "utf-8", mode: "0600"});
+        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), expect.any(String), {encoding: "utf-8", mode: 0o600});
 
         const nodeTransport = JSON.parse(mockWriteFileSync.mock.calls[0][1]) as NodeTransport;
 
@@ -131,7 +131,7 @@ describe("Node find", () => {
 
         const expectedFileName = loggingTestTransport.logMessages[0].message.split(FileService.fileDownloadedMessage)[1];
 
-        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), expect.any(String), {encoding: "utf-8", mode: "0600"});
+        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), expect.any(String), {encoding: "utf-8", mode: 0o600});
 
         const nodeTransport = JSON.parse(mockWriteFileSync.mock.calls[0][1]) as NodeTransport;
 
@@ -175,7 +175,7 @@ describe("Node find", () => {
 
         const expectedFileName = loggingTestTransport.logMessages[0].message.split(FileService.fileDownloadedMessage)[1];
 
-        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), expect.any(String), {encoding: "utf-8", mode: "0600"});
+        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), expect.any(String), {encoding: "utf-8", mode: 0o600});
 
         const nodeTransport = JSON.parse(mockWriteFileSync.mock.calls[0][1]) as NodeTransport;
 

--- a/tests/commands/configuration-management/config-validate.spec.ts
+++ b/tests/commands/configuration-management/config-validate.spec.ts
@@ -84,7 +84,7 @@ describe("Config validate", () => {
         expect(mockWriteFileSync).toHaveBeenCalledWith(
             expect.stringMatching(/config_validate_report_.+\.json$/),
             JSON.stringify(response),
-            { encoding: "utf-8" }
+            { encoding: "utf-8", mode: 0o600 }
         );
     })
 

--- a/tests/commands/configuration-management/config-version-create.spec.ts
+++ b/tests/commands/configuration-management/config-version-create.spec.ts
@@ -49,7 +49,7 @@ describe("Package Version create", () => {
 
         const expectedFileName = loggingTestTransport.logMessages[0].message.split(FileService.fileDownloadedMessage)[1];
 
-        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), expect.any(String), {encoding: "utf-8"});
+        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), expect.any(String), {encoding: "utf-8", mode: "0600"});
 
         const savedTransport = JSON.parse(mockWriteFileSync.mock.calls[0][1]) as PackageVersionCreatedTransport;
 

--- a/tests/commands/configuration-management/config-version-create.spec.ts
+++ b/tests/commands/configuration-management/config-version-create.spec.ts
@@ -49,7 +49,7 @@ describe("Package Version create", () => {
 
         const expectedFileName = loggingTestTransport.logMessages[0].message.split(FileService.fileDownloadedMessage)[1];
 
-        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), expect.any(String), {encoding: "utf-8", mode: "0600"});
+        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), expect.any(String), {encoding: "utf-8", mode: 0o600});
 
         const savedTransport = JSON.parse(mockWriteFileSync.mock.calls[0][1]) as PackageVersionCreatedTransport;
 

--- a/tests/commands/configuration-management/config-version.spec.ts
+++ b/tests/commands/configuration-management/config-version.spec.ts
@@ -48,7 +48,7 @@ describe("Package Version get", () => {
 
         const expectedFileName = loggingTestTransport.logMessages[0].message.split(FileService.fileDownloadedMessage)[1];
 
-        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), expect.any(String), {encoding: "utf-8", mode: "0600"});
+        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), expect.any(String), {encoding: "utf-8", mode: 0o600});
 
         const packageVersionTransport = JSON.parse(mockWriteFileSync.mock.calls[0][1]) as PackageVersionTransport;
 

--- a/tests/commands/configuration-management/config-version.spec.ts
+++ b/tests/commands/configuration-management/config-version.spec.ts
@@ -48,7 +48,7 @@ describe("Package Version get", () => {
 
         const expectedFileName = loggingTestTransport.logMessages[0].message.split(FileService.fileDownloadedMessage)[1];
 
-        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), expect.any(String), {encoding: "utf-8"});
+        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), expect.any(String), {encoding: "utf-8", mode: "0600"});
 
         const packageVersionTransport = JSON.parse(mockWriteFileSync.mock.calls[0][1]) as PackageVersionTransport;
 

--- a/tests/commands/configuration-management/list-assignments.spec.ts
+++ b/tests/commands/configuration-management/list-assignments.spec.ts
@@ -39,7 +39,7 @@ describe("List assignments", () => {
 
         const expectedFileName = loggingTestTransport.logMessages[0].message.split(FileService.fileDownloadedMessage)[1];
 
-        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), JSON.stringify(mockAssignmentValues), {encoding: "utf-8", mode: "0600"});
+        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), JSON.stringify(mockAssignmentValues), {encoding: "utf-8", mode: 0o600});
     })
 
     it("Should contain url params in the url", async () => {

--- a/tests/commands/configuration-management/list-assignments.spec.ts
+++ b/tests/commands/configuration-management/list-assignments.spec.ts
@@ -39,7 +39,7 @@ describe("List assignments", () => {
 
         const expectedFileName = loggingTestTransport.logMessages[0].message.split(FileService.fileDownloadedMessage)[1];
 
-        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), JSON.stringify(mockAssignmentValues), {encoding: "utf-8"});
+        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), JSON.stringify(mockAssignmentValues), {encoding: "utf-8", mode: "0600"});
     })
 
     it("Should contain url params in the url", async () => {

--- a/tests/commands/deployment/deployment-create.spec.ts
+++ b/tests/commands/deployment/deployment-create.spec.ts
@@ -39,7 +39,7 @@ describe("Deployment create", () => {
 
         const expectedFileName = loggingTestTransport.logMessages[0].message.split(FileService.fileDownloadedMessage)[1];
 
-        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), expect.any(String), {encoding: "utf-8", mode: "0600"});
+        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), expect.any(String), {encoding: "utf-8", mode: 0o600});
 
         const deploymentTransport = JSON.parse(mockWriteFileSync.mock.calls[0][1]) as DeploymentTransport;
 

--- a/tests/commands/deployment/deployment-create.spec.ts
+++ b/tests/commands/deployment/deployment-create.spec.ts
@@ -39,7 +39,7 @@ describe("Deployment create", () => {
 
         const expectedFileName = loggingTestTransport.logMessages[0].message.split(FileService.fileDownloadedMessage)[1];
 
-        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), expect.any(String), {encoding: "utf-8"});
+        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), expect.any(String), {encoding: "utf-8", mode: "0600"});
 
         const deploymentTransport = JSON.parse(mockWriteFileSync.mock.calls[0][1]) as DeploymentTransport;
 

--- a/tests/commands/deployment/deployment-list-active.spec.ts
+++ b/tests/commands/deployment/deployment-list-active.spec.ts
@@ -42,7 +42,7 @@ describe("Deployment list active", () => {
 
         const expectedFileName = loggingTestTransport.logMessages[0].message.split(FileService.fileDownloadedMessage)[1];
 
-        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), expect.any(String), {encoding: "utf-8", mode: "0600"});
+        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), expect.any(String), {encoding: "utf-8", mode: 0o600});
 
         const deploymentTransport = JSON.parse(mockWriteFileSync.mock.calls[0][1]) as DeploymentTransport;
 
@@ -90,7 +90,7 @@ describe("Deployment list active", () => {
 
         const expectedFileName = loggingTestTransport.logMessages[0].message.split(FileService.fileDownloadedMessage)[1];
 
-        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), expect.any(String), {encoding: "utf-8", mode: "0600"});
+        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), expect.any(String), {encoding: "utf-8", mode: 0o600});
 
         const deploymentTransports = JSON.parse(mockWriteFileSync.mock.calls[0][1]) as DeploymentTransport[];
         expect(deploymentTransports.length).toBe(1);

--- a/tests/commands/deployment/deployment-list-active.spec.ts
+++ b/tests/commands/deployment/deployment-list-active.spec.ts
@@ -42,7 +42,7 @@ describe("Deployment list active", () => {
 
         const expectedFileName = loggingTestTransport.logMessages[0].message.split(FileService.fileDownloadedMessage)[1];
 
-        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), expect.any(String), {encoding: "utf-8"});
+        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), expect.any(String), {encoding: "utf-8", mode: "0600"});
 
         const deploymentTransport = JSON.parse(mockWriteFileSync.mock.calls[0][1]) as DeploymentTransport;
 
@@ -90,7 +90,7 @@ describe("Deployment list active", () => {
 
         const expectedFileName = loggingTestTransport.logMessages[0].message.split(FileService.fileDownloadedMessage)[1];
 
-        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), expect.any(String), {encoding: "utf-8"});
+        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), expect.any(String), {encoding: "utf-8", mode: "0600"});
 
         const deploymentTransports = JSON.parse(mockWriteFileSync.mock.calls[0][1]) as DeploymentTransport[];
         expect(deploymentTransports.length).toBe(1);

--- a/tests/commands/deployment/deployment-list-deployables.spec.ts
+++ b/tests/commands/deployment/deployment-list-deployables.spec.ts
@@ -47,7 +47,7 @@ describe("Deployment list deployables", () => {
 
         const expectedFileName = loggingTestTransport.logMessages[0].message.split(FileService.fileDownloadedMessage)[1];
 
-        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), expect.any(String), {encoding: "utf-8", mode: "0600"});
+        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), expect.any(String), {encoding: "utf-8", mode: 0o600});
 
         const deployableTransports = JSON.parse(mockWriteFileSync.mock.calls[0][1]) as DeployableTransport[];
         expect(deployableTransports.length).toBe(2);

--- a/tests/commands/deployment/deployment-list-deployables.spec.ts
+++ b/tests/commands/deployment/deployment-list-deployables.spec.ts
@@ -47,7 +47,7 @@ describe("Deployment list deployables", () => {
 
         const expectedFileName = loggingTestTransport.logMessages[0].message.split(FileService.fileDownloadedMessage)[1];
 
-        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), expect.any(String), {encoding: "utf-8"});
+        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), expect.any(String), {encoding: "utf-8", mode: "0600"});
 
         const deployableTransports = JSON.parse(mockWriteFileSync.mock.calls[0][1]) as DeployableTransport[];
         expect(deployableTransports.length).toBe(2);

--- a/tests/commands/deployment/deployment-list-history.spec.ts
+++ b/tests/commands/deployment/deployment-list-history.spec.ts
@@ -60,7 +60,7 @@ describe("Deployments list history", () => {
 
         const expectedFileName = loggingTestTransport.logMessages[0].message.split(FileService.fileDownloadedMessage)[1];
 
-        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), expect.any(String), {encoding: "utf-8"});
+        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), expect.any(String), {encoding: "utf-8", mode: "0600"});
 
         const deploymentTransports = JSON.parse(mockWriteFileSync.mock.calls[0][1]) as DeploymentTransport[];
         expect(deploymentTransports.length).toBe(1);

--- a/tests/commands/deployment/deployment-list-history.spec.ts
+++ b/tests/commands/deployment/deployment-list-history.spec.ts
@@ -60,7 +60,7 @@ describe("Deployments list history", () => {
 
         const expectedFileName = loggingTestTransport.logMessages[0].message.split(FileService.fileDownloadedMessage)[1];
 
-        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), expect.any(String), {encoding: "utf-8", mode: "0600"});
+        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), expect.any(String), {encoding: "utf-8", mode: 0o600});
 
         const deploymentTransports = JSON.parse(mockWriteFileSync.mock.calls[0][1]) as DeploymentTransport[];
         expect(deploymentTransports.length).toBe(1);

--- a/tests/commands/deployment/deployment-list-targets.spec.ts
+++ b/tests/commands/deployment/deployment-list-targets.spec.ts
@@ -34,7 +34,7 @@ describe("Deployment list targets", () => {
 
         const expectedFileName = loggingTestTransport.logMessages[0].message.split(FileService.fileDownloadedMessage)[1];
 
-        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), expect.any(String), {encoding: "utf-8", mode: "0600"});
+        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), expect.any(String), {encoding: "utf-8", mode: 0o600});
 
         const targetTransports = JSON.parse(mockWriteFileSync.mock.calls[0][1]) as DeployableTransport[];
         expect(targetTransports.length).toBe(2);

--- a/tests/commands/deployment/deployment-list-targets.spec.ts
+++ b/tests/commands/deployment/deployment-list-targets.spec.ts
@@ -34,7 +34,7 @@ describe("Deployment list targets", () => {
 
         const expectedFileName = loggingTestTransport.logMessages[0].message.split(FileService.fileDownloadedMessage)[1];
 
-        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), expect.any(String), {encoding: "utf-8"});
+        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), expect.any(String), {encoding: "utf-8", mode: "0600"});
 
         const targetTransports = JSON.parse(mockWriteFileSync.mock.calls[0][1]) as DeployableTransport[];
         expect(targetTransports.length).toBe(2);

--- a/tests/commands/git-profile/git-profile-create.spec.ts
+++ b/tests/commands/git-profile/git-profile-create.spec.ts
@@ -74,7 +74,7 @@ describe("Git Profile - Create Profile", () => {
                 repository: repository,
                 authenticationType: AuthenticationType.HTTPS
             }),
-            { encoding: "utf-8" }
+            { encoding: "utf-8", mode: "0600" }
         );
 
         expect(mockQuestionClose).toHaveBeenCalled();
@@ -105,7 +105,7 @@ describe("Git Profile - Create Profile", () => {
                 repository: repository,
                 authenticationType: AuthenticationType.SSH
             }),
-            { encoding: "utf-8" }
+            { encoding: "utf-8", mode: "0600" }
         );
 
         const loggedMessage = loggingTestTransport.logMessages[0].message.trim();
@@ -136,14 +136,14 @@ describe("Git Profile - Create Profile", () => {
         expect(fs.writeFileSync).toHaveBeenCalledWith(
             path.resolve(mockProfilePath, `${profileName}.json`),
             expect.any(String),
-            { encoding: "utf-8" }
+            { encoding: "utf-8", mode: "0600" }
         );
 
         const configPath = path.resolve(mockProfilePath, "config.json");
         expect(fs.writeFileSync).toHaveBeenCalledWith(
             configPath,
             JSON.stringify({ defaultProfile: profileName }),
-            { encoding: "utf-8" }
+            { encoding: "utf-8", mode: "0600" }
         );
 
         const successMessage = loggingTestTransport.logMessages[1].message.trim();
@@ -263,7 +263,7 @@ describe("Git Profile - Create Profile", () => {
 
         await gitProfileCommandService.createProfile(false);
 
-        expect(fs.mkdirSync).toHaveBeenCalledWith(mockProfilePath);
+        expect(fs.mkdirSync).toHaveBeenCalledWith(mockProfilePath, 0o700);
     });
 });
 

--- a/tests/commands/git-profile/git-profile-create.spec.ts
+++ b/tests/commands/git-profile/git-profile-create.spec.ts
@@ -74,7 +74,7 @@ describe("Git Profile - Create Profile", () => {
                 repository: repository,
                 authenticationType: AuthenticationType.HTTPS
             }),
-            { encoding: "utf-8", mode: "0600" }
+            { encoding: "utf-8", mode: 0o600 }
         );
 
         expect(mockQuestionClose).toHaveBeenCalled();
@@ -105,7 +105,7 @@ describe("Git Profile - Create Profile", () => {
                 repository: repository,
                 authenticationType: AuthenticationType.SSH
             }),
-            { encoding: "utf-8", mode: "0600" }
+            { encoding: "utf-8", mode: 0o600 }
         );
 
         const loggedMessage = loggingTestTransport.logMessages[0].message.trim();
@@ -136,14 +136,14 @@ describe("Git Profile - Create Profile", () => {
         expect(fs.writeFileSync).toHaveBeenCalledWith(
             path.resolve(mockProfilePath, `${profileName}.json`),
             expect.any(String),
-            { encoding: "utf-8", mode: "0600" }
+            { encoding: "utf-8", mode: 0o600 }
         );
 
         const configPath = path.resolve(mockProfilePath, "config.json");
         expect(fs.writeFileSync).toHaveBeenCalledWith(
             configPath,
             JSON.stringify({ defaultProfile: profileName }),
-            { encoding: "utf-8", mode: "0600" }
+            { encoding: "utf-8", mode: 0o600 }
         );
 
         const successMessage = loggingTestTransport.logMessages[1].message.trim();

--- a/tests/core/git-profile/git/git.service.spec.ts
+++ b/tests/core/git-profile/git/git.service.spec.ts
@@ -196,7 +196,7 @@ describe("GitService", () => {
     });
 
     const assertDirectoryCreated = (directory: string) => {
-        expect(fs.mkdirSync).toHaveBeenCalledWith(directory, { recursive: true });
+        expect(fs.mkdirSync).toHaveBeenCalledWith(directory, { recursive: true, mode: 0o700 });
     };
 
     const assertGitDirectoryCleanup = (directory: string) => {

--- a/tests/core/profile/profile.service.spec.ts
+++ b/tests/core/profile/profile.service.spec.ts
@@ -874,7 +874,7 @@ describe("ProfileService - makeDefaultProfile", () => {
         await profileService.makeDefaultProfile("my-profile");
 
         expect(profileService.findProfile).toHaveBeenCalledWith("my-profile");
-        expect(fs.writeFileSync).toHaveBeenCalledWith(configPath, JSON.stringify({ defaultProfile: "my-profile" }), { encoding: "utf-8" });
+        expect(fs.writeFileSync).toHaveBeenCalledWith(configPath, JSON.stringify({ defaultProfile: "my-profile" }), { encoding: "utf-8", mode: "0600" });
     });
 
     it("should reject when findProfile fails", async () => {
@@ -940,11 +940,11 @@ describe("ProfileService - storeProfile", () => {
 
         await profileService.storeProfile(profile);
 
-        expect(fs.mkdirSync).toHaveBeenCalledWith(mockProfilePath);
+        expect(fs.mkdirSync).toHaveBeenCalledWith(mockProfilePath, 0o700);
         expect(fs.writeFileSync).toHaveBeenCalledWith(
             path.resolve(mockProfilePath, "test-profile.json"),
             expect.stringContaining("https://example.celonis.cloud"),
-            { encoding: "utf-8" }
+            { encoding: "utf-8", mode: "0600" }
         );
         expect(profile.team).toBe("https://example.celonis.cloud");
     });
@@ -963,7 +963,7 @@ describe("ProfileService - storeProfile", () => {
         expect(fs.writeFileSync).toHaveBeenCalledWith(
             path.resolve(mockProfilePath, "my-profile.json"),
             expect.any(String),
-            { encoding: "utf-8" }
+            { encoding: "utf-8", mode: "0600" }
         );
     });
 });
@@ -1225,7 +1225,7 @@ describe("Profile Service - Store Profile", () => {
         expect(fs.writeFileSync).toHaveBeenCalledWith(
             path.resolve(mockProfilePath, "plain-text-profile.json"),
             JSON.stringify(expectedProfile),
-            { encoding: "utf-8" }
+            { encoding: "utf-8", mode: "0600" }
         );
     });
 

--- a/tests/core/profile/profile.service.spec.ts
+++ b/tests/core/profile/profile.service.spec.ts
@@ -874,7 +874,7 @@ describe("ProfileService - makeDefaultProfile", () => {
         await profileService.makeDefaultProfile("my-profile");
 
         expect(profileService.findProfile).toHaveBeenCalledWith("my-profile");
-        expect(fs.writeFileSync).toHaveBeenCalledWith(configPath, JSON.stringify({ defaultProfile: "my-profile" }), { encoding: "utf-8", mode: "0600" });
+        expect(fs.writeFileSync).toHaveBeenCalledWith(configPath, JSON.stringify({ defaultProfile: "my-profile" }), { encoding: "utf-8", mode: 0o600 });
     });
 
     it("should reject when findProfile fails", async () => {
@@ -944,7 +944,7 @@ describe("ProfileService - storeProfile", () => {
         expect(fs.writeFileSync).toHaveBeenCalledWith(
             path.resolve(mockProfilePath, "test-profile.json"),
             expect.stringContaining("https://example.celonis.cloud"),
-            { encoding: "utf-8", mode: "0600" }
+            { encoding: "utf-8", mode: 0o600 }
         );
         expect(profile.team).toBe("https://example.celonis.cloud");
     });
@@ -963,7 +963,7 @@ describe("ProfileService - storeProfile", () => {
         expect(fs.writeFileSync).toHaveBeenCalledWith(
             path.resolve(mockProfilePath, "my-profile.json"),
             expect.any(String),
-            { encoding: "utf-8", mode: "0600" }
+            { encoding: "utf-8", mode: 0o600 }
         );
     });
 });
@@ -1225,7 +1225,7 @@ describe("Profile Service - Store Profile", () => {
         expect(fs.writeFileSync).toHaveBeenCalledWith(
             path.resolve(mockProfilePath, "plain-text-profile.json"),
             JSON.stringify(expectedProfile),
-            { encoding: "utf-8", mode: "0600" }
+            { encoding: "utf-8", mode: 0o600 }
         );
     });
 

--- a/tests/core/utils/file.service.spec.ts
+++ b/tests/core/utils/file.service.spec.ts
@@ -16,11 +16,11 @@ describe("FileService", () => {
         fileService = new FileService();
 
         if (!fs.existsSync(tempDir)) {
-            fs.mkdirSync(tempDir, { recursive: true });
+            fs.mkdirSync(tempDir, { recursive: true, mode: 0o700 });
         }
 
         if (!fs.existsSync(symLinkSourceTempDir)) {
-            fs.mkdirSync(symLinkSourceTempDir, { recursive: true });
+            fs.mkdirSync(symLinkSourceTempDir, { recursive: true, mode: 0o700 });
         }
 
         fileService = new FileService();
@@ -39,7 +39,7 @@ describe("FileService", () => {
     describe("zipDirectoryInBatchExportFormat", () => {
         test("Should throw error if sourceDir is a symlink", () => {
             const targetDir = path.join(tempDir, "realDir");
-            fs.mkdirSync(targetDir);
+            fs.mkdirSync(targetDir, 0o700);
 
             const symlinkDir = path.join(tempDir, "symlinkDir");
             fs.symlinkSync(targetDir, symlinkDir, "dir");
@@ -49,11 +49,11 @@ describe("FileService", () => {
 
         test("Should skip symlinked folder and only include real folder", () => {
             const realFolder = path.join(tempDir, "realFolder");
-            fs.mkdirSync(realFolder);
+            fs.mkdirSync(realFolder, 0o700);
             fs.writeFileSync(path.join(realFolder, "insideFile.txt"), "content");
 
             const symLinkTargetFolder = path.join(symLinkSourceTempDir, "targetFolder");
-            fs.mkdirSync(symLinkTargetFolder);
+            fs.mkdirSync(symLinkTargetFolder, 0o700);
             const folderSymlink = path.join(tempDir, "folderSymlink");
             fs.symlinkSync(symLinkTargetFolder, folderSymlink, "dir");
 

--- a/tests/utls/config-utils.ts
+++ b/tests/utls/config-utils.ts
@@ -12,12 +12,12 @@ export class ConfigUtils {
     public static buildBatchExportZipWithStudioManifest(manifest: PackageManifestTransport[], studioManifest: StudioPackageManifest[], packageZips: AdmZip[]): AdmZip {
 
         const zipExport = new AdmZip();
-        zipExport.addFile("manifest.json", Buffer.from(stringify(manifest)));
-        zipExport.addFile("studio.json", Buffer.from(stringify(studioManifest)));
+        zipExport.addFile("manifest.json", Buffer.from(stringify(manifest)), "", 0o600);
+        zipExport.addFile("studio.json", Buffer.from(stringify(studioManifest)), "", 0o600);
         packageZips.forEach(packageZip => {
             const fileName = `${packageZip.getZipComment()}.zip`
             packageZip.addZipComment("")
-            zipExport.addFile(fileName, packageZip.toBuffer());
+            zipExport.addFile(fileName, packageZip.toBuffer(), "", 0o600);
         })
 
         return zipExport;
@@ -25,11 +25,11 @@ export class ConfigUtils {
     public static buildBatchExportZip(manifest: PackageManifestTransport[], packageZips: AdmZip[]): AdmZip {
 
         const zipExport = new AdmZip();
-        zipExport.addFile("manifest.json", Buffer.from(stringify(manifest)));
+        zipExport.addFile("manifest.json", Buffer.from(stringify(manifest)), "", 0o600);
         packageZips.forEach(packageZip => {
             const fileName = `${packageZip.getZipComment()}.zip`
             packageZip.addZipComment("")
-            zipExport.addFile(fileName, packageZip.toBuffer());
+            zipExport.addFile(fileName, packageZip.toBuffer(), "", 0o600);
         })
 
         return zipExport;
@@ -38,11 +38,11 @@ export class ConfigUtils {
     public static buildExportPackageZip(packageNode: NodeExportTransport, childNodes: NodeExportTransport[], version: string): AdmZip {
         const zipExport = new AdmZip();
 
-        zipExport.addFile("package.json", Buffer.from(stringify(packageNode)));
-        zipExport.addFile("nodes/", Buffer.alloc(0));
+        zipExport.addFile("package.json", Buffer.from(stringify(packageNode)), "", 0o600);
+        zipExport.addFile("nodes/", Buffer.alloc(0), "", 0o600);
 
         childNodes.forEach(child => {
-            zipExport.addFile(`nodes/${child.key}.json`, Buffer.from(stringify(child)));
+            zipExport.addFile(`nodes/${child.key}.json`, Buffer.from(stringify(child)), "", 0o600);
         });
 
        zipExport.addZipComment(`${packageNode.key}_${version}`);

--- a/tests/utls/config-utils.ts
+++ b/tests/utls/config-utils.ts
@@ -6,18 +6,19 @@ import {
 } from "../../src/commands/configuration-management/interfaces/package-export.interfaces";
 import { stringify } from "../../src/core/utils/json";
 import { SpaceTransport } from "../../src/commands/studio/interfaces/space.interface";
+import { FileConstants } from "../../src/core/utils/file.constants";
 
 export class ConfigUtils {
 
     public static buildBatchExportZipWithStudioManifest(manifest: PackageManifestTransport[], studioManifest: StudioPackageManifest[], packageZips: AdmZip[]): AdmZip {
 
         const zipExport = new AdmZip();
-        zipExport.addFile("manifest.json", Buffer.from(stringify(manifest)), "", 0o600);
-        zipExport.addFile("studio.json", Buffer.from(stringify(studioManifest)), "", 0o600);
+        zipExport.addFile("manifest.json", Buffer.from(stringify(manifest)), "", FileConstants.DEFAULT_FILE_PERMISSIONS);
+        zipExport.addFile("studio.json", Buffer.from(stringify(studioManifest)), "", FileConstants.DEFAULT_FILE_PERMISSIONS);
         packageZips.forEach(packageZip => {
             const fileName = `${packageZip.getZipComment()}.zip`
             packageZip.addZipComment("")
-            zipExport.addFile(fileName, packageZip.toBuffer(), "", 0o600);
+            zipExport.addFile(fileName, packageZip.toBuffer(), "", FileConstants.DEFAULT_FILE_PERMISSIONS);
         })
 
         return zipExport;
@@ -25,11 +26,11 @@ export class ConfigUtils {
     public static buildBatchExportZip(manifest: PackageManifestTransport[], packageZips: AdmZip[]): AdmZip {
 
         const zipExport = new AdmZip();
-        zipExport.addFile("manifest.json", Buffer.from(stringify(manifest)), "", 0o600);
+        zipExport.addFile("manifest.json", Buffer.from(stringify(manifest)), "", FileConstants.DEFAULT_FILE_PERMISSIONS);
         packageZips.forEach(packageZip => {
             const fileName = `${packageZip.getZipComment()}.zip`
             packageZip.addZipComment("")
-            zipExport.addFile(fileName, packageZip.toBuffer(), "", 0o600);
+            zipExport.addFile(fileName, packageZip.toBuffer(), "", FileConstants.DEFAULT_FILE_PERMISSIONS);
         })
 
         return zipExport;
@@ -38,11 +39,11 @@ export class ConfigUtils {
     public static buildExportPackageZip(packageNode: NodeExportTransport, childNodes: NodeExportTransport[], version: string): AdmZip {
         const zipExport = new AdmZip();
 
-        zipExport.addFile("package.json", Buffer.from(stringify(packageNode)), "", 0o600);
-        zipExport.addFile("nodes/", Buffer.alloc(0), "", 0o600);
+        zipExport.addFile("package.json", Buffer.from(stringify(packageNode)), "", FileConstants.DEFAULT_FILE_PERMISSIONS);
+        zipExport.addFile("nodes/", Buffer.alloc(0), "", FileConstants.DEFAULT_FILE_PERMISSIONS);
 
         childNodes.forEach(child => {
-            zipExport.addFile(`nodes/${child.key}.json`, Buffer.from(stringify(child)), "", 0o600);
+            zipExport.addFile(`nodes/${child.key}.json`, Buffer.from(stringify(child)), "", FileConstants.DEFAULT_FILE_PERMISSIONS);
         });
 
        zipExport.addZipComment(`${packageNode.key}_${version}`);


### PR DESCRIPTION
#### Description

Prevent world writeable/readable files created by content-cli. Directories are created with user rwx permissions and files are created with user rw permissions only.

Note: Downloaded package zips that are not created by content-cli itself but that come from the API have more lenient permissions so when unpacked manually they will still have group/world permissions.

#### Relevant links

https://celonis.atlassian.net/browse/TA-4732

#### Checklist

- [x] I have self-reviewed this PR
- [x] I have tested the change and proved that it works in different scenarios
- [ ] I have updated docs if needed
