### PR TITLE
SP-807: Display skills endpoint when showing the descriptor

### DIFF
--- a/src/commands/asset-registry/asset-registry.interfaces.ts
+++ b/src/commands/asset-registry/asset-registry.interfaces.ts
@@ -25,6 +25,7 @@ export interface AssetEndpoints {
     schema: string;
     validate: string;
     examples?: string;
+    skills?: string;
 }
 
 export interface AssetContributions {

--- a/src/commands/asset-registry/asset-registry.service.ts
+++ b/src/commands/asset-registry/asset-registry.service.ts
@@ -176,5 +176,8 @@ export class AssetRegistryService {
         if (descriptor.endpoints.examples) {
             logger.info(`  examples:   ${descriptor.endpoints.examples}`);
         }
+        if (descriptor.endpoints.skills) {
+            logger.info(`  skills:     ${descriptor.endpoints.skills}`);
+        }
     }
 }

--- a/tests/commands/asset-registry/asset-registry-get.spec.ts
+++ b/tests/commands/asset-registry/asset-registry-get.spec.ts
@@ -38,6 +38,7 @@ describe("Asset registry get", () => {
                 expect.stringContaining("/validate/board_v2"),
             ])
         );
+        expect(messages.join("\n")).not.toContain("skills:");
     });
 
     it("Should get a specific asset type as JSON", async () => {
@@ -67,6 +68,26 @@ describe("Asset registry get", () => {
         expect(messages).toEqual(
             expect.arrayContaining([
                 expect.stringContaining("/examples/board_v2"),
+            ])
+        );
+    });
+
+    it("Should include the skills endpoint when present", async () => {
+        const descriptorWithSkillsEndpoint: AssetRegistryDescriptor = {
+            ...boardDescriptor,
+            endpoints: {
+                ...boardDescriptor.endpoints,
+                skills: "/skills/board_v2",
+            },
+        };
+        mockAxiosGet("https://myTeam.celonis.cloud/pacman/api/core/asset-registry/types/BOARD_V2", descriptorWithSkillsEndpoint);
+
+        await new AssetRegistryService(testContext).getType("BOARD_V2", false);
+
+        const messages = loggingTestTransport.logMessages.map((m) => m.message);
+        expect(messages).toEqual(
+            expect.arrayContaining([
+                expect.stringContaining("/skills/board_v2"),
             ])
         );
     });


### PR DESCRIPTION
#### Description

Displays the optional skills endpoint for asset registry descriptors (`asset-registry get` command).

#### Relevant links

- Jira: [SP-807](https://celonis.atlassian.net/browse/SP-807)

#### Checklist

- [x] I have self-reviewed this PR
- [x] I have tested the change and proved that it works in different scenarios
- [x] I have updated docs if needed


[SP-807]: https://celonis.atlassian.net/browse/SP-807?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI display and optional interface field only; no auth, validation, or API behavior changes.
> 
> **Overview**
> Extends asset registry descriptor typing and **`asset-registry get`** human-readable output so an optional **`skills`** API path is shown when the registry returns it, matching how **`examples`** is already handled.
> 
> **`AssetEndpoints`** gains an optional `skills` field; **`logDescriptorDetail`** logs a `skills:` line only when that value is set. Tests assert descriptors without `skills` do not print `skills:`, and that a descriptor with `/skills/board_v2` includes it in the log output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f720f8a9071e12a91ada8cdec0ac3700d50e887d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->