### PR TITLE
SP-159: do not move package to space if branch package

### DIFF
--- a/src/commands/configuration-management/studio.service.ts
+++ b/src/commands/configuration-management/studio.service.ts
@@ -23,6 +23,7 @@ import { SpaceApi } from "../studio/api/space-api";
 import { StudioVariablesApi } from "../studio/api/studio-variables-api";
 import { SpaceService } from "../studio/service/space.service";
 import { StudioVariableService } from "../studio/service/studio-variable.service";
+import { BranchUtils } from "../../core/utils/branches";
 
 export class StudioService {
 
@@ -103,7 +104,7 @@ export class StudioService {
         }
         for (const  manifest of studioManifests) {
             const existingPackage = existingStudioPackages.find(existingPackage => existingPackage.key === manifest.packageKey);
-            if (existingPackage) {
+            if (existingPackage && !BranchUtils.isBranchPackageKey(existingPackage.key)) {
                 await this.studioPackageApi.movePackageToSpace(existingPackage.id, manifest.space.id);
             }
             await this.assignRuntimeVariables(manifest);

--- a/src/core/utils/branches.ts
+++ b/src/core/utils/branches.ts
@@ -1,11 +1,6 @@
 export class BranchUtils {
     private static readonly BRANCH_SEPARATOR = "@";
 
-    /**
-     * Checks if a package key represents a branch.
-     * @param packageKey The string to check
-     * @throws Error if the package key is null, undefined, or empty/whitespace
-     */
     public static isBranchPackageKey(packageKey: string): boolean {
         if (!packageKey || packageKey.trim().length === 0) {
             throw new Error("Package key cannot be empty");

--- a/src/core/utils/branches.ts
+++ b/src/core/utils/branches.ts
@@ -1,0 +1,16 @@
+export class BranchUtils {
+    private static readonly BRANCH_SEPARATOR = "@";
+
+    /**
+     * Checks if a package key represents a branch.
+     * @param packageKey The string to check
+     * @throws Error if the package key is null, undefined, or empty/whitespace
+     */
+    public static isBranchPackageKey(packageKey: string): boolean {
+        if (!packageKey || packageKey.trim().length === 0) {
+            throw new Error("Package key cannot be empty");
+        }
+
+        return packageKey.includes(BranchUtils.BRANCH_SEPARATOR);
+    }
+}

--- a/tests/core/utils/branches.spec.ts
+++ b/tests/core/utils/branches.spec.ts
@@ -1,0 +1,25 @@
+import { BranchUtils } from "../../../src/core/utils/branches";
+
+describe("BranchUtils", () => {
+    describe("isBranchPackageKey", () => {
+        it("should return true when package key contains branch separator", () => {
+            expect(BranchUtils.isBranchPackageKey("package@feature-branch")).toBe(true);
+        });
+
+        it("should return false when package key does not contain branch separator", () => {
+            expect(BranchUtils.isBranchPackageKey("package")).toBe(false);
+        });
+
+        it("should throw an error if the input is empty", () => {
+            expect(() => BranchUtils.isBranchPackageKey("")).toThrow("Package key cannot be empty");
+        });
+
+        it("should throw an error if the input is only whitespace", () => {
+            expect(() => BranchUtils.isBranchPackageKey("   ")).toThrow("Package key cannot be empty");
+        });
+
+        it("should throw an error if the input is null", () => {
+            expect(() => BranchUtils.isBranchPackageKey(null)).toThrow("Package key cannot be empty");
+        });
+    });
+});


### PR DESCRIPTION
#### Description

This PR ensures that Content-CLI does not move a package to a space if it is a branch package, thereby avoiding a possible `MoveNodeException` in pacman.

#### Relevant links

- Jira: [SP-159](https://celonis.atlassian.net/browse/SP-159)

#### Checklist

- [x] I have self-reviewed this PR
- [x] I have tested the change and proved that it works in different scenarios
- [ ] I have updated docs if needed


[SP-159]: https://celonis.atlassian.net/browse/SP-159?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ