### PR TITLE
SP-139: Document PACKAGE_SETTINGS validation layer

### DIFF
--- a/.cursor/skills/asset-registry-endpoints/SKILL.md
+++ b/.cursor/skills/asset-registry-endpoints/SKILL.md
@@ -298,6 +298,12 @@ staging version of a package, use `config validate`:
 $CLI config validate --packageKey <pkg> --layers SCHEMA BUSINESS PACKAGE_SETTINGS -p <profile>
 ```
 
+To validate only package settings without asset business rules:
+
+```bash
+$CLI config validate --packageKey <pkg> --layers SCHEMA PACKAGE_SETTINGS -p <profile>
+```
+
 - `--layers SCHEMA BUSINESS PACKAGE_SETTINGS` runs all validation layers in a
   single request. Supported values today are `SCHEMA`, `BUSINESS`, and
   `PACKAGE_SETTINGS`.

--- a/.cursor/skills/asset-registry-endpoints/SKILL.md
+++ b/.cursor/skills/asset-registry-endpoints/SKILL.md
@@ -80,9 +80,11 @@ $CLI config import -d <export_dir> --validate --overwrite
   importing. If there are validation errors the import is **not** performed and
   the errors are returned. If there are no errors, the package and its assets
   are imported normally. To also run **BUSINESS-layer** rules (e.g. PQL
-  parsing, data-model availability, KPI uniqueness for Knowledge Models), run
-  `config validate --layers SCHEMA BUSINESS` against the imported staging
-  version — see *Validating an imported package* below.
+  parsing, data-model availability, KPI uniqueness for Knowledge Models) and
+  **PACKAGE_SETTINGS** checks (dependencies, variables, and flavor-specific
+  package settings), run
+  `config validate --layers SCHEMA BUSINESS PACKAGE_SETTINGS` against the
+  imported staging version — see *Validating an imported package* below.
 - `--overwrite` — required when updating an existing package
 - Without `--overwrite` — creates a **new** package (use for first-time import)
 
@@ -289,16 +291,19 @@ $CLI config import -d <export_dir> --validate --overwrite -p <profile>
 
 ### Validating an imported package
 
-To run **business-layer** rules against the staging version of a package (e.g.
-PQL parsing, data-model availability, KPI uniqueness for `SEMANTIC_MODEL`),
-use `config validate`:
+To run **business-layer** rules and **package-settings** checks against the
+staging version of a package, use `config validate`:
 
 ```bash
-$CLI config validate --packageKey <pkg> --layers SCHEMA BUSINESS -p <profile>
+$CLI config validate --packageKey <pkg> --layers SCHEMA BUSINESS PACKAGE_SETTINGS -p <profile>
 ```
 
-- `--layers SCHEMA BUSINESS` runs both layers in a single request. Supported
-  values today are `SCHEMA` and `BUSINESS`.
+- `--layers SCHEMA BUSINESS PACKAGE_SETTINGS` runs all validation layers in a
+  single request. Supported values today are `SCHEMA`, `BUSINESS`, and
+  `PACKAGE_SETTINGS`.
+- `PACKAGE_SETTINGS` validates package dependencies, package variable
+  definitions, variable assignments such as Studio data models, and
+  flavor-specific package settings for Studio/OCDM packages.
 - `--nodeKeys <key1> <key2>` (optional) restricts validation to specific nodes.
 - `--json` writes the full structured report to a file in the current working
   directory instead of printing to the console.
@@ -371,4 +376,4 @@ $CLI config import -d <export_dir> --validate --overwrite -p <profile>
 | `config list` | List packages |
 | `config export --packageKeys X --unzip` | Export packages |
 | `config import -d <dir> --validate --overwrite` | Validate (SCHEMA only) and import packages |
-| `config validate --packageKey P --layers SCHEMA BUSINESS` | Validate a package's staging version against the SCHEMA and/or BUSINESS layers |
+| `config validate --packageKey P --layers SCHEMA BUSINESS PACKAGE_SETTINGS` | Validate a package's staging version against the SCHEMA, BUSINESS, and/or PACKAGE_SETTINGS layers |

--- a/.cursor/skills/asset-registry-endpoints/SKILL.md
+++ b/.cursor/skills/asset-registry-endpoints/SKILL.md
@@ -382,4 +382,5 @@ $CLI config import -d <export_dir> --validate --overwrite -p <profile>
 | `config list` | List packages |
 | `config export --packageKeys X --unzip` | Export packages |
 | `config import -d <dir> --validate --overwrite` | Validate (SCHEMA only) and import packages |
+| `config validate --packageKey P --layers SCHEMA PACKAGE_SETTINGS` | Validate schema and package settings without running BUSINESS-layer rules |
 | `config validate --packageKey P --layers SCHEMA BUSINESS PACKAGE_SETTINGS` | Validate a package's staging version against the SCHEMA, BUSINESS, and/or PACKAGE_SETTINGS layers |

--- a/docs/user-guide/agentic-development-guide.md
+++ b/docs/user-guide/agentic-development-guide.md
@@ -87,10 +87,10 @@ Or validate during import with the `--validate` flag — note that this runs the
 content-cli config import -d <export_dir> --validate --overwrite
 ```
 
-To also run business-layer rules (PQL parsing, data-model availability, KPI uniqueness, …), run `config validate` against the just-imported staging version:
+To also run business-layer rules (PQL parsing, data-model availability, KPI uniqueness, …) and package-settings checks (dependencies, variables, and flavor-specific package settings), run `config validate` against the just-imported staging version:
 
 ```bash
-content-cli config validate --packageKey <package-key> --layers SCHEMA BUSINESS
+content-cli config validate --packageKey <package-key> --layers SCHEMA BUSINESS PACKAGE_SETTINGS
 ```
 
 If validation returns errors, fix the issues before importing.

--- a/docs/user-guide/config-commands.md
+++ b/docs/user-guide/config-commands.md
@@ -175,7 +175,7 @@ Add `--validate` to `config import` to run validation against each node **before
 content-cli config import -p <sourceProfile> -d <export_dir> --validate --overwrite
 ```
 
-`config import --validate` runs the **SCHEMA** layer only. It does **not** run BUSINESS-layer checks (PQL parsing, data-model availability, KPI uniqueness, etc.). To run business validation, use [`config validate`](#validate-package-configurations) after the import.
+`config import --validate` runs the **SCHEMA** layer only. It does **not** run BUSINESS-layer checks (PQL parsing, data-model availability, KPI uniqueness, etc.) or PACKAGE_SETTINGS checks (package dependencies, variables, and flavor-specific package settings). To run those validations, use [`config validate`](#validate-package-configurations) after the import.
 
 ## Validate Package Configurations
 
@@ -211,14 +211,17 @@ The `--layers` option selects which validation layers to run. Multiple layers ca
 |---|---|---|
 | `SCHEMA` | Asset-schema conformance of each node's `configuration` field — required properties, enum values, type checks, conditional schemas. | Asset registry |
 | `BUSINESS` | Asset-type-specific business rules — for `SEMANTIC_MODEL`, e.g. PQL parsing, data-model availability, KPI uniqueness. Rules live in the owning asset service. | Owning asset service (e.g. `cloud-semantic-layer` for Knowledge Models) |
+| `PACKAGE_SETTINGS` | Package-level configuration rules — package dependencies, package variable definitions, variable assignments such as Studio data models, and flavor-specific package settings for Studio/OCDM packages. | Pacman plus flavor-specific services |
 
-Currently `SCHEMA` and `BUSINESS` are the only layers accepted by the Pacman API. Other values are rejected with a `400 layers.unsupported` error.
+Currently `SCHEMA`, `BUSINESS`, and `PACKAGE_SETTINGS` are the layers accepted by the Pacman API. Other values are rejected with a `400 layers.unsupported` error.
 
-To run both layers:
+To run all layers:
 
 ```bash
-content-cli config validate --packageKey <packageKey> --layers SCHEMA BUSINESS
+content-cli config validate --packageKey <packageKey> --layers SCHEMA BUSINESS PACKAGE_SETTINGS
 ```
+
+Use `PACKAGE_SETTINGS` when you need to verify that the package's own settings are usable in the destination team before continuing authoring or import work. It reports issues such as missing dependency versions, duplicate dependency or variable keys, blank variable keys/types, missing Studio data model assignments, and OCDM package-settings problems when the corresponding backend validation is enabled.
 
 ### Validate Specific Nodes
 
@@ -233,7 +236,7 @@ content-cli config validate --packageKey <packageKey> --nodeKeys node-key-1 node
 Use `--json` to write the full validation report to a JSON file in the current working directory instead of printing it to the console:
 
 ```bash
-content-cli config validate --packageKey <packageKey> --layers SCHEMA BUSINESS --json
+content-cli config validate --packageKey <packageKey> --layers SCHEMA BUSINESS PACKAGE_SETTINGS --json
 ```
 
 The filename is printed on success:
@@ -253,7 +256,7 @@ interface ValidationReport {
 }
 
 interface ValidationResult {
-    layer: "SCHEMA" | "BUSINESS";
+    layer: "SCHEMA" | "BUSINESS" | "PACKAGE_SETTINGS";
     severity: "ERROR" | "WARNING" | "INFO";
     nodeKey: string;
     assetType: string;

--- a/src/commands/configuration-management/module.ts
+++ b/src/commands/configuration-management/module.ts
@@ -65,7 +65,7 @@ class Module extends IModule {
             .requiredOption("--packageKey <packageKey>", "Key of the package to validate")
             .option(
                 "--layers <layers...>",
-                "Validation layers to run. Allowed values: SCHEMA, BUSINESS (can be combined, e.g. --layers SCHEMA BUSINESS). Defaults to SCHEMA.",
+                "Validation layers to run. Allowed values: SCHEMA, BUSINESS, PACKAGE_SETTINGS (can be combined, e.g. --layers SCHEMA BUSINESS PACKAGE_SETTINGS). Defaults to SCHEMA.",
                 ["SCHEMA"]
             )
             .option("--nodeKeys <nodeKeys...>", "Specific node keys to validate (default: all nodes)")


### PR DESCRIPTION
#### Description

Documents the `PACKAGE_SETTINGS` validation layer for `config validate` so users and agents can discover how to run package-level checks after import.

- Adds `PACKAGE_SETTINGS` to `--layers` help.
- Updates the config user guide with package-settings validation scope and examples.
- Updates the agentic development guide and asset-registry skill quick reference.

#### Relevant links

- Jira: [SP-139](https://celonis.atlassian.net/browse/SP-139)

#### Checklist

- [x] I have self-reviewed this PR
- [x] I have tested the change and proved that it works in different scenarios — `yarn test tests/commands/configuration-management/config-validate.spec.ts`
- [x] I have updated docs if needed

Includes-AI-Code: true

Made with [Cursor](https://cursor.com)

[SP-139]: https://celonis.atlassian.net/browse/SP-139?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ