### PR TITLE
BINFR-6408: Add pull/push view-bookmarks commands

### DIFF
--- a/docs/user-guide/studio-commands.md
+++ b/docs/user-guide/studio-commands.md
@@ -220,7 +220,7 @@ content-cli pull view-bookmarks --profile my-profile-name --id 73d39112-73ae-4bb
 ```
 
 After you have pulled your view bookmarks with the --type option,
-it's time to push them inside a view in a different package. You can accomplish this using
+it's time to push them inside a view in a different team. You can accomplish this using
 the same command as with pushing other assets to Studio:
 
 ```

--- a/docs/user-guide/studio-commands.md
+++ b/docs/user-guide/studio-commands.md
@@ -212,16 +212,16 @@ content-cli push analysis --help
 ## Pull and Push View Bookmarks
 
 Enable users to pull and push view (board) bookmarks using content-cli. For pulling view bookmarks
-you can specify --type (SHARED/ALL), and by default it fetches USER bookmarks.
+you can specify --type (SHARED/ALL/USER), and by default it fetches USER bookmarks:
 
 ```
 // Pull view bookmarks
 content-cli pull view-bookmarks --profile my-profile-name --id 73d39112-73ae-4bbe-8051-3c0f14e065ec --type SHARED
 ```
 
-After you have pulled your view bookmarks with the --type option,
+After you have pulled your view bookmarks,
 it's time to push them inside a view in a different team. You can accomplish this using
-the same command as with pushing other assets to Studio:
+the same command as with pushing other assets in Studio:
 
 ```
 // Push view bookmarks to Studio

--- a/docs/user-guide/studio-commands.md
+++ b/docs/user-guide/studio-commands.md
@@ -208,3 +208,22 @@ that analysis. Use the ***--help*** flag to see all options for a specific comma
 content-cli pull analysis --help
 content-cli push analysis --help
 ```
+
+## Pull and Push View Bookmarks
+
+Enable users to pull and push view (board) bookmarks using content-cli. For pulling view bookmarks
+you can specify --type (SHARED/ALL), and by default it fetches USER bookmarks.
+
+```
+// Pull view bookmarks
+content-cli pull view-bookmarks --profile my-profile-name --id 73d39112-73ae-4bbe-8051-3c0f14e065ec --type SHARED
+```
+
+After you have pulled your view bookmarks with the --type option,
+it's time to push them inside a view in a different package. You can accomplish this using
+the same command as with pushing other assets to Studio:
+
+```
+// Push view bookmarks to Studio
+content-cli push view-bookmarks -p my-profile-name --id 73d39112-73ae-4bbe-8051-3c0f14e065ec --file studio_view_bookmarks_39c5bb7b-b486-4230-ab01-854a17ddbff2.json
+```

--- a/src/commands/view/module.ts
+++ b/src/commands/view/module.ts
@@ -4,18 +4,8 @@
 
 import { Configurator, IModule } from "../../core/command/module-handler";
 import { Context } from "../../core/command/cli-context";
-import { Command, InvalidArgumentError, OptionValues } from "commander";
+import { Command, OptionValues } from "commander";
 import { ViewBookmarksCommandService } from "./view-bookmarks-command.service";
-
-const VIEW_BOOKMARK_TYPES = ["USER", "SHARED", "ALL"];
-
-function parseViewBookmarkType(value: string): string {
-    const normalized = value.toUpperCase();
-    if (!VIEW_BOOKMARK_TYPES.includes(normalized)) {
-        throw new InvalidArgumentError(`Allowed values are: ${VIEW_BOOKMARK_TYPES.join(", ")}.`);
-    }
-    return normalized;
-}
 
 class Module extends IModule {
 
@@ -24,7 +14,7 @@ class Module extends IModule {
         pullCommand
             .command("view-bookmarks")
             .description("Command to pull view bookmarks")
-            .option("--type <type>", "Type of view bookmarks to pull: USER (default), SHARED, or ALL", parseViewBookmarkType)
+            .option("--type <type>", "Type of view bookmarks to pull: USER (default), SHARED, or ALL")
             .requiredOption("--id <id>", "ID of the view (board) to pull bookmarks from")
             .action(this.pullViewBookmarks);
 

--- a/src/commands/view/module.ts
+++ b/src/commands/view/module.ts
@@ -4,8 +4,18 @@
 
 import { Configurator, IModule } from "../../core/command/module-handler";
 import { Context } from "../../core/command/cli-context";
-import { Command, OptionValues } from "commander";
+import { Command, InvalidArgumentError, OptionValues } from "commander";
 import { ViewBookmarksCommandService } from "./view-bookmarks-command.service";
+
+const VIEW_BOOKMARK_TYPES = ["USER", "SHARED", "ALL"];
+
+function parseViewBookmarkType(value: string): string {
+    const normalized = value.toUpperCase();
+    if (!VIEW_BOOKMARK_TYPES.includes(normalized)) {
+        throw new InvalidArgumentError(`Allowed values are: ${VIEW_BOOKMARK_TYPES.join(", ")}.`);
+    }
+    return normalized;
+}
 
 class Module extends IModule {
 
@@ -14,7 +24,7 @@ class Module extends IModule {
         pullCommand
             .command("view-bookmarks")
             .description("Command to pull view bookmarks")
-            .option("--type <type>", "Type of view bookmarks to pull: USER (default), SHARED, or ALL")
+            .option("--type <type>", "Type of view bookmarks to pull: USER (default), SHARED, or ALL", parseViewBookmarkType)
             .requiredOption("--id <id>", "ID of the view (board) to pull bookmarks from")
             .action(this.pullViewBookmarks);
 

--- a/src/commands/view/module.ts
+++ b/src/commands/view/module.ts
@@ -11,17 +11,19 @@ class Module extends IModule {
 
     public register(context: Context, configurator: Configurator): void {
         const pullCommand = configurator.command("pull");
-        pullCommand.command("view-bookmarks")
-            .description("Command to pull a view bookmarks")
-            .option("--type <type>", "Pull SHARED/ALL View Bookmarks, else by default get USER bookmarks")
-            .requiredOption("--id <id>", "Id of the view (board) you want to pull")
+        pullCommand
+            .command("view-bookmarks")
+            .description("Command to pull view bookmarks")
+            .option("--type <type>", "Type of view bookmarks to pull: USER (default), SHARED, or ALL")
+            .requiredOption("--id <id>", "ID of the view (board) to pull bookmarks from")
             .action(this.pullViewBookmarks);
 
         const pushCommand = configurator.command("push");
-        pushCommand.command("view-bookmarks")
-            .description("Command to push a view bookmarks to a board")
-            .requiredOption("--id <id>", "Id of the view (board) to which you want to push the view bookmarks")
-            .requiredOption("-f, --file <file>", "The file you want to push")
+        pushCommand
+            .command("view-bookmarks")
+            .description("Command to push view bookmarks to a board")
+            .requiredOption("--id <id>", "ID of the view (board) to push bookmarks into")
+            .requiredOption("-f, --file <file>", "The file to push")
             .action(this.pushViewBookmarks);
     }
 

--- a/src/commands/view/module.ts
+++ b/src/commands/view/module.ts
@@ -1,0 +1,37 @@
+/**
+ * Commands related to the View feature.
+ */
+
+import { Configurator, IModule } from "../../core/command/module-handler";
+import { Context } from "../../core/command/cli-context";
+import { Command, OptionValues } from "commander";
+import { ViewBookmarksCommandService } from "./view-bookmarks-command.service";
+
+class Module extends IModule {
+
+    public register(context: Context, configurator: Configurator): void {
+        const pullCommand = configurator.command("pull");
+        pullCommand.command("view-bookmarks")
+            .description("Command to pull a view bookmarks")
+            .option("--type <type>", "Pull SHARED/ALL View Bookmarks, else by default get USER bookmarks")
+            .requiredOption("--id <id>", "Id of the view (board) you want to pull")
+            .action(this.pullViewBookmarks);
+
+        const pushCommand = configurator.command("push");
+        pushCommand.command("view-bookmarks")
+            .description("Command to push a view bookmarks to a board")
+            .requiredOption("--id <id>", "Id of the view (board) to which you want to push the view bookmarks")
+            .requiredOption("-f, --file <file>", "The file you want to push")
+            .action(this.pushViewBookmarks);
+    }
+
+    private async pullViewBookmarks(context: Context, command: Command, options: OptionValues): Promise<void> {
+        await new ViewBookmarksCommandService(context).pullViewBookmarks(options.id, options.type);
+    }
+
+    private async pushViewBookmarks(context: Context, command: Command, options: OptionValues): Promise<void> {
+        await new ViewBookmarksCommandService(context).pushViewBookmarks(options.id, options.file);
+    }
+}
+
+export = Module;

--- a/src/commands/view/view-bookmarks-command.service.ts
+++ b/src/commands/view/view-bookmarks-command.service.ts
@@ -1,5 +1,8 @@
 import { ViewBookmarksManagerFactory } from "./view-bookmarks.manager-factory";
 import { Context } from "../../core/command/cli-context";
+import { FatalError, logger } from "../../core/utils/logger";
+
+const ALLOWED_VIEW_BOOKMARK_TYPES = ["USER", "SHARED", "ALL"];
 
 export class ViewBookmarksCommandService {
     private readonly viewBookmarksManagerFactory: ViewBookmarksManagerFactory;
@@ -9,6 +12,9 @@ export class ViewBookmarksCommandService {
     }
 
     public async pullViewBookmarks(boardId: string, type?: string): Promise<void> {
+        if (type !== undefined && !ALLOWED_VIEW_BOOKMARK_TYPES.includes(type.toUpperCase())) {
+            logger.error(new FatalError(`Invalid type "${type}". Allowed values are: ${ALLOWED_VIEW_BOOKMARK_TYPES.join(", ")}.`));
+        }
         await this.viewBookmarksManagerFactory.createViewBookmarksManager(null, boardId, type).pull();
     }
 

--- a/src/commands/view/view-bookmarks-command.service.ts
+++ b/src/commands/view/view-bookmarks-command.service.ts
@@ -1,0 +1,18 @@
+import { ViewBookmarksManagerFactory } from "./view-bookmarks.manager-factory";
+import { Context } from "../../core/command/cli-context";
+
+export class ViewBookmarksCommandService {
+    private viewBookmarksManagerFactory: ViewBookmarksManagerFactory;
+
+    constructor(context: Context) {
+        this.viewBookmarksManagerFactory = new ViewBookmarksManagerFactory(context);
+    }
+
+    public async pullViewBookmarks(boardId: string, type: string): Promise<void> {
+        await this.viewBookmarksManagerFactory.createViewBookmarksManager(null, boardId, type).pull();
+    }
+
+    public async pushViewBookmarks(boardId: string, filename: string): Promise<void> {
+        await this.viewBookmarksManagerFactory.createViewBookmarksManager(filename, boardId).push();
+    }
+}

--- a/src/commands/view/view-bookmarks-command.service.ts
+++ b/src/commands/view/view-bookmarks-command.service.ts
@@ -8,7 +8,7 @@ export class ViewBookmarksCommandService {
         this.viewBookmarksManagerFactory = new ViewBookmarksManagerFactory(context);
     }
 
-    public async pullViewBookmarks(boardId: string, type: string): Promise<void> {
+    public async pullViewBookmarks(boardId: string, type?: string): Promise<void> {
         await this.viewBookmarksManagerFactory.createViewBookmarksManager(null, boardId, type).pull();
     }
 

--- a/src/commands/view/view-bookmarks-command.service.ts
+++ b/src/commands/view/view-bookmarks-command.service.ts
@@ -2,7 +2,7 @@ import { ViewBookmarksManagerFactory } from "./view-bookmarks.manager-factory";
 import { Context } from "../../core/command/cli-context";
 
 export class ViewBookmarksCommandService {
-    private viewBookmarksManagerFactory: ViewBookmarksManagerFactory;
+    private readonly viewBookmarksManagerFactory: ViewBookmarksManagerFactory;
 
     constructor(context: Context) {
         this.viewBookmarksManagerFactory = new ViewBookmarksManagerFactory(context);

--- a/src/commands/view/view-bookmarks-command.service.ts
+++ b/src/commands/view/view-bookmarks-command.service.ts
@@ -14,6 +14,7 @@ export class ViewBookmarksCommandService {
     public async pullViewBookmarks(boardId: string, type?: string): Promise<void> {
         if (type !== undefined && !ALLOWED_VIEW_BOOKMARK_TYPES.includes(type.toUpperCase())) {
             logger.error(new FatalError(`Invalid type "${type}". Allowed values are: ${ALLOWED_VIEW_BOOKMARK_TYPES.join(", ")}.`));
+            return;
         }
         await this.viewBookmarksManagerFactory.createViewBookmarksManager(null, boardId, type).pull();
     }

--- a/src/commands/view/view-bookmarks.manager-factory.ts
+++ b/src/commands/view/view-bookmarks.manager-factory.ts
@@ -19,9 +19,7 @@ export class ViewBookmarksManagerFactory {
     ): ViewBookmarksManager {
         const viewBookmarksManager = new ViewBookmarksManager(this.context);
         viewBookmarksManager.boardId = boardId;
-        if (type === undefined || type === null) {
-            type = "USER";
-        }
+        type = (type ?? "USER").toUpperCase();
 
         viewBookmarksManager.type = type;
         if (filename !== null) {

--- a/src/commands/view/view-bookmarks.manager-factory.ts
+++ b/src/commands/view/view-bookmarks.manager-factory.ts
@@ -18,7 +18,7 @@ export class ViewBookmarksManagerFactory {
 
         viewBookmarksManager.type = type;
         if (filename !== null) {
-            viewBookmarksManager.fileName = this.resolveFilePath(filename);
+            viewBookmarksManager.filePath = this.resolveFilePath(filename);
         }
         return viewBookmarksManager;
     }

--- a/src/commands/view/view-bookmarks.manager-factory.ts
+++ b/src/commands/view/view-bookmarks.manager-factory.ts
@@ -5,30 +5,25 @@ import { FatalError, logger } from "../../core/utils/logger";
 import { Context } from "../../core/command/cli-context";
 
 export class ViewBookmarksManagerFactory {
-
     private readonly context: Context;
 
     constructor(context: Context) {
         this.context = context;
     }
 
-    public createViewBookmarksManager(
-        filename: string,
-        boardId: string,
-        type?: string
-    ): ViewBookmarksManager {
+    public createViewBookmarksManager(filename: string, boardId: string, type?: string): ViewBookmarksManager {
         const viewBookmarksManager = new ViewBookmarksManager(this.context);
         viewBookmarksManager.boardId = boardId;
         type = (type ?? "USER").toUpperCase();
 
         viewBookmarksManager.type = type;
         if (filename !== null) {
-            viewBookmarksManager.fileName = this.readFile(filename);
+            viewBookmarksManager.fileName = this.resolveFilePath(filename);
         }
         return viewBookmarksManager;
     }
 
-    private readFile(fileName: string): string {
+    private resolveFilePath(fileName: string): string {
         if (!fs.existsSync(path.resolve(process.cwd(), fileName))) {
             logger.error(new FatalError("The provided file does not exist"));
         }

--- a/src/commands/view/view-bookmarks.manager-factory.ts
+++ b/src/commands/view/view-bookmarks.manager-factory.ts
@@ -1,0 +1,39 @@
+import * as fs from "fs";
+import * as path from "path";
+import { ViewBookmarksManager } from "./view-bookmarks.manager";
+import { FatalError, logger } from "../../core/utils/logger";
+import { Context } from "../../core/command/cli-context";
+
+export class ViewBookmarksManagerFactory {
+
+    private readonly context: Context;
+
+    constructor(context: Context) {
+        this.context = context;
+    }
+
+    public createViewBookmarksManager(
+        filename: string,
+        boardId: string,
+        type?: string
+    ): ViewBookmarksManager {
+        const viewBookmarksManager = new ViewBookmarksManager(this.context);
+        viewBookmarksManager.boardId = boardId;
+        if (type === undefined || type === null) {
+            type = "USER";
+        }
+
+        viewBookmarksManager.type = type;
+        if (filename !== null) {
+            viewBookmarksManager.fileName = this.readFile(filename);
+        }
+        return viewBookmarksManager;
+    }
+
+    private readFile(fileName: string): string {
+        if (!fs.existsSync(path.resolve(process.cwd(), fileName))) {
+            logger.error(new FatalError("The provided file does not exist"));
+        }
+        return path.resolve(process.cwd(), fileName);
+    }
+}

--- a/src/commands/view/view-bookmarks.manager-factory.ts
+++ b/src/commands/view/view-bookmarks.manager-factory.ts
@@ -1,5 +1,5 @@
-import * as fs from "fs";
-import * as path from "path";
+import * as fs from "node:fs";
+import * as path from "node:path";
 import { ViewBookmarksManager } from "./view-bookmarks.manager";
 import { FatalError, logger } from "../../core/utils/logger";
 import { Context } from "../../core/command/cli-context";

--- a/src/commands/view/view-bookmarks.manager.ts
+++ b/src/commands/view/view-bookmarks.manager.ts
@@ -1,12 +1,12 @@
-import * as fs from "fs";
+import * as fs from "node:fs";
 import * as FormData from "form-data";
 import { Context } from "../../core/command/cli-context";
 import { BaseManager } from "../../core/http/http-shared/base.manager";
 import { ManagerConfig } from "../../core/http/http-shared/manager-config.interface";
 
 export class ViewBookmarksManager extends BaseManager {
-    private static BASE_URL = "/blueprint/api/bookmarks";
-    private static VIEW_BOOKMARKS_FILE_PREFIX = "studio_view_bookmarks_";
+    private static readonly BASE_URL = "/blueprint/api/bookmarks";
+    private static readonly VIEW_BOOKMARKS_FILE_PREFIX = "studio_view_bookmarks_";
 
     private _boardId: string;
     private _fileName: string;

--- a/src/commands/view/view-bookmarks.manager.ts
+++ b/src/commands/view/view-bookmarks.manager.ts
@@ -1,0 +1,64 @@
+import * as fs from "fs";
+import * as FormData from "form-data";
+import { Context } from "../../core/command/cli-context";
+import { BaseManager } from "../../core/http/http-shared/base.manager";
+import { ManagerConfig } from "../../core/http/http-shared/manager-config.interface";
+
+export class ViewBookmarksManager extends BaseManager {
+    private static BASE_URL = "/blueprint/api/bookmarks";
+    private static VIEW_BOOKMARKS_FILE_PREFIX = "studio_view_bookmarks_";
+
+    private _boardId: string;
+    private _fileName: string;
+    private _type: string;
+
+    constructor(context: Context) {
+        super(context);
+    }
+
+    public get fileName(): string {
+        return this._fileName;
+    }
+
+    public set fileName(value: string) {
+        this._fileName = value;
+    }
+
+    public get boardId(): string {
+        return this._boardId;
+    }
+
+    public set boardId(value: string) {
+        this._boardId = value;
+    }
+
+    public get type(): string {
+        return this._type;
+    }
+
+    public set type(value: string) {
+        this._type = value;
+    }
+
+    public getConfig(): ManagerConfig {
+        const pullUrl = `${ViewBookmarksManager.BASE_URL}/export?boardId=${this.boardId}&type=${this.type}`;
+        return {
+            pushUrl: `${ViewBookmarksManager.BASE_URL}/import?boardId=${this.boardId}`,
+            pullUrl: pullUrl,
+            exportFileName: `${ViewBookmarksManager.VIEW_BOOKMARKS_FILE_PREFIX}${this.boardId}.json`,
+            onPushSuccessMessage: (): string => {
+                return "View Bookmarks was pushed successfully.";
+            },
+        };
+    }
+
+    public getBody(): any {
+        const formData = new FormData();
+        formData.append("file", fs.createReadStream(this.fileName));
+        return formData;
+    }
+
+    protected getSerializedFileContent(data: any): string {
+        return JSON.stringify(data);
+    }
+}

--- a/src/commands/view/view-bookmarks.manager.ts
+++ b/src/commands/view/view-bookmarks.manager.ts
@@ -41,13 +41,12 @@ export class ViewBookmarksManager extends BaseManager {
     }
 
     public getConfig(): ManagerConfig {
-        const pullUrl = `${ViewBookmarksManager.BASE_URL}/export?boardId=${this.boardId}&type=${this.type}`;
         return {
-            pushUrl: `${ViewBookmarksManager.BASE_URL}/import?boardId=${this.boardId}`,
-            pullUrl: pullUrl,
+            pushUrl: `${ViewBookmarksManager.BASE_URL}/import?boardId=${encodeURIComponent(this.boardId)}`,
+            pullUrl: `${ViewBookmarksManager.BASE_URL}/export?boardId=${encodeURIComponent(this.boardId)}&type=${encodeURIComponent(this.type)}`,
             exportFileName: `${ViewBookmarksManager.VIEW_BOOKMARKS_FILE_PREFIX}${this.boardId}.json`,
             onPushSuccessMessage: (): string => {
-                return "View Bookmarks was pushed successfully.";
+                return "View Bookmarks were pushed successfully.";
             },
         };
     }

--- a/src/commands/view/view-bookmarks.manager.ts
+++ b/src/commands/view/view-bookmarks.manager.ts
@@ -9,19 +9,19 @@ export class ViewBookmarksManager extends BaseManager {
     private static readonly VIEW_BOOKMARKS_FILE_PREFIX = "studio_view_bookmarks_";
 
     private _boardId: string;
-    private _fileName: string;
+    private _filePath: string;
     private _type: string;
 
     constructor(context: Context) {
         super(context);
     }
 
-    public get fileName(): string {
-        return this._fileName;
+    public get filePath(): string {
+        return this._filePath;
     }
 
-    public set fileName(value: string) {
-        this._fileName = value;
+    public set filePath(value: string) {
+        this._filePath = value;
     }
 
     public get boardId(): string {
@@ -53,7 +53,7 @@ export class ViewBookmarksManager extends BaseManager {
 
     public getBody(): any {
         const formData = new FormData();
-        formData.append("file", fs.createReadStream(this.fileName));
+        formData.append("file", fs.createReadStream(this.filePath));
         return formData;
     }
 

--- a/src/core/command/module-handler.ts
+++ b/src/core/command/module-handler.ts
@@ -181,8 +181,14 @@ export class CommandConfig {
         return this;
     }
 
-    public option(flags: string, description?: string, defaultValue?: string | boolean | string[]): CommandConfig {
-        this.cmd.option(flags, description, defaultValue);
+    public option(flags: string, description?: string, defaultValue?: string | boolean | string[]): CommandConfig;
+    public option(flags: string, description: string, parseArg: (value: string, previous: unknown) => unknown, defaultValue?: string | boolean | string[]): CommandConfig;
+    public option(flags: string, description?: string, parseArgOrDefault?: ((value: string, previous: unknown) => unknown) | string | boolean | string[], defaultValue?: string | boolean | string[]): CommandConfig {
+        if (typeof parseArgOrDefault === "function") {
+            this.cmd.option(flags, description, parseArgOrDefault, defaultValue);
+        } else {
+            this.cmd.option(flags, description, parseArgOrDefault);
+        }
         return this;
     }
 

--- a/src/core/command/module-handler.ts
+++ b/src/core/command/module-handler.ts
@@ -181,14 +181,8 @@ export class CommandConfig {
         return this;
     }
 
-    public option(flags: string, description?: string, defaultValue?: string | boolean | string[]): CommandConfig;
-    public option(flags: string, description: string, parseArg: (value: string, previous: unknown) => unknown, defaultValue?: string | boolean | string[]): CommandConfig;
-    public option(flags: string, description?: string, parseArgOrDefault?: ((value: string, previous: unknown) => unknown) | string | boolean | string[], defaultValue?: string | boolean | string[]): CommandConfig {
-        if (typeof parseArgOrDefault === "function") {
-            this.cmd.option(flags, description, parseArgOrDefault, defaultValue);
-        } else {
-            this.cmd.option(flags, description, parseArgOrDefault);
-        }
+    public option(flags: string, description?: string, defaultValue?: string | boolean | string[]): CommandConfig {
+        this.cmd.option(flags, description, defaultValue);
         return this;
     }
 

--- a/tests/commands/view/view-bookmarks-module.spec.ts
+++ b/tests/commands/view/view-bookmarks-module.spec.ts
@@ -1,0 +1,63 @@
+import Module = require("../../../src/commands/view/module");
+import { Command, OptionValues } from "commander";
+import { ViewBookmarksCommandService } from "../../../src/commands/view/view-bookmarks-command.service";
+import { testContext } from "../../utls/test-context";
+import { createMockConfigurator } from "../../utls/configurator-mock";
+
+jest.mock("../../../src/commands/view/view-bookmarks-command.service");
+
+describe("View Bookmarks Module", () => {
+    let module: Module;
+    let mockCommand: Command;
+    let mockService: jest.Mocked<ViewBookmarksCommandService>;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        module = new Module();
+        mockCommand = {} as Command;
+
+        mockService = {
+            pullViewBookmarks: jest.fn().mockResolvedValue(undefined),
+            pushViewBookmarks: jest.fn().mockResolvedValue(undefined),
+        } as any;
+
+        (ViewBookmarksCommandService as jest.MockedClass<typeof ViewBookmarksCommandService>)
+            .mockImplementation(() => mockService);
+    });
+
+    it("should call pullViewBookmarks with id and type", async () => {
+        const options: OptionValues = { id: "board-123", type: "SHARED" };
+        await (module as any).pullViewBookmarks(testContext, mockCommand, options);
+        expect(mockService.pullViewBookmarks).toHaveBeenCalledWith("board-123", "SHARED");
+    });
+
+    it("should call pushViewBookmarks with id and file", async () => {
+        const options: OptionValues = { id: "board-123", file: "bookmarks.json" };
+        await (module as any).pushViewBookmarks(testContext, mockCommand, options);
+        expect(mockService.pushViewBookmarks).toHaveBeenCalledWith("board-123", "bookmarks.json");
+    });
+
+    describe("register", () => {
+        it("registers the pull and push command groups without throwing", () => {
+            const mockConfigurator = createMockConfigurator();
+
+            expect(() => new Module().register(testContext, mockConfigurator)).not.toThrow();
+
+            expect(mockConfigurator.command).toHaveBeenCalledWith("pull");
+            expect(mockConfigurator.command).toHaveBeenCalledWith("push");
+        });
+
+        it("wires an action handler for every leaf subcommand", () => {
+            const mockConfigurator = createMockConfigurator();
+
+            new Module().register(testContext, mockConfigurator);
+
+            // pull view-bookmarks + push view-bookmarks
+            const expectedLeafCommands = 2;
+            expect(mockConfigurator.action).toHaveBeenCalledTimes(expectedLeafCommands);
+            for (const call of mockConfigurator.action.mock.calls) {
+                expect(typeof call[0]).toBe("function");
+            }
+        });
+    });
+});

--- a/tests/commands/view/view-bookmarks.spec.ts
+++ b/tests/commands/view/view-bookmarks.spec.ts
@@ -1,0 +1,76 @@
+import * as fs from "fs";
+import * as path from "path";
+import { mockAxiosGet, mockAxiosPost, mockedAxiosInstance } from "../../utls/http-requests-mock";
+import { mockCreateReadStream, mockExistsSync } from "../../utls/fs-mock-utils";
+import { ViewBookmarksCommandService } from "../../../src/commands/view/view-bookmarks-command.service";
+import { ViewBookmarksManagerFactory } from "../../../src/commands/view/view-bookmarks.manager-factory";
+import { loggingTestTransport, mockWriteFileSync } from "../../jest.setup";
+import { testContext } from "../../utls/test-context";
+
+describe("View bookmarks", () => {
+
+    const boardId = "73d39112-73ae-4bbe-8051-3c0f14e065ec";
+    const exportBaseUrl = `https://myTeam.celonis.cloud/blueprint/api/bookmarks/export?boardId=${boardId}`;
+    const importUrl = `https://myTeam.celonis.cloud/blueprint/api/bookmarks/import?boardId=${boardId}`;
+    const bookmarksResponse = [
+        {
+            bookmark: { name: "My View Bookmark", ownerId: "user-1", userPreferenceId: "pref-1" },
+            preference: { id: "pref-1", value: "{}" },
+        },
+    ];
+
+    describe("pull", () => {
+        it("Should call export API with the default USER type and write the response to a file", async () => {
+            mockAxiosGet(`${exportBaseUrl}&type=USER`, bookmarksResponse);
+
+            await new ViewBookmarksCommandService(testContext).pullViewBookmarks(boardId, undefined);
+
+            expect(mockedAxiosInstance.get).toHaveBeenCalledWith(`${exportBaseUrl}&type=USER`, expect.anything());
+            expect(mockWriteFileSync).toHaveBeenCalledWith(
+                path.resolve(process.cwd(), `studio_view_bookmarks_${boardId}.json`),
+                JSON.stringify(bookmarksResponse),
+                { encoding: "utf-8", mode: 0o600 }
+            );
+            expect(loggingTestTransport.logMessages.length).toBe(1);
+            expect(loggingTestTransport.logMessages[0].message).toContain("File downloaded successfully. New filename: ");
+        });
+
+        it("Should call export API with the provided type", async () => {
+            mockAxiosGet(`${exportBaseUrl}&type=SHARED`, bookmarksResponse);
+
+            await new ViewBookmarksCommandService(testContext).pullViewBookmarks(boardId, "SHARED");
+
+            expect(mockedAxiosInstance.get).toHaveBeenCalledWith(`${exportBaseUrl}&type=SHARED`, expect.anything());
+            expect(mockWriteFileSync).toHaveBeenCalledWith(
+                path.resolve(process.cwd(), `studio_view_bookmarks_${boardId}.json`),
+                JSON.stringify(bookmarksResponse),
+                { encoding: "utf-8", mode: 0o600 }
+            );
+        });
+    });
+
+    describe("push", () => {
+        it("Should call import API with the file as multipart body", async () => {
+            mockAxiosPost(importUrl, {});
+            mockExistsSync();
+            mockCreateReadStream(Buffer.from(JSON.stringify(bookmarksResponse)));
+
+            await new ViewBookmarksCommandService(testContext).pushViewBookmarks(boardId, "bookmarks.json");
+
+            expect(mockedAxiosInstance.post).toHaveBeenCalledWith(importUrl, expect.anything(), expect.anything());
+            expect(loggingTestTransport.logMessages.length).toBe(1);
+            expect(loggingTestTransport.logMessages[0].message).toContain("View Bookmarks were pushed successfully.");
+        });
+    });
+
+    describe("manager factory", () => {
+        it("Should report a fatal error when the push file does not exist", () => {
+            (fs.existsSync as jest.Mock).mockReturnValue(false);
+            const exitSpy = jest.spyOn(process, "exit").mockImplementation((() => undefined) as never);
+
+            new ViewBookmarksManagerFactory(testContext).createViewBookmarksManager("missing.json", boardId);
+
+            expect(exitSpy).toHaveBeenCalledWith(1);
+        });
+    });
+});

--- a/tests/commands/view/view-bookmarks.spec.ts
+++ b/tests/commands/view/view-bookmarks.spec.ts
@@ -1,5 +1,5 @@
-import * as fs from "fs";
-import * as path from "path";
+import * as fs from "node:fs";
+import * as path from "node:path";
 import { mockAxiosGet, mockAxiosPost, mockedAxiosInstance } from "../../utls/http-requests-mock";
 import { mockCreateReadStream, mockExistsSync } from "../../utls/fs-mock-utils";
 import { ViewBookmarksCommandService } from "../../../src/commands/view/view-bookmarks-command.service";

--- a/tests/jest.setup.ts
+++ b/tests/jest.setup.ts
@@ -6,8 +6,6 @@ import { logger } from "../src/core/utils/logger";
 
 mockAxios();
 jest.mock("fs");
-// Route "node:fs" imports to the same mock instance as "fs" so that helpers
-// operating on "fs" (e.g. mockExistsSync) also affect modules importing "node:fs".
 jest.mock("node:fs", () => require("fs"));
 
 const mockWriteFileSync = jest.fn();

--- a/tests/jest.setup.ts
+++ b/tests/jest.setup.ts
@@ -6,6 +6,9 @@ import { logger } from "../src/core/utils/logger";
 
 mockAxios();
 jest.mock("fs");
+// Route "node:fs" imports to the same mock instance as "fs" so that helpers
+// operating on "fs" (e.g. mockExistsSync) also affect modules importing "node:fs".
+jest.mock("node:fs", () => require("fs"));
 
 const mockWriteFileSync = jest.fn();
 (fs.writeFileSync as jest.Mock).mockImplementation(mockWriteFileSync);


### PR DESCRIPTION
## Ticket
https://celonis.atlassian.net/browse/BINFR-6408

## Summary
- Add `pull view-bookmarks` and `push view-bookmarks` commands to transfer view (board) bookmarks between teams.
- Mirrors the existing analysis bookmarks implementation but targets the blueprint `BookmarksTransferController` import/export endpoints (`/blueprint/api/bookmarks/export|import`).
- New module under `src/commands/view/` (auto-discovered by `ModuleHandler`): manager, manager-factory, command-service, and module registration.
- Documents the new commands in `docs/user-guide/studio-commands.md`.

## Details
- `pull view-bookmarks --id <boardId> [--type USER|SHARED|ALL]` -> `GET /blueprint/api/bookmarks/export?boardId=<id>&type=<type>` (defaults to `USER`), writes `studio_view_bookmarks_<id>.json`.
- `push view-bookmarks --id <boardId> -f <file>` -> `POST /blueprint/api/bookmarks/import?boardId=<id>` (multipart `file`).

## Test plan
- [x] `npm run build` compiles cleanly
- [x] `pull view-bookmarks --help` / `push view-bookmarks --help` show expected options
- [ ] Manual end-to-end pull/push against a blueprint environment

Includes-AI-Code: true

Made with [Cursor](https://cursor.com)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Follows the established analysis-bookmarks pattern with new blueprint endpoints; scope is CLI asset transfer and covered by unit tests, with no auth or core platform changes in this diff.
> 
> **Overview**
> Adds **content-cli** support to **pull** and **push view (board) bookmarks** between teams, parallel to the existing analysis bookmarks flow but wired to blueprint **`/blueprint/api/bookmarks/export`** and **`import`**.
> 
> New **`pull view-bookmarks`** takes a board **`--id`** and optional **`--type`** (`USER` default, `SHARED`, or `ALL`), downloads JSON as `studio_view_bookmarks_<boardId>.json`. **`push view-bookmarks`** posts that file as multipart to the target board. Implementation lives under **`src/commands/view/`** (module registration, command service, manager + factory on **`BaseManager`**), with user-guide docs and Jest coverage; test setup aliases **`node:fs`** to the existing **`fs`** mock.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c26621b8ac037b682dcd95257b42638211b1b51. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->