### PR TITLE
SP-758: add register() smoke test for asset-registry module

### DIFF
--- a/tests/commands/asset-registry/asset-registry-module.spec.ts
+++ b/tests/commands/asset-registry/asset-registry-module.spec.ts
@@ -2,6 +2,7 @@ import Module = require("../../../src/commands/asset-registry/module");
 import { Command, OptionValues } from "commander";
 import { AssetRegistryService } from "../../../src/commands/asset-registry/asset-registry.service";
 import { testContext } from "../../utls/test-context";
+import { createMockConfigurator } from "../../utls/configurator-mock";
 
 jest.mock("../../../src/commands/asset-registry/asset-registry.service");
 
@@ -114,5 +115,35 @@ describe("Asset Registry Module", () => {
         const options: OptionValues = { assetType: "BOARD_V2", json: "" };
         await (module as any).getType(testContext, mockCommand, options);
         expect(mockService.getType).toHaveBeenCalledWith("BOARD_V2", false);
+    });
+
+    describe("register", () => {
+        it("registers all expected command groups without throwing", () => {
+            const mockConfigurator = createMockConfigurator();
+
+            expect(() => new Module().register(testContext, mockConfigurator)).not.toThrow();
+
+            expect(mockConfigurator.command).toHaveBeenCalledWith("asset-registry");
+            expect(mockConfigurator.command).toHaveBeenCalledWith("skills");
+            expect(mockConfigurator.command).toHaveBeenCalledWith("list");
+            expect(mockConfigurator.command).toHaveBeenCalledWith("get");
+            expect(mockConfigurator.command).toHaveBeenCalledWith("schema");
+            expect(mockConfigurator.command).toHaveBeenCalledWith("examples");
+            expect(mockConfigurator.command).toHaveBeenCalledWith("validate");
+        });
+
+        it("wires an action handler for every leaf subcommand", () => {
+            const mockConfigurator = createMockConfigurator();
+
+            new Module().register(testContext, mockConfigurator);
+
+            // Each leaf command terminates the fluent chain with .action(handler).
+            // Keep this count in sync when adding or removing commands in module.ts.
+            const expectedLeafCommands = 6;
+            expect(mockConfigurator.action).toHaveBeenCalledTimes(expectedLeafCommands);
+            for (const call of mockConfigurator.action.mock.calls) {
+                expect(typeof call[0]).toBe("function");
+            }
+        });
     });
 });


### PR DESCRIPTION
#### Description

Mirrors the `register()` smoke-test pattern introduced for `configuration-management` in #363, this time for `asset-registry/module.ts`. Calling `module.register(testContext, mockConfigurator)` runs every `.command().option().action()` line in the module without spinning up Commander, flipping the entire `register()` body to covered.

Two new test cases added to `tests/commands/asset-registry/asset-registry-module.spec.ts`:

- **`registers all expected command groups without throwing`** — asserts that `asset-registry`, `skills`, and each of the five leaf command names (`list`, `get`, `schema`, `examples`, `validate`) are registered on the configurator chain.
- **`wires an action handler for every leaf subcommand`** — asserts that exactly `6` `.action()` calls land (`listTypes`, `getType`, `getSchema`, `getExamples`, `validate`, `listSkills`) and that each receives a function. The expected count guards against accidental additions or removals; update the constant when subcommands change.

No source code changes — test-only addition.

Verified locally:

```
PASS tests/commands/asset-registry/asset-registry-module.spec.ts
  Asset Registry Module
    ...
    register
      ✓ registers all expected command groups without throwing
      ✓ wires an action handler for every leaf subcommand

Tests: 10 passed, 10 total
```

#### Relevant links

- [SP-758](https://celonis.atlassian.net/browse/SP-758) — Unit test coverage uplift/refinement for content-cli to satisfy 90% launch requirement
- #363 — original `register()` smoke-test pattern for `configuration-management`

Made with [Cursor](https://cursor.com)

[SP-758]: https://celonis.atlassian.net/browse/SP-758?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ