### PR TITLE
SP-397: include description in asset-registry list output

### DIFF
--- a/docs/user-guide/asset-registry-commands.md
+++ b/docs/user-guide/asset-registry-commands.md
@@ -14,9 +14,11 @@ content-cli asset-registry list
 Example output:
 
 ```
-BOARD_V2 - View [DASHBOARDS] (basePath: /blueprint/api)
-SEMANTIC_MODEL - Knowledge Model [DATA_AND_PROCESS_MODELING] (basePath: /semantic-layer/api)
+BOARD_V2 - View [DASHBOARDS]
+SEMANTIC_MODEL - Knowledge Model [DATA_AND_PROCESS_MODELING] - Defines KPIs, records, filters, and data bindings for analytics
 ```
+
+Each line is `<assetType> - <displayName> [<group>]` followed by ` - <description>` when the asset type provides one.
 
 It is also possible to use the `--json` option for writing the full response to a file that gets created in the working directory.
 

--- a/src/commands/asset-registry/asset-registry.service.ts
+++ b/src/commands/asset-registry/asset-registry.service.ts
@@ -131,9 +131,12 @@ export class AssetRegistryService {
     }
 
     private logDescriptorSummary(descriptor: AssetRegistryDescriptor): void {
-        logger.info(
-            `${descriptor.assetType} - ${descriptor.displayName} [${descriptor.group}]`
-        );
+        const base = `${descriptor.assetType} - ${descriptor.displayName} [${descriptor.group}]`;
+        if (descriptor.description) {
+            logger.info(`${base} - ${descriptor.description}`);
+        } else {
+            logger.info(base);
+        }
     }
 
     private logDescriptorDetail(descriptor: AssetRegistryDescriptor): void {

--- a/tests/commands/asset-registry/asset-registry-list.spec.ts
+++ b/tests/commands/asset-registry/asset-registry-list.spec.ts
@@ -42,22 +42,44 @@ describe("Asset registry list", () => {
         },
     };
 
-    it("Should list all asset types with description when present", async () => {
-        mockAxiosGet("https://myTeam.celonis.cloud/pacman/api/core/asset-registry/types", metadata);
+    it("Should render the description when it is present", async () => {
+        const withDescription: AssetRegistryMetadata = {
+            types: {
+                SEMANTIC_MODEL: metadata.types.SEMANTIC_MODEL,
+            },
+        };
+        mockAxiosGet(
+            "https://myTeam.celonis.cloud/pacman/api/core/asset-registry/types",
+            withDescription
+        );
 
         await new AssetRegistryService(testContext).listTypes(false);
 
-        expect(loggingTestTransport.logMessages.length).toBe(2);
+        expect(loggingTestTransport.logMessages.length).toBe(1);
+        expect(loggingTestTransport.logMessages[0].message).toContain(
+            "SEMANTIC_MODEL - Knowledge Model [DATA_AND_PROCESS_MODELING] - Defines KPIs, records, filters, and data bindings for analytics"
+        );
+    });
 
+    it("Should omit the description when it is not present", async () => {
+        const withoutDescription: AssetRegistryMetadata = {
+            types: {
+                BOARD_V2: metadata.types.BOARD_V2
+            },
+        };
+        mockAxiosGet(
+            "https://myTeam.celonis.cloud/pacman/api/core/asset-registry/types",
+            withoutDescription
+        );
+
+        await new AssetRegistryService(testContext).listTypes(false);
+
+        expect(loggingTestTransport.logMessages.length).toBe(1);
         expect(loggingTestTransport.logMessages[0].message).toContain(
             "BOARD_V2 - View [DASHBOARDS]"
         );
         expect(loggingTestTransport.logMessages[0].message).not.toContain(" - null");
         expect(loggingTestTransport.logMessages[0].message).not.toMatch(/\] - /);
-
-        expect(loggingTestTransport.logMessages[1].message).toContain(
-            "SEMANTIC_MODEL - Knowledge Model [DATA_AND_PROCESS_MODELING] - Defines KPIs, records, filters, and data bindings for analytics"
-        );
     });
 
     it("Should list all asset types as JSON", async () => {

--- a/tests/commands/asset-registry/asset-registry-list.spec.ts
+++ b/tests/commands/asset-registry/asset-registry-list.spec.ts
@@ -42,17 +42,22 @@ describe("Asset registry list", () => {
         },
     };
 
-    it("Should list all asset types", async () => {
+    it("Should list all asset types with description when present", async () => {
         mockAxiosGet("https://myTeam.celonis.cloud/pacman/api/core/asset-registry/types", metadata);
 
         await new AssetRegistryService(testContext).listTypes(false);
 
         expect(loggingTestTransport.logMessages.length).toBe(2);
-        expect(loggingTestTransport.logMessages[0].message).toContain("BOARD_V2");
-        expect(loggingTestTransport.logMessages[0].message).toContain("View");
-        expect(loggingTestTransport.logMessages[0].message).toContain("DASHBOARDS");
-        expect(loggingTestTransport.logMessages[1].message).toContain("SEMANTIC_MODEL");
-        expect(loggingTestTransport.logMessages[1].message).toContain("Knowledge Model");
+
+        expect(loggingTestTransport.logMessages[0].message).toContain(
+            "BOARD_V2 - View [DASHBOARDS]"
+        );
+        expect(loggingTestTransport.logMessages[0].message).not.toContain(" - null");
+        expect(loggingTestTransport.logMessages[0].message).not.toMatch(/\] - /);
+
+        expect(loggingTestTransport.logMessages[1].message).toContain(
+            "SEMANTIC_MODEL - Knowledge Model [DATA_AND_PROCESS_MODELING] - Defines KPIs, records, filters, and data bindings for analytics"
+        );
     });
 
     it("Should list all asset types as JSON", async () => {


### PR DESCRIPTION
`asset-registry list` previously rendered each entry as `<assetType> - <displayName> [<group>]`, dropping the descriptor's `description` field. Append ` - <description>` when a description is present and leave the line unchanged for descriptors with `null` descriptions. Update the user-guide example output (also drops a stale `(basePath: ...)` suffix the docs claimed but the code never produced) and refresh the unit test to cover both the with-description and no-description branches.

Changed files:
- `src/commands/asset-registry/asset-registry.service.ts` — `logDescriptorSummary` now conditionally appends the description.
- `tests/commands/asset-registry/asset-registry-list.spec.ts` — covers both the with-description and no-description branches (asserts no trailing ` - ` and no `null` literal when the descriptor has no description).
- `docs/user-guide/asset-registry-commands.md` — example output refreshed and a one-liner added explaining the format. Also drops a stale `(basePath: ...)` suffix the docs claimed but the code never produced.

#### Testing

- `npx jest --testPathPattern="asset-registry/asset-registry-list"` — 3/3 passing
- Full `asset-registry` suite — 36/36 passing
- Built locally and ran `asset-registry list` against develop; all 8 registered asset types now show their description after the group.

#### Relevant links

- Jira: [SP-397](https://celonis.atlassian.net/browse/SP-397)

#### Checklist

- [x] I have self-reviewed this PR
- [x] I have tested the change and proved that it works in different scenarios
- [x] I have updated docs if needed


Includes-AI-Code: true

[SP-397]: https://celonis.atlassian.net/browse/SP-397?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ