### PR TITLE
SP-40: remove redundant base path from asset reg list summary

### DIFF
--- a/src/commands/asset-registry/asset-registry.service.ts
+++ b/src/commands/asset-registry/asset-registry.service.ts
@@ -70,7 +70,7 @@ export class AssetRegistryService {
 
     private logDescriptorSummary(descriptor: AssetRegistryDescriptor): void {
         logger.info(
-            `${descriptor.assetType} - ${descriptor.displayName} [${descriptor.group}] (basePath: ${descriptor.service.basePath})`
+            `${descriptor.assetType} - ${descriptor.displayName} [${descriptor.group}]`
         );
     }
 


### PR DESCRIPTION
#### Description

With the introduction of the public proxy API endpoints, the `basePath` of the public API is always the same and therefore redundant.

Output of `asset-registry list` before this change:

```
info:    ai-annotations-agent-widget - Annotation Builder LLM [AI/ML Tools] (basePath: /pacman/api)
info:    BOARD_V2 - View [DASHBOARDS] (basePath: /pacman/api)
...
```

Output after this change:
```
info:    ai-annotations-agent-widget - Annotation Builder LLM [AI/ML Tools]
info:    BOARD_V2 - View [DASHBOARDS]
...
```

#### Relevant links

- Jira: [SP-40](https://celonis.atlassian.net/browse/SP-40)

#### Checklist

- [X] I have self-reviewed this PR
- [X] I have tested the change and proved that it works in different scenarios
- [ ] I have updated docs if needed


[SP-40]: https://celonis.atlassian.net/browse/SP-40?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only changes CLI log formatting for `asset-registry list` by removing the displayed `basePath`, with no API calls or data handling changes.
> 
> **Overview**
> Simplifies the `asset-registry list` console output by removing the redundant `(basePath: ...)` suffix from each asset type summary line.
> 
> Detailed output (`getType`/`logDescriptorDetail`) is unchanged and still includes `Base Path` when requested.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 30b37e9df29ee3918fd8f3157c72b9607b650104. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->