### PR TITLE
SP-925: Add PLATFORM_SERVICE validation layer to config validate

### DIFF
--- a/docs/user-guide/config-commands.md
+++ b/docs/user-guide/config-commands.md
@@ -204,19 +204,20 @@ The `--layers` option selects which validation layers to run. Multiple layers ca
 | `SCHEMA` | Asset-schema conformance of each node's `configuration` field — required properties, enum values, type checks, conditional schemas. | Asset registry |
 | `BUSINESS` | Asset-type-specific business rules — for `SEMANTIC_MODEL`, e.g. PQL parsing, data-model availability, KPI uniqueness. Rules live in the owning asset service. | Owning asset service (e.g. `cloud-semantic-layer` for Knowledge Models) |
 | `PACKAGE_SETTINGS` | Package-level configuration rules — package dependencies, package variable definitions, variable assignments such as Studio data models, and flavor-specific package settings for Studio/OCDM packages. | Pacman plus flavor-specific services |
-| `PLATFORM_SERVICE` | Platform-service-owned validation — each participating platform service checks the assets it owns against its live service (for example Semantic Layer "list-problems" checks), surfacing platform-level problems that only the running service can detect. Which services take part, and how their findings map to severities, is declared by platform-service descriptors. | Owning platform services (e.g. `cloud-semantic-layer`), coordinated by Pacman |
+| `PIG_SEMANTICS` | Semantic-model validation delegated to the Process Intelligence Graph semantic-layer runtime (PIG-SL), surfacing the `list-problems` findings the live service reports for Knowledge Models. | Semantic layer (`cloud-semantic-layer`) |
+| `DATA_PIPELINES` | Validation delegated to the data-pipeline platform service for the package's data-integration assets. | Data pipeline service |
 
-`SCHEMA`, `BUSINESS`, `PACKAGE_SETTINGS`, and `PLATFORM_SERVICE` are the layers accepted by the Pacman API. Other values are rejected with a `400 layers.unsupported` error.
+`SCHEMA`, `BUSINESS`, `PACKAGE_SETTINGS`, `PIG_SEMANTICS`, and `DATA_PIPELINES` are the layers accepted by the Pacman API. Other values are rejected with a `400 layers.unsupported` error.
 
 To run all layers:
 
 ```bash
-content-cli config package validate --packageKey <packageKey> --layers SCHEMA BUSINESS PACKAGE_SETTINGS PLATFORM_SERVICE
+content-cli config package validate --packageKey <packageKey> --layers SCHEMA BUSINESS PACKAGE_SETTINGS PIG_SEMANTICS DATA_PIPELINES
 ```
 
 Use `PACKAGE_SETTINGS` when you need to verify that the package's own settings are usable in the destination team before continuing authoring or import work. It reports issues such as missing dependency versions, duplicate dependency or variable keys, blank variable keys/types, missing Studio data model assignments, and OCDM package-settings problems when the corresponding backend validation is enabled.
 
-Use `PLATFORM_SERVICE` to additionally validate the package against the live platform services that own its assets — for example Semantic Layer problem checks for Knowledge Models. The set of services that take part, and how their findings map to severities, is declared by platform-service descriptors, so additional services can join the layer without CLI changes.
+Use `PIG_SEMANTICS` and `DATA_PIPELINES` to additionally validate the package against the live platform services that own its assets: `PIG_SEMANTICS` runs the Process Intelligence Graph semantic-layer checks (for example for Knowledge Models) and `DATA_PIPELINES` runs the data-pipeline service checks for the package's data-integration assets. Both delegate validation to the owning service rather than running in-process; which services take part, and how their findings map to severities, is declared by platform-service descriptors.
 
 ### Validate Specific Nodes
 
@@ -231,7 +232,7 @@ content-cli config package validate --packageKey <packageKey> --nodeKeys node-ke
 Use `--json` to write the full validation report to a JSON file in the current working directory instead of printing it to the console:
 
 ```bash
-content-cli config package validate --packageKey <packageKey> --layers SCHEMA BUSINESS PACKAGE_SETTINGS PLATFORM_SERVICE --json
+content-cli config package validate --packageKey <packageKey> --layers SCHEMA BUSINESS PACKAGE_SETTINGS PIG_SEMANTICS DATA_PIPELINES --json
 ```
 
 The filename is printed on success:
@@ -251,7 +252,7 @@ interface ValidationReport {
 }
 
 interface ValidationResult {
-    layer: "SCHEMA" | "BUSINESS" | "PACKAGE_SETTINGS" | "PLATFORM_SERVICE";
+    layer: "SCHEMA" | "BUSINESS" | "PACKAGE_SETTINGS" | "PIG_SEMANTICS" | "DATA_PIPELINES";
     severity: "ERROR" | "WARNING" | "INFO";
     nodeKey: string;
     assetType: string;

--- a/docs/user-guide/config-commands.md
+++ b/docs/user-guide/config-commands.md
@@ -206,7 +206,7 @@ The `--layers` option selects which validation layers to run. Multiple layers ca
 | `PACKAGE_SETTINGS` | Package-level configuration rules — package dependencies, package variable definitions, variable assignments such as Studio data models, and flavor-specific package settings for Studio/OCDM packages. | Pacman plus flavor-specific services |
 | `PLATFORM_SERVICE` | Platform-service-owned validation — each participating platform service checks the assets it owns against its live service (for example Semantic Layer "list-problems" checks), surfacing platform-level problems that only the running service can detect. Which services take part, and how their findings map to severities, is declared by platform-service descriptors. | Owning platform services (e.g. `cloud-semantic-layer`), coordinated by Pacman |
 
-`SCHEMA`, `BUSINESS`, and `PACKAGE_SETTINGS` are accepted by the Pacman API today. `PLATFORM_SERVICE` is the newest layer and is only accepted once platform-service validation is enabled on the validate endpoint. Any value the endpoint does not (yet) support is rejected with a `400 layers.unsupported` error.
+`SCHEMA`, `BUSINESS`, and `PACKAGE_SETTINGS` are accepted by the Pacman API. `PLATFORM_SERVICE` is accepted once platform-service validation is enabled on the validate endpoint. Any value the endpoint does not support is rejected with a `400 layers.unsupported` error.
 
 To run all layers:
 
@@ -216,7 +216,7 @@ content-cli config package validate --packageKey <packageKey> --layers SCHEMA BU
 
 Use `PACKAGE_SETTINGS` when you need to verify that the package's own settings are usable in the destination team before continuing authoring or import work. It reports issues such as missing dependency versions, duplicate dependency or variable keys, blank variable keys/types, missing Studio data model assignments, and OCDM package-settings problems when the corresponding backend validation is enabled.
 
-Use `PLATFORM_SERVICE` to additionally validate the package against the live platform services that own its assets — for example Semantic Layer problem checks for Knowledge Models. The set of services that take part, and how their findings map to severities, is declared by platform-service descriptors, so new services can join the layer without CLI changes. Because it runs against the owning services, `PLATFORM_SERVICE` is only accepted once platform-service validation is enabled on the validate endpoint; until then the request is rejected with `400 layers.unsupported`.
+Use `PLATFORM_SERVICE` to additionally validate the package against the live platform services that own its assets — for example Semantic Layer problem checks for Knowledge Models. The set of services that take part, and how their findings map to severities, is declared by platform-service descriptors, so additional services can join the layer without CLI changes. Because it runs against the owning services, `PLATFORM_SERVICE` is only accepted once platform-service validation is enabled on the validate endpoint.
 
 ### Validate Specific Nodes
 

--- a/docs/user-guide/config-commands.md
+++ b/docs/user-guide/config-commands.md
@@ -204,16 +204,19 @@ The `--layers` option selects which validation layers to run. Multiple layers ca
 | `SCHEMA` | Asset-schema conformance of each node's `configuration` field — required properties, enum values, type checks, conditional schemas. | Asset registry |
 | `BUSINESS` | Asset-type-specific business rules — for `SEMANTIC_MODEL`, e.g. PQL parsing, data-model availability, KPI uniqueness. Rules live in the owning asset service. | Owning asset service (e.g. `cloud-semantic-layer` for Knowledge Models) |
 | `PACKAGE_SETTINGS` | Package-level configuration rules — package dependencies, package variable definitions, variable assignments such as Studio data models, and flavor-specific package settings for Studio/OCDM packages. | Pacman plus flavor-specific services |
+| `PLATFORM_SERVICE` | Platform-service-owned validation — each participating platform service checks the assets it owns against its live service (for example Semantic Layer "list-problems" checks), surfacing platform-level problems that only the running service can detect. Which services take part, and how their findings map to severities, is declared by platform-service descriptors. | Owning platform services (e.g. `cloud-semantic-layer`), coordinated by Pacman |
 
-Currently `SCHEMA`, `BUSINESS`, and `PACKAGE_SETTINGS` are the layers accepted by the Pacman API. Other values are rejected with a `400 layers.unsupported` error.
+`SCHEMA`, `BUSINESS`, and `PACKAGE_SETTINGS` are accepted by the Pacman API today. `PLATFORM_SERVICE` is the newest layer and is only accepted once platform-service validation is enabled on the validate endpoint. Any value the endpoint does not (yet) support is rejected with a `400 layers.unsupported` error.
 
 To run all layers:
 
 ```bash
-content-cli config package validate --packageKey <packageKey> --layers SCHEMA BUSINESS PACKAGE_SETTINGS
+content-cli config package validate --packageKey <packageKey> --layers SCHEMA BUSINESS PACKAGE_SETTINGS PLATFORM_SERVICE
 ```
 
 Use `PACKAGE_SETTINGS` when you need to verify that the package's own settings are usable in the destination team before continuing authoring or import work. It reports issues such as missing dependency versions, duplicate dependency or variable keys, blank variable keys/types, missing Studio data model assignments, and OCDM package-settings problems when the corresponding backend validation is enabled.
+
+Use `PLATFORM_SERVICE` to additionally validate the package against the live platform services that own its assets — for example Semantic Layer problem checks for Knowledge Models. The set of services that take part, and how their findings map to severities, is declared by platform-service descriptors, so new services can join the layer without CLI changes. Because it runs against the owning services, `PLATFORM_SERVICE` is only accepted once platform-service validation is enabled on the validate endpoint; until then the request is rejected with `400 layers.unsupported`.
 
 ### Validate Specific Nodes
 
@@ -228,7 +231,7 @@ content-cli config package validate --packageKey <packageKey> --nodeKeys node-ke
 Use `--json` to write the full validation report to a JSON file in the current working directory instead of printing it to the console:
 
 ```bash
-content-cli config package validate --packageKey <packageKey> --layers SCHEMA BUSINESS PACKAGE_SETTINGS --json
+content-cli config package validate --packageKey <packageKey> --layers SCHEMA BUSINESS PACKAGE_SETTINGS PLATFORM_SERVICE --json
 ```
 
 The filename is printed on success:
@@ -248,7 +251,7 @@ interface ValidationReport {
 }
 
 interface ValidationResult {
-    layer: "SCHEMA" | "BUSINESS" | "PACKAGE_SETTINGS";
+    layer: "SCHEMA" | "BUSINESS" | "PACKAGE_SETTINGS" | "PLATFORM_SERVICE";
     severity: "ERROR" | "WARNING" | "INFO";
     nodeKey: string;
     assetType: string;

--- a/docs/user-guide/config-commands.md
+++ b/docs/user-guide/config-commands.md
@@ -206,7 +206,7 @@ The `--layers` option selects which validation layers to run. Multiple layers ca
 | `PACKAGE_SETTINGS` | Package-level configuration rules — package dependencies, package variable definitions, variable assignments such as Studio data models, and flavor-specific package settings for Studio/OCDM packages. | Pacman plus flavor-specific services |
 | `PLATFORM_SERVICE` | Platform-service-owned validation — each participating platform service checks the assets it owns against its live service (for example Semantic Layer "list-problems" checks), surfacing platform-level problems that only the running service can detect. Which services take part, and how their findings map to severities, is declared by platform-service descriptors. | Owning platform services (e.g. `cloud-semantic-layer`), coordinated by Pacman |
 
-`SCHEMA`, `BUSINESS`, and `PACKAGE_SETTINGS` are accepted by the Pacman API. `PLATFORM_SERVICE` is accepted once platform-service validation is enabled on the validate endpoint. Any value the endpoint does not support is rejected with a `400 layers.unsupported` error.
+`SCHEMA`, `BUSINESS`, `PACKAGE_SETTINGS`, and `PLATFORM_SERVICE` are the layers accepted by the Pacman API. Other values are rejected with a `400 layers.unsupported` error.
 
 To run all layers:
 
@@ -216,7 +216,7 @@ content-cli config package validate --packageKey <packageKey> --layers SCHEMA BU
 
 Use `PACKAGE_SETTINGS` when you need to verify that the package's own settings are usable in the destination team before continuing authoring or import work. It reports issues such as missing dependency versions, duplicate dependency or variable keys, blank variable keys/types, missing Studio data model assignments, and OCDM package-settings problems when the corresponding backend validation is enabled.
 
-Use `PLATFORM_SERVICE` to additionally validate the package against the live platform services that own its assets — for example Semantic Layer problem checks for Knowledge Models. The set of services that take part, and how their findings map to severities, is declared by platform-service descriptors, so additional services can join the layer without CLI changes. Because it runs against the owning services, `PLATFORM_SERVICE` is only accepted once platform-service validation is enabled on the validate endpoint.
+Use `PLATFORM_SERVICE` to additionally validate the package against the live platform services that own its assets — for example Semantic Layer problem checks for Knowledge Models. The set of services that take part, and how their findings map to severities, is declared by platform-service descriptors, so additional services can join the layer without CLI changes.
 
 ### Validate Specific Nodes
 

--- a/src/commands/configuration-management/module.ts
+++ b/src/commands/configuration-management/module.ts
@@ -84,7 +84,7 @@ class Module extends IModule {
             .requiredOption("--packageKey <packageKey>", "Key of the package to validate")
             .option(
                 "--layers <layers...>",
-                "Validation layers to run. Allowed values: SCHEMA, BUSINESS, PACKAGE_SETTINGS, PLATFORM_SERVICE (can be combined, e.g. --layers SCHEMA BUSINESS PACKAGE_SETTINGS PLATFORM_SERVICE). Defaults to SCHEMA.",
+                "Validation layers to run. Allowed values: SCHEMA, BUSINESS, PACKAGE_SETTINGS, PIG_SEMANTICS, DATA_PIPELINES (can be combined, e.g. --layers SCHEMA BUSINESS PACKAGE_SETTINGS PIG_SEMANTICS DATA_PIPELINES). Defaults to SCHEMA.",
                 ["SCHEMA"]
             )
             .option("--nodeKeys <nodeKeys...>", "Specific node keys to validate (default: all nodes)")
@@ -103,7 +103,7 @@ class Module extends IModule {
             .requiredOption("--packageKey <packageKey>", "Key of the package to validate")
             .option(
                 "--layers <layers...>",
-                "Validation layers to run. Allowed values: SCHEMA, BUSINESS, PACKAGE_SETTINGS, PLATFORM_SERVICE (can be combined, e.g. --layers SCHEMA BUSINESS PACKAGE_SETTINGS PLATFORM_SERVICE). Defaults to SCHEMA.",
+                "Validation layers to run. Allowed values: SCHEMA, BUSINESS, PACKAGE_SETTINGS, PIG_SEMANTICS, DATA_PIPELINES (can be combined, e.g. --layers SCHEMA BUSINESS PACKAGE_SETTINGS PIG_SEMANTICS DATA_PIPELINES). Defaults to SCHEMA.",
                 ["SCHEMA"]
             )
             .option("--nodeKeys <nodeKeys...>", "Specific node keys to validate (default: all nodes)")

--- a/src/commands/configuration-management/module.ts
+++ b/src/commands/configuration-management/module.ts
@@ -84,7 +84,7 @@ class Module extends IModule {
             .requiredOption("--packageKey <packageKey>", "Key of the package to validate")
             .option(
                 "--layers <layers...>",
-                "Validation layers to run. Allowed values: SCHEMA, BUSINESS, PACKAGE_SETTINGS (can be combined, e.g. --layers SCHEMA BUSINESS PACKAGE_SETTINGS). Defaults to SCHEMA.",
+                "Validation layers to run. Allowed values: SCHEMA, BUSINESS, PACKAGE_SETTINGS, PLATFORM_SERVICE (can be combined, e.g. --layers SCHEMA BUSINESS PACKAGE_SETTINGS PLATFORM_SERVICE). Defaults to SCHEMA.",
                 ["SCHEMA"]
             )
             .option("--nodeKeys <nodeKeys...>", "Specific node keys to validate (default: all nodes)")
@@ -103,7 +103,7 @@ class Module extends IModule {
             .requiredOption("--packageKey <packageKey>", "Key of the package to validate")
             .option(
                 "--layers <layers...>",
-                "Validation layers to run. Allowed values: SCHEMA, BUSINESS, PACKAGE_SETTINGS (can be combined, e.g. --layers SCHEMA BUSINESS PACKAGE_SETTINGS). Defaults to SCHEMA.",
+                "Validation layers to run. Allowed values: SCHEMA, BUSINESS, PACKAGE_SETTINGS, PLATFORM_SERVICE (can be combined, e.g. --layers SCHEMA BUSINESS PACKAGE_SETTINGS PLATFORM_SERVICE). Defaults to SCHEMA.",
                 ["SCHEMA"]
             )
             .option("--nodeKeys <nodeKeys...>", "Specific node keys to validate (default: all nodes)")

--- a/tests/commands/configuration-management/config-validate.spec.ts
+++ b/tests/commands/configuration-management/config-validate.spec.ts
@@ -105,7 +105,7 @@ describe("Config validate", () => {
         expect(allMessages).toContain("Errors: 0");
     })
 
-    it("Should send PLATFORM_SERVICE layer in request body when combined with other layers", async () => {
+    it("Should send PIG_SEMANTICS and DATA_PIPELINES layers in request body when combined with other layers", async () => {
         const response: SchemaValidationResponse = {
             packageKey: "my-package",
             valid: true,
@@ -117,23 +117,23 @@ describe("Config validate", () => {
 
         await new PackageValidationService(testContext).validatePackage(
             "my-package",
-            ["SCHEMA", "BUSINESS", "PACKAGE_SETTINGS", "PLATFORM_SERVICE"],
+            ["SCHEMA", "BUSINESS", "PACKAGE_SETTINGS", "PIG_SEMANTICS", "DATA_PIPELINES"],
             null,
             false
         );
 
         expect(mockedPostRequestBodyByUrl.get(VALIDATE_URL)).toEqual(
-            JSON.stringify({ layers: ["SCHEMA", "BUSINESS", "PACKAGE_SETTINGS", "PLATFORM_SERVICE"] })
+            JSON.stringify({ layers: ["SCHEMA", "BUSINESS", "PACKAGE_SETTINGS", "PIG_SEMANTICS", "DATA_PIPELINES"] })
         );
     })
 
-    it("Should render PLATFORM_SERVICE findings in human-readable output", async () => {
+    it("Should render PIG_SEMANTICS findings in human-readable output", async () => {
         const response: SchemaValidationResponse = {
             packageKey: "my-package",
             valid: false,
             summary: { errors: 0, warnings: 1, info: 0 },
             results: [{
-                layer: "PLATFORM_SERVICE",
+                layer: "PIG_SEMANTICS",
                 severity: "WARNING",
                 nodeKey: "my-knowledge-model",
                 assetType: "SEMANTIC_MODEL",
@@ -145,7 +145,7 @@ describe("Config validate", () => {
 
         mockAxiosPost(VALIDATE_URL, response);
 
-        await new PackageValidationService(testContext).validatePackage("my-package", ["PLATFORM_SERVICE"], null, false);
+        await new PackageValidationService(testContext).validatePackage("my-package", ["PIG_SEMANTICS"], null, false);
 
         const allMessages = loggingTestTransport.logMessages.map(m => m.message).join("\n");
         expect(allMessages).toContain("Validation result: INVALID");
@@ -154,25 +154,25 @@ describe("Config validate", () => {
         expect(allMessages).toContain("DATA_MODEL_NOT_FOUND");
     })
 
-    it("Should write PLATFORM_SERVICE findings to the JSON report when json flag is set", async () => {
+    it("Should write DATA_PIPELINES findings to the JSON report when json flag is set", async () => {
         const response: SchemaValidationResponse = {
             packageKey: "my-package",
             valid: false,
             summary: { errors: 1, warnings: 0, info: 0 },
             results: [{
-                layer: "PLATFORM_SERVICE",
+                layer: "DATA_PIPELINES",
                 severity: "ERROR",
-                nodeKey: "my-knowledge-model",
-                assetType: "SEMANTIC_MODEL",
-                path: "$.dataModel",
-                code: "DATA_MODEL_NOT_FOUND",
-                message: "Referenced data model is not available in the target team"
+                nodeKey: "my-data-pool",
+                assetType: "DATA_POOL",
+                path: "$.connection",
+                code: "CONNECTION_NOT_FOUND",
+                message: "Referenced connection is not available in the target team"
             }]
         };
 
         mockAxiosPost(VALIDATE_URL, response);
 
-        await new PackageValidationService(testContext).validatePackage("my-package", ["PLATFORM_SERVICE"], null, true);
+        await new PackageValidationService(testContext).validatePackage("my-package", ["DATA_PIPELINES"], null, true);
 
         expect(mockWriteFileSync).toHaveBeenCalledWith(
             expect.stringMatching(/config_validate_report_.+\.json$/),

--- a/tests/commands/configuration-management/config-validate.spec.ts
+++ b/tests/commands/configuration-management/config-validate.spec.ts
@@ -104,4 +104,80 @@ describe("Config validate", () => {
         expect(allMessages).toContain("Validation result: VALID");
         expect(allMessages).toContain("Errors: 0");
     })
+
+    it("Should send PLATFORM_SERVICE layer in request body when combined with other layers", async () => {
+        const response: SchemaValidationResponse = {
+            packageKey: "my-package",
+            valid: true,
+            summary: { errors: 0, warnings: 0, info: 0 },
+            results: []
+        };
+
+        mockAxiosPost(VALIDATE_URL, response);
+
+        await new PackageValidationService(testContext).validatePackage(
+            "my-package",
+            ["SCHEMA", "BUSINESS", "PACKAGE_SETTINGS", "PLATFORM_SERVICE"],
+            null,
+            false
+        );
+
+        expect(mockedPostRequestBodyByUrl.get(VALIDATE_URL)).toEqual(
+            JSON.stringify({ layers: ["SCHEMA", "BUSINESS", "PACKAGE_SETTINGS", "PLATFORM_SERVICE"] })
+        );
+    })
+
+    it("Should render PLATFORM_SERVICE findings in human-readable output", async () => {
+        const response: SchemaValidationResponse = {
+            packageKey: "my-package",
+            valid: false,
+            summary: { errors: 0, warnings: 1, info: 0 },
+            results: [{
+                layer: "PLATFORM_SERVICE",
+                severity: "WARNING",
+                nodeKey: "my-knowledge-model",
+                assetType: "SEMANTIC_MODEL",
+                path: "$.dataModel",
+                code: "DATA_MODEL_NOT_FOUND",
+                message: "Referenced data model is not available in the target team"
+            }]
+        };
+
+        mockAxiosPost(VALIDATE_URL, response);
+
+        await new PackageValidationService(testContext).validatePackage("my-package", ["PLATFORM_SERVICE"], null, false);
+
+        const allMessages = loggingTestTransport.logMessages.map(m => m.message).join("\n");
+        expect(allMessages).toContain("Validation result: INVALID");
+        expect(allMessages).toContain("Warnings: 1");
+        expect(allMessages).toContain("my-knowledge-model (SEMANTIC_MODEL)");
+        expect(allMessages).toContain("DATA_MODEL_NOT_FOUND");
+    })
+
+    it("Should write PLATFORM_SERVICE findings to the JSON report when json flag is set", async () => {
+        const response: SchemaValidationResponse = {
+            packageKey: "my-package",
+            valid: false,
+            summary: { errors: 1, warnings: 0, info: 0 },
+            results: [{
+                layer: "PLATFORM_SERVICE",
+                severity: "ERROR",
+                nodeKey: "my-knowledge-model",
+                assetType: "SEMANTIC_MODEL",
+                path: "$.dataModel",
+                code: "DATA_MODEL_NOT_FOUND",
+                message: "Referenced data model is not available in the target team"
+            }]
+        };
+
+        mockAxiosPost(VALIDATE_URL, response);
+
+        await new PackageValidationService(testContext).validatePackage("my-package", ["PLATFORM_SERVICE"], null, true);
+
+        expect(mockWriteFileSync).toHaveBeenCalledWith(
+            expect.stringMatching(/config_validate_report_.+\.json$/),
+            JSON.stringify(response),
+            { encoding: "utf-8", mode: 0o600 }
+        );
+    })
 })


### PR DESCRIPTION
#### Description

Adds `PLATFORM_SERVICE` (Layer 4: Platform Service Validation) as an accepted value of the `--layers` option on `config package validate` and the deprecated `config validate` alias.

What changed:
- **CLI help** — both validate commands now list `PLATFORM_SERVICE` in the `--layers` allowed values and combined example.
- **Rendering** — platform-service findings flow through the existing report path unchanged: the text report prints each finding (severity, node key, asset type, message, code) and `--json` writes the full report. No new branching was needed because the response shape (`results[]`) is layer-agnostic.
- **Docs** — `docs/user-guide/config-commands.md` gains a `PLATFORM_SERVICE` row in the layers table, a usage paragraph, updated examples, and the `ValidationResult.layer` union now includes the new layer.
- **Tests** — `config-validate.spec.ts` adds coverage for the request body (combined layers), the text report, and the JSON report for `PLATFORM_SERVICE`. Full suite green (47 suites / 425 tests).

> **Note:** the `PLATFORM_SERVICE` backend layer is being added to the Pacman validate endpoint under a separate change. The docs and CLI present it as a supported layer; merge this PR once the Pacman change is live so the two land together.

#### Relevant links

- Jira: https://celonis.atlassian.net/browse/SP-925

#### Checklist

- [x] I have self-reviewed this PR
- [ ] I have tested the change and proved that it works in different scenarios (pending the Pacman endpoint change; unit-tested request body + text + JSON rendering)
- [x] I have updated docs if needed

Made with [Cursor](https://cursor.com)