### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,14 +4,18 @@
 /src                                              @celonis/studio-platform
 /src/core                                         @celonis/studio-platform
 /src/commands/configuration-management/           @celonis/astro
+/tests/commands/configuration-management/         @celonis/astro
 /src/commands/profile/                            @celonis/studio-platform
 /src/commands/asset-registry/                     @celonis/astro
+/tests/commands/asset-registry/                   @celonis/astro
 /src/commands/deployment/                         @celonis/astro
+/tests/commands/deployment/                       @celonis/astro
 /src/commands/action-flows/                       @celonis/process-automation
 /tests/commands/action-flows/                     @celonis/process-automation
 /src/commands/analysis/                           @celonis/process-analytics
 /src/commands/cpm4/                               @celonis/cpm4
 /src/commands/data-pipeline/                      @Dusan-r @IvanGandacov @EktaCelonis @gorasoCelonis
 /src/commands/studio/                             @celonis/astro
+/tests/commands/studio/                           @celonis/astro
 /package.json                                     @celonis/studio-platform @aocelo @siavash-celonis
 /yarn.lock                                        @celonis/studio-platform @aocelo @siavash-celonis

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,10 +1,10 @@
-*                                                 @celonis/astro
+*                                                 @celonis/studio-platform
 
-/*                                                @celonis/astro
-/src                                              @celonis/astro
-/src/core                                         @celonis/astro
+/*                                                @celonis/studio-platform
+/src                                              @celonis/studio-platform
+/src/core                                         @celonis/studio-platform
 /src/commands/configuration-management/           @celonis/astro
-/src/commands/profile/                            @celonis/astro
+/src/commands/profile/                            @celonis/studio-platform
 /src/commands/asset-registry/                     @celonis/astro
 /src/commands/deployment/                         @celonis/astro
 /src/commands/action-flows/                       @celonis/process-automation
@@ -13,5 +13,5 @@
 /src/commands/cpm4/                               @celonis/cpm4
 /src/commands/data-pipeline/                      @Dusan-r @IvanGandacov @EktaCelonis @gorasoCelonis
 /src/commands/studio/                             @celonis/astro
-/package.json                                     @celonis/astro @aocelo @siavash-celonis
-/yarn.lock                                        @celonis/astro @aocelo @siavash-celonis
+/package.json                                     @celonis/studio-platform @aocelo @siavash-celonis
+/yarn.lock                                        @celonis/studio-platform @aocelo @siavash-celonis


### PR DESCRIPTION
#### Description

Update `.github/CODEOWNERS`:

- Catch-all and `/src/commands/profile/` move to `@celonis/studio-platform`.
- `configuration-management/`, `asset-registry/`, `deployment/`, and `studio/` stay on `@celonis/astro`.
- Other teams' folders unchanged.

#### Checklist

- [x] I have self-reviewed this PR