### PR TITLE
SP-38: Add new CLI commands for singe node operations

### DIFF
--- a/src/commands/configuration-management/api/node-api.ts
+++ b/src/commands/configuration-management/api/node-api.ts
@@ -1,6 +1,6 @@
 import { HttpClient } from "../../../core/http/http-client";
 import { Context } from "../../../core/command/cli-context";
-import { NodeTransport } from "../interfaces/node.interfaces";
+import { NodeTransport, SaveNodeTransport, UpdateNodeTransport } from "../interfaces/node.interfaces";
 import { FatalError } from "../../../core/utils/logger";
 
 export class NodeApi {
@@ -30,6 +30,37 @@ export class NodeApi {
             .get(`/pacman/api/core/packages/${packageKey}/nodes/${nodeKey}?${queryParams.toString()}`)
             .catch((e) => {
                 throw new FatalError(`Problem finding node ${nodeKey} in package ${packageKey} for version ${version}: ${e}`);
+            });
+    }
+
+    public async createStagingNode(packageKey: string, transport: SaveNodeTransport, validateOnly: boolean): Promise<NodeTransport | void> {
+        const suffix = validateOnly ? "?validate=true" : "";
+
+        return this.httpClient()
+            .post(`/pacman/api/core/staging/packages/${packageKey}/nodes${suffix}`, transport)
+            .catch((e) => {
+                throw new FatalError(`Problem creating node in package ${packageKey}: ${e}`);
+            });
+    }
+
+    public async updateStagingNode(packageKey: string, nodeKey: string, transport: UpdateNodeTransport, validateOnly: boolean): Promise<NodeTransport | void> {
+        const suffix = validateOnly ? "?validate=true" : "";
+
+        return this.httpClient()
+            .put(`/pacman/api/core/staging/packages/${packageKey}/nodes/${nodeKey}${suffix}`, transport)
+            .catch((e) => {
+                throw new FatalError(`Problem updating node ${nodeKey} in package ${packageKey}: ${e}`);
+            });
+    }
+
+    public async archiveStagingNode(packageKey: string, nodeKey: string, force: boolean): Promise<void> {
+        const queryParams = new URLSearchParams();
+        queryParams.set("force", force.toString());
+
+        return this.httpClient()
+            .delete(`/pacman/api/core/staging/packages/${packageKey}/nodes/${nodeKey}/archive?${queryParams.toString()}`)
+            .catch((e) => {
+                throw new FatalError(`Problem archiving node ${nodeKey} in package ${packageKey}: ${e}`);
             });
     }
 

--- a/src/commands/configuration-management/interfaces/node.interfaces.ts
+++ b/src/commands/configuration-management/interfaces/node.interfaces.ts
@@ -20,3 +20,25 @@ export interface NodeTransport {
     schemaVersion: number;
     flavor?: string;
 }
+
+export interface SaveNodeTransport {
+    key: string;
+    name: string;
+    parentNodeKey: string;
+    type: string;
+    configuration?: NodeConfiguration;
+    invalidConfiguration?: string;
+    invalidContent?: boolean;
+    schemaVersion?: number;
+    [key: string]: any;
+}
+
+export interface UpdateNodeTransport {
+    name: string;
+    parentNodeKey: string;
+    configuration?: NodeConfiguration;
+    invalidConfiguration?: string;
+    invalidContent?: boolean;
+    schemaVersion?: number;
+    [key: string]: any;
+}

--- a/src/commands/configuration-management/module.ts
+++ b/src/commands/configuration-management/module.ts
@@ -12,7 +12,6 @@ import { NodeDiffService } from "./node-diff.service";
 import { NodeDependencyService } from "./node-dependency.service";
 import { PackageVersionCommandService } from "./package-version-command.service";
 import { PackageValidationService } from "./package-validation.service";
-import { fileService } from "../../core/utils/file-service";
 
 class Module extends IModule {
 
@@ -277,26 +276,11 @@ class Module extends IModule {
     }
 
     private async createNode(context: Context, command: Command, options: OptionValues): Promise<void> {
-        const body = Module.resolveBody(options.body, options.file);
-        await new NodeService(context).createNode(options.packageKey, body, options.validate, options.json);
+        await new NodeService(context).createNode(options.packageKey, options.body, options.file, options.validate, options.json);
     }
 
     private async updateNode(context: Context, command: Command, options: OptionValues): Promise<void> {
-        const body = Module.resolveBody(options.body, options.file);
-        await new NodeService(context).updateNode(options.packageKey, options.nodeKey, body, options.validate, options.json);
-    }
-
-    private static resolveBody(body: string | undefined, file: string | undefined): string {
-        if (body && file) {
-            throw new Error("Please provide either --body or --file, but not both.");
-        }
-        if (!body && !file) {
-            throw new Error("Please provide either --body or --file.");
-        }
-        if (file) {
-            return fileService.readFile(file);
-        }
-        return body!;
+        await new NodeService(context).updateNode(options.packageKey, options.nodeKey, options.body, options.file, options.validate, options.json);
     }
 
     private async archiveNode(context: Context, command: Command, options: OptionValues): Promise<void> {

--- a/src/commands/configuration-management/module.ts
+++ b/src/commands/configuration-management/module.ts
@@ -12,6 +12,7 @@ import { NodeDiffService } from "./node-diff.service";
 import { NodeDependencyService } from "./node-dependency.service";
 import { PackageVersionCommandService } from "./package-version-command.service";
 import { PackageValidationService } from "./package-validation.service";
+import { fileService } from "../../core/utils/file-service";
 
 class Module extends IModule {
 
@@ -115,6 +116,32 @@ class Module extends IModule {
             .option("--withConfiguration", "Include node configuration in the response", false)
             .option("--json", "Return the response as a JSON file")
             .action(this.findNode);
+
+        nodesCommand.command("create")
+            .description("Create a new staging node in a package")
+            .requiredOption("--packageKey <packageKey>", "Identifier of the package")
+            .option("--body <body>", "Node payload as JSON string")
+            .option("-f, --file <file>", "Path to a JSON file containing the node payload")
+            .option("--validate", "Only validate the payload without persisting. Returns success if valid.", false)
+            .option("--json", "Return the response as a JSON file")
+            .action(this.createNode);
+
+        nodesCommand.command("update")
+            .description("Update a staging node in a package")
+            .requiredOption("--packageKey <packageKey>", "Identifier of the package")
+            .requiredOption("--nodeKey <nodeKey>", "Identifier of the node")
+            .option("--body <body>", "Node payload as JSON string")
+            .option("-f, --file <file>", "Path to a JSON file containing the node payload")
+            .option("--validate", "Only validate the payload without persisting. Returns success if valid.", false)
+            .option("--json", "Return the response as a JSON file")
+            .action(this.updateNode);
+
+        nodesCommand.command("delete")
+            .description("Delete (archive) a staging node in a package")
+            .requiredOption("--packageKey <packageKey>", "Identifier of the package")
+            .requiredOption("--nodeKey <nodeKey>", "Identifier of the node")
+            .option("--force", "Force delete even if the node has dependants", false)
+            .action(this.archiveNode);
 
         nodesCommand.command("list")
             .description("List nodes in a specific package version")
@@ -247,6 +274,33 @@ class Module extends IModule {
 
     private async findNode(context: Context, command: Command, options: OptionValues): Promise<void> {
         await new NodeService(context).findNode(options.packageKey, options.nodeKey, options.withConfiguration, options.packageVersion ?? null, options.json);
+    }
+
+    private async createNode(context: Context, command: Command, options: OptionValues): Promise<void> {
+        const body = Module.resolveBody(options.body, options.file);
+        await new NodeService(context).createNode(options.packageKey, body, options.validate, options.json);
+    }
+
+    private async updateNode(context: Context, command: Command, options: OptionValues): Promise<void> {
+        const body = Module.resolveBody(options.body, options.file);
+        await new NodeService(context).updateNode(options.packageKey, options.nodeKey, body, options.validate, options.json);
+    }
+
+    private static resolveBody(body: string | undefined, file: string | undefined): string {
+        if (body && file) {
+            throw new Error("Please provide either --body or --file, but not both.");
+        }
+        if (!body && !file) {
+            throw new Error("Please provide either --body or --file.");
+        }
+        if (file) {
+            return fileService.readFile(file);
+        }
+        return body!;
+    }
+
+    private async archiveNode(context: Context, command: Command, options: OptionValues): Promise<void> {
+        await new NodeService(context).archiveNode(options.packageKey, options.nodeKey, options.force);
     }
 
     private async listNodes(context: Context, command: Command, options: OptionValues): Promise<void> {

--- a/src/commands/configuration-management/module.ts
+++ b/src/commands/configuration-management/module.ts
@@ -136,11 +136,11 @@ class Module extends IModule {
             .option("--json", "Return the response as a JSON file")
             .action(this.updateNode);
 
-        nodesCommand.command("delete")
-            .description("Delete (archive) a staging node in a package")
+        nodesCommand.command("archive")
+            .description("Archive a staging node in a package")
             .requiredOption("--packageKey <packageKey>", "Identifier of the package")
             .requiredOption("--nodeKey <nodeKey>", "Identifier of the node")
-            .option("--force", "Force delete even if the node has dependants", false)
+            .option("--force", "Force archive even if the node has dependants", false)
             .action(this.archiveNode);
 
         nodesCommand.command("list")

--- a/src/commands/configuration-management/node.service.ts
+++ b/src/commands/configuration-management/node.service.ts
@@ -40,8 +40,8 @@ export class NodeService {
         }
     }
 
-    public async createNode(packageKey: string, body: string, validateOnly: boolean, jsonResponse: boolean): Promise<void> {
-        const transport: SaveNodeTransport = JSON.parse(body);
+    public async createNode(packageKey: string, body: string | undefined, file: string | undefined, validateOnly: boolean, jsonResponse: boolean): Promise<void> {
+        const transport: SaveNodeTransport = JSON.parse(NodeService.resolveBody(body, file));
         const node = await this.nodeApi.createStagingNode(packageKey, transport, validateOnly);
 
         if (validateOnly) {
@@ -58,8 +58,8 @@ export class NodeService {
         }
     }
 
-    public async updateNode(packageKey: string, nodeKey: string, body: string, validateOnly: boolean, jsonResponse: boolean): Promise<void> {
-        const transport: UpdateNodeTransport = JSON.parse(body);
+    public async updateNode(packageKey: string, nodeKey: string, body: string | undefined, file: string | undefined, validateOnly: boolean, jsonResponse: boolean): Promise<void> {
+        const transport: UpdateNodeTransport = JSON.parse(NodeService.resolveBody(body, file));
         const node = await this.nodeApi.updateStagingNode(packageKey, nodeKey, transport, validateOnly);
 
         if (validateOnly) {
@@ -79,6 +79,19 @@ export class NodeService {
     public async archiveNode(packageKey: string, nodeKey: string, force: boolean): Promise<void> {
         await this.nodeApi.archiveStagingNode(packageKey, nodeKey, force);
         logger.info(`Node ${nodeKey} in package ${packageKey} archived successfully.`);
+    }
+
+    private static resolveBody(body: string | undefined, file: string | undefined): string {
+        if (body && file) {
+            throw new Error("Please provide either --body or --file, but not both.");
+        }
+        if (!body && !file) {
+            throw new Error("Please provide either --body or --file.");
+        }
+        if (file) {
+            return fileService.readFile(file);
+        }
+        return body!;
     }
 
     private printNode(node: NodeTransport): void {

--- a/src/commands/configuration-management/node.service.ts
+++ b/src/commands/configuration-management/node.service.ts
@@ -3,7 +3,7 @@ import { Context } from "../../core/command/cli-context";
 import { fileService, FileService } from "../../core/utils/file-service";
 import { logger } from "../../core/utils/logger";
 import { v4 as uuidv4 } from "uuid";
-import { NodeTransport } from "./interfaces/node.interfaces";
+import { NodeTransport, SaveNodeTransport, UpdateNodeTransport } from "./interfaces/node.interfaces";
 
 export class NodeService {
     private nodeApi: NodeApi;
@@ -38,6 +38,47 @@ export class NodeService {
                 logger.info(JSON.stringify(node))
             });
         }
+    }
+
+    public async createNode(packageKey: string, body: string, validateOnly: boolean, jsonResponse: boolean): Promise<void> {
+        const transport: SaveNodeTransport = JSON.parse(body);
+        const node = await this.nodeApi.createStagingNode(packageKey, transport, validateOnly);
+
+        if (validateOnly) {
+            logger.info(`Validation successful for node ${transport.key} in package ${packageKey}.`);
+            return;
+        }
+
+        if (jsonResponse) {
+            const filename = uuidv4() + ".json";
+            fileService.writeToFileWithGivenName(JSON.stringify(node, null, 2), filename);
+            logger.info(FileService.fileDownloadedMessage + filename);
+        } else {
+            this.printNode(node as NodeTransport);
+        }
+    }
+
+    public async updateNode(packageKey: string, nodeKey: string, body: string, validateOnly: boolean, jsonResponse: boolean): Promise<void> {
+        const transport: UpdateNodeTransport = JSON.parse(body);
+        const node = await this.nodeApi.updateStagingNode(packageKey, nodeKey, transport, validateOnly);
+
+        if (validateOnly) {
+            logger.info(`Validation successful for node ${nodeKey} in package ${packageKey}.`);
+            return;
+        }
+
+        if (jsonResponse) {
+            const filename = uuidv4() + ".json";
+            fileService.writeToFileWithGivenName(JSON.stringify(node, null, 2), filename);
+            logger.info(FileService.fileDownloadedMessage + filename);
+        } else {
+            this.printNode(node as NodeTransport);
+        }
+    }
+
+    public async archiveNode(packageKey: string, nodeKey: string, force: boolean): Promise<void> {
+        await this.nodeApi.archiveStagingNode(packageKey, nodeKey, force);
+        logger.info(`Node ${nodeKey} in package ${packageKey} archived successfully.`);
     }
 
     private printNode(node: NodeTransport): void {

--- a/tests/commands/configuration-management/config-node-archive.spec.ts
+++ b/tests/commands/configuration-management/config-node-archive.spec.ts
@@ -1,0 +1,29 @@
+import { mockAxiosDelete } from "../../utls/http-requests-mock";
+import { NodeService } from "../../../src/commands/configuration-management/node.service";
+import { testContext } from "../../utls/test-context";
+import { loggingTestTransport } from "../../jest.setup";
+
+describe("Node archive", () => {
+    const packageKey = "package-key";
+    const nodeKey = "node-key";
+
+    it("Should archive node without force", async () => {
+        const apiUrl = `https://myTeam.celonis.cloud/pacman/api/core/staging/packages/${packageKey}/nodes/${nodeKey}/archive?force=false`;
+        mockAxiosDelete(apiUrl);
+
+        await new NodeService(testContext).archiveNode(packageKey, nodeKey, false);
+
+        expect(loggingTestTransport.logMessages.length).toBe(1);
+        expect(loggingTestTransport.logMessages[0].message).toContain(`Node ${nodeKey} in package ${packageKey} archived successfully.`);
+    });
+
+    it("Should archive node with force", async () => {
+        const apiUrl = `https://myTeam.celonis.cloud/pacman/api/core/staging/packages/${packageKey}/nodes/${nodeKey}/archive?force=true`;
+        mockAxiosDelete(apiUrl);
+
+        await new NodeService(testContext).archiveNode(packageKey, nodeKey, true);
+
+        expect(loggingTestTransport.logMessages.length).toBe(1);
+        expect(loggingTestTransport.logMessages[0].message).toContain(`Node ${nodeKey} in package ${packageKey} archived successfully.`);
+    });
+});

--- a/tests/commands/configuration-management/config-node-create.spec.ts
+++ b/tests/commands/configuration-management/config-node-create.spec.ts
@@ -54,7 +54,7 @@ describe("Node create", () => {
 
         const expectedFileName = loggingTestTransport.logMessages[0].message.split(FileService.fileDownloadedMessage)[1];
 
-        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), expect.any(String), {encoding: "utf-8"});
+        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), expect.any(String), {encoding: "utf-8", mode: 0o600});
 
         const savedTransport = JSON.parse(mockWriteFileSync.mock.calls[0][1]) as NodeTransport;
 

--- a/tests/commands/configuration-management/config-node-create.spec.ts
+++ b/tests/commands/configuration-management/config-node-create.spec.ts
@@ -1,0 +1,87 @@
+import { NodeTransport, SaveNodeTransport } from "../../../src/commands/configuration-management/interfaces/node.interfaces";
+import { mockAxiosPost, mockedPostRequestBodyByUrl } from "../../utls/http-requests-mock";
+import { NodeService } from "../../../src/commands/configuration-management/node.service";
+import { testContext } from "../../utls/test-context";
+import { loggingTestTransport, mockWriteFileSync } from "../../jest.setup";
+import { FileService } from "../../../src/core/utils/file-service";
+import * as path from "path";
+
+describe("Node create", () => {
+    const packageKey = "package-key";
+    const apiUrl = `https://myTeam.celonis.cloud/pacman/api/core/staging/packages/${packageKey}/nodes`;
+    const validateOnlyUrl = `https://myTeam.celonis.cloud/pacman/api/core/staging/packages/${packageKey}/nodes?validate=true`;
+
+    const createdNode: NodeTransport = {
+        id: "new-node-id",
+        key: "new-node-key",
+        name: "New Node",
+        packageNodeKey: packageKey,
+        parentNodeKey: packageKey,
+        packageNodeId: "package-node-id",
+        type: "VIEW",
+        invalidContent: false,
+        creationDate: new Date().toISOString(),
+        changeDate: new Date().toISOString(),
+        createdBy: "user-id",
+        updatedBy: "user-id",
+        schemaVersion: 2,
+        flavor: "STUDIO",
+    };
+
+    const saveTransport: SaveNodeTransport = {
+        key: "new-node-key",
+        name: "New Node",
+        parentNodeKey: packageKey,
+        type: "VIEW",
+        configuration: { someKey: "someValue" },
+    };
+
+    it("Should create node and print result", async () => {
+        mockAxiosPost(apiUrl, createdNode);
+
+        await new NodeService(testContext).createNode(packageKey, JSON.stringify(saveTransport), false, false);
+
+        expect(loggingTestTransport.logMessages.length).toBe(11);
+        expect(loggingTestTransport.logMessages[0].message).toContain(`ID: ${createdNode.id}`);
+        expect(loggingTestTransport.logMessages[1].message).toContain(`Key: ${createdNode.key}`);
+        expect(loggingTestTransport.logMessages[2].message).toContain(`Name: ${createdNode.name}`);
+    });
+
+    it("Should create node and return as JSON", async () => {
+        mockAxiosPost(apiUrl, createdNode);
+
+        await new NodeService(testContext).createNode(packageKey, JSON.stringify(saveTransport), false, true);
+
+        const expectedFileName = loggingTestTransport.logMessages[0].message.split(FileService.fileDownloadedMessage)[1];
+
+        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), expect.any(String), {encoding: "utf-8"});
+
+        const savedTransport = JSON.parse(mockWriteFileSync.mock.calls[0][1]) as NodeTransport;
+
+        expect(savedTransport).toEqual(createdNode);
+    });
+
+    it("Should send correct request body", async () => {
+        mockAxiosPost(apiUrl, createdNode);
+
+        await new NodeService(testContext).createNode(packageKey, JSON.stringify(saveTransport), false, false);
+
+        const requestBody = JSON.parse(mockedPostRequestBodyByUrl.get(apiUrl));
+        expect(requestBody.key).toBe(saveTransport.key);
+        expect(requestBody.name).toBe(saveTransport.name);
+        expect(requestBody.parentNodeKey).toBe(saveTransport.parentNodeKey);
+        expect(requestBody.type).toBe(saveTransport.type);
+    });
+
+    it("Should call validate-only endpoint when validateOnly=true", async () => {
+        mockAxiosPost(validateOnlyUrl, undefined);
+
+        await new NodeService(testContext).createNode(packageKey, JSON.stringify(saveTransport), true, false);
+
+        expect(mockWriteFileSync).not.toHaveBeenCalled();
+        expect(loggingTestTransport.logMessages.length).toBe(1);
+        expect(loggingTestTransport.logMessages[0].message).toContain(
+            `Validation successful for node ${saveTransport.key} in package ${packageKey}.`
+        );
+    });
+});

--- a/tests/commands/configuration-management/config-node-create.spec.ts
+++ b/tests/commands/configuration-management/config-node-create.spec.ts
@@ -39,7 +39,7 @@ describe("Node create", () => {
     it("Should create node and print result", async () => {
         mockAxiosPost(apiUrl, createdNode);
 
-        await new NodeService(testContext).createNode(packageKey, JSON.stringify(saveTransport), false, false);
+        await new NodeService(testContext).createNode(packageKey, JSON.stringify(saveTransport), undefined, false, false);
 
         expect(loggingTestTransport.logMessages.length).toBe(11);
         expect(loggingTestTransport.logMessages[0].message).toContain(`ID: ${createdNode.id}`);
@@ -50,7 +50,7 @@ describe("Node create", () => {
     it("Should create node and return as JSON", async () => {
         mockAxiosPost(apiUrl, createdNode);
 
-        await new NodeService(testContext).createNode(packageKey, JSON.stringify(saveTransport), false, true);
+        await new NodeService(testContext).createNode(packageKey, JSON.stringify(saveTransport), undefined, false, true);
 
         const expectedFileName = loggingTestTransport.logMessages[0].message.split(FileService.fileDownloadedMessage)[1];
 
@@ -64,7 +64,7 @@ describe("Node create", () => {
     it("Should send correct request body", async () => {
         mockAxiosPost(apiUrl, createdNode);
 
-        await new NodeService(testContext).createNode(packageKey, JSON.stringify(saveTransport), false, false);
+        await new NodeService(testContext).createNode(packageKey, JSON.stringify(saveTransport), undefined, false, false);
 
         const requestBody = JSON.parse(mockedPostRequestBodyByUrl.get(apiUrl));
         expect(requestBody.key).toBe(saveTransport.key);
@@ -76,7 +76,7 @@ describe("Node create", () => {
     it("Should call validate-only endpoint when validateOnly=true", async () => {
         mockAxiosPost(validateOnlyUrl, undefined);
 
-        await new NodeService(testContext).createNode(packageKey, JSON.stringify(saveTransport), true, false);
+        await new NodeService(testContext).createNode(packageKey, JSON.stringify(saveTransport), undefined, true, false);
 
         expect(mockWriteFileSync).not.toHaveBeenCalled();
         expect(loggingTestTransport.logMessages.length).toBe(1);

--- a/tests/commands/configuration-management/config-node-update.spec.ts
+++ b/tests/commands/configuration-management/config-node-update.spec.ts
@@ -53,7 +53,7 @@ describe("Node update", () => {
 
         const expectedFileName = loggingTestTransport.logMessages[0].message.split(FileService.fileDownloadedMessage)[1];
 
-        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), expect.any(String), {encoding: "utf-8"});
+        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), expect.any(String), {encoding: "utf-8", mode: 0o600});
 
         const savedTransport = JSON.parse(mockWriteFileSync.mock.calls[0][1]) as NodeTransport;
 

--- a/tests/commands/configuration-management/config-node-update.spec.ts
+++ b/tests/commands/configuration-management/config-node-update.spec.ts
@@ -38,7 +38,7 @@ describe("Node update", () => {
     it("Should update node and print result", async () => {
         mockAxiosPut(apiUrl, updatedNode);
 
-        await new NodeService(testContext).updateNode(packageKey, nodeKey, JSON.stringify(updateTransport), false, false);
+        await new NodeService(testContext).updateNode(packageKey, nodeKey, JSON.stringify(updateTransport), undefined, false, false);
 
         expect(loggingTestTransport.logMessages.length).toBe(11);
         expect(loggingTestTransport.logMessages[0].message).toContain(`ID: ${updatedNode.id}`);
@@ -49,7 +49,7 @@ describe("Node update", () => {
     it("Should update node and return as JSON", async () => {
         mockAxiosPut(apiUrl, updatedNode);
 
-        await new NodeService(testContext).updateNode(packageKey, nodeKey, JSON.stringify(updateTransport), false, true);
+        await new NodeService(testContext).updateNode(packageKey, nodeKey, JSON.stringify(updateTransport), undefined, false, true);
 
         const expectedFileName = loggingTestTransport.logMessages[0].message.split(FileService.fileDownloadedMessage)[1];
 
@@ -63,7 +63,7 @@ describe("Node update", () => {
     it("Should send correct request body", async () => {
         mockAxiosPut(apiUrl, updatedNode);
 
-        await new NodeService(testContext).updateNode(packageKey, nodeKey, JSON.stringify(updateTransport), false, false);
+        await new NodeService(testContext).updateNode(packageKey, nodeKey, JSON.stringify(updateTransport), undefined, false, false);
 
         const requestBody = JSON.parse(mockedPostRequestBodyByUrl.get(apiUrl));
         expect(requestBody.name).toBe(updateTransport.name);
@@ -74,7 +74,7 @@ describe("Node update", () => {
     it("Should call validate-only endpoint when validateOnly=true", async () => {
         mockAxiosPut(validateOnlyUrl, undefined);
 
-        await new NodeService(testContext).updateNode(packageKey, nodeKey, JSON.stringify(updateTransport), true, false);
+        await new NodeService(testContext).updateNode(packageKey, nodeKey, JSON.stringify(updateTransport), undefined, true, false);
 
         expect(mockWriteFileSync).not.toHaveBeenCalled();
         expect(loggingTestTransport.logMessages.length).toBe(1);

--- a/tests/commands/configuration-management/config-node-update.spec.ts
+++ b/tests/commands/configuration-management/config-node-update.spec.ts
@@ -1,0 +1,85 @@
+import { NodeTransport, UpdateNodeTransport } from "../../../src/commands/configuration-management/interfaces/node.interfaces";
+import { mockAxiosPut, mockedPostRequestBodyByUrl } from "../../utls/http-requests-mock";
+import { NodeService } from "../../../src/commands/configuration-management/node.service";
+import { testContext } from "../../utls/test-context";
+import { loggingTestTransport, mockWriteFileSync } from "../../jest.setup";
+import { FileService } from "../../../src/core/utils/file-service";
+import * as path from "path";
+
+describe("Node update", () => {
+    const packageKey = "package-key";
+    const nodeKey = "node-key";
+    const apiUrl = `https://myTeam.celonis.cloud/pacman/api/core/staging/packages/${packageKey}/nodes/${nodeKey}`;
+    const validateOnlyUrl = `https://myTeam.celonis.cloud/pacman/api/core/staging/packages/${packageKey}/nodes/${nodeKey}?validate=true`;
+
+    const updatedNode: NodeTransport = {
+        id: "node-id",
+        key: nodeKey,
+        name: "Updated Node Name",
+        packageNodeKey: packageKey,
+        parentNodeKey: packageKey,
+        packageNodeId: "package-node-id",
+        type: "VIEW",
+        invalidContent: false,
+        creationDate: new Date().toISOString(),
+        changeDate: new Date().toISOString(),
+        createdBy: "user-id",
+        updatedBy: "user-id",
+        schemaVersion: 2,
+        flavor: "STUDIO",
+    };
+
+    const updateTransport: UpdateNodeTransport = {
+        name: "Updated Node Name",
+        parentNodeKey: packageKey,
+        configuration: { updatedKey: "updatedValue" },
+    };
+
+    it("Should update node and print result", async () => {
+        mockAxiosPut(apiUrl, updatedNode);
+
+        await new NodeService(testContext).updateNode(packageKey, nodeKey, JSON.stringify(updateTransport), false, false);
+
+        expect(loggingTestTransport.logMessages.length).toBe(11);
+        expect(loggingTestTransport.logMessages[0].message).toContain(`ID: ${updatedNode.id}`);
+        expect(loggingTestTransport.logMessages[1].message).toContain(`Key: ${updatedNode.key}`);
+        expect(loggingTestTransport.logMessages[2].message).toContain(`Name: ${updatedNode.name}`);
+    });
+
+    it("Should update node and return as JSON", async () => {
+        mockAxiosPut(apiUrl, updatedNode);
+
+        await new NodeService(testContext).updateNode(packageKey, nodeKey, JSON.stringify(updateTransport), false, true);
+
+        const expectedFileName = loggingTestTransport.logMessages[0].message.split(FileService.fileDownloadedMessage)[1];
+
+        expect(mockWriteFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), expectedFileName), expect.any(String), {encoding: "utf-8"});
+
+        const savedTransport = JSON.parse(mockWriteFileSync.mock.calls[0][1]) as NodeTransport;
+
+        expect(savedTransport).toEqual(updatedNode);
+    });
+
+    it("Should send correct request body", async () => {
+        mockAxiosPut(apiUrl, updatedNode);
+
+        await new NodeService(testContext).updateNode(packageKey, nodeKey, JSON.stringify(updateTransport), false, false);
+
+        const requestBody = JSON.parse(mockedPostRequestBodyByUrl.get(apiUrl));
+        expect(requestBody.name).toBe(updateTransport.name);
+        expect(requestBody.parentNodeKey).toBe(updateTransport.parentNodeKey);
+        expect(requestBody.configuration).toEqual(updateTransport.configuration);
+    });
+
+    it("Should call validate-only endpoint when validateOnly=true", async () => {
+        mockAxiosPut(validateOnlyUrl, undefined);
+
+        await new NodeService(testContext).updateNode(packageKey, nodeKey, JSON.stringify(updateTransport), true, false);
+
+        expect(mockWriteFileSync).not.toHaveBeenCalled();
+        expect(loggingTestTransport.logMessages.length).toBe(1);
+        expect(loggingTestTransport.logMessages[0].message).toContain(
+            `Validation successful for node ${nodeKey} in package ${packageKey}.`
+        );
+    });
+});

--- a/tests/utls/http-requests-mock.ts
+++ b/tests/utls/http-requests-mock.ts
@@ -7,6 +7,7 @@ const mockedAxiosInstance = {} as AxiosInstance;
 const mockedGetResponseByUrl = new Map<string, any>();
 const mockedPostResponseByUrl = new Map<string, any>();
 const mockedPostRequestBodyByUrl = new Map<string, any>();
+const mockedDeleteResponseByUrl = new Map<string, any>();
 
 const mockAxios = () : void => {
     AxiosInitializer.initializeAxios = jest.fn().mockReturnValue(mockedAxiosInstance);
@@ -14,6 +15,7 @@ const mockAxios = () : void => {
     mockedAxiosInstance.get = jest.fn();
     mockedAxiosInstance.post = jest.fn();
     mockedAxiosInstance.put = jest.fn();
+    mockedAxiosInstance.delete = jest.fn();
 }
 
 const mockAxiosGet = (url: string, responseData: any) => {
@@ -68,10 +70,22 @@ const mockAxiosPut = (url: string, responseData: any) => {
     })
 }
 
+const mockAxiosDelete = (url: string) => {
+    mockedDeleteResponseByUrl.set(url, undefined);
+    (mockedAxiosInstance.delete as jest.Mock).mockImplementation((requestUrl: string) => {
+        if (mockedDeleteResponseByUrl.has(requestUrl)) {
+            return Promise.resolve({ data: undefined, status: 204 });
+        } else {
+            fail("API call not mocked.")
+        }
+    })
+}
+
 afterEach(() => {
     mockedGetResponseByUrl.clear();
     mockedPostResponseByUrl.clear();
     mockedPostRequestBodyByUrl.clear();
+    mockedDeleteResponseByUrl.clear();
 })
 
 export {
@@ -80,5 +94,6 @@ export {
     mockAxiosGet,
     mockAxiosPost,
     mockAxiosPut,
+    mockAxiosDelete,
     mockedPostRequestBodyByUrl
 };


### PR DESCRIPTION
#### Description

Adds new CLI commands for single-node operations against the Pacman public API:

- `config nodes create --packageKey ... [--body <json> | -f <file>] [--validate] [--json]` — creates a staging node. `--validate` calls the validate-only endpoint (no persistence) and exits with a success log if the payload is valid; otherwise fails.
- `config nodes update --packageKey ... --nodeKey ... [--body <json> | -f <file>] [--validate] [--json]` — updates a staging node. `--validate` behaves the same as above.
- `config nodes delete --packageKey ... --nodeKey ... [--force]` — archives a staging node.

Payload can be provided either inline via `--body` or from a file via `-f/--file` (mutually exclusive; one is required for create/update).

#### Relevant links

- Jira: https://celonis.atlassian.net/browse/SP-38
- Pacman endpoints PR: https://github.com/celonis/pacman/pull/1647

#### Checklist

- [x] I have self-reviewed this PR
- [x] I have tested the change and proved that it works in different scenarios
- [ ] I have updated docs if needed