### PR TITLE
SP-1233: Deprecate Studio package push/pull/list commands in favour of config

### DIFF
--- a/src/commands/studio/module.ts
+++ b/src/commands/studio/module.ts
@@ -15,7 +15,8 @@ class Module extends IModule {
     public register(context: Context, configurator: Configurator): void {
         const listCommand = configurator.command("list");
         listCommand.command("packages")
-            .description("Command to list all packages")
+            .description("[Deprecated] Use 'config package list' instead. Command to list all packages")
+            .deprecationNotice("'list packages' is deprecated and will be removed in a future release. Use 'config package list' instead.")
             .option("--json", "Return response as json type", "")
             .option("--includeDependencies", "Include variables and dependencies", "")
             .option("--packageKeys <packageKeys...>", "Lists only given package keys")
@@ -39,7 +40,8 @@ class Module extends IModule {
             .action(this.pullAsset);
 
         pullCommand.command("package")
-            .description("Command to pull a package")
+            .description("[Deprecated] Use 'config package export' instead. Command to pull a package")
+            .deprecationNotice("'pull package' is deprecated and will be removed in a future release. Use 'config package export' instead.")
             .requiredOption("--key <key>", "Key of the package you want to pull")
             .option("--store", "Pull package with store deployment metadata")
             .option("--newKey <newKey>", "Define a new key for your package")
@@ -59,7 +61,8 @@ class Module extends IModule {
             .action(this.pushAssets);
 
         pushCommand.command("package")
-            .description("Command to push a package to Studio")
+            .description("[Deprecated] Use 'config package import' instead. Command to push a package to Studio")
+            .deprecationNotice("'push package' is deprecated and will be removed in a future release. Use 'config package import' instead.")
             .option("--newKey <newKey>", "Define a new key for your package")
             .option("--overwrite", "Overwrite package and its assets")
             .requiredOption("-f, --file <file>", "The file you want to push")
@@ -67,7 +70,8 @@ class Module extends IModule {
             .action(this.pushPackage);
 
         pushCommand.command("packages")
-            .description("Command to push packages to Studio")
+            .description("[Deprecated] Use 'config package import' (single package) instead. Command to push packages to Studio")
+            .deprecationNotice("'push packages' is deprecated and will be removed in a future release. Use 'config package import' (single package) instead.")
             .requiredOption("--spaceKey <spaceKey>", "The key of the destination space")
             .action(this.pushPackages);
 

--- a/tests/commands/studio/module.spec.ts
+++ b/tests/commands/studio/module.spec.ts
@@ -1,0 +1,76 @@
+import Module = require("../../../src/commands/studio/module");
+import { testContext } from "../../utls/test-context";
+import { createMockConfigurator } from "../../utls/configurator-mock";
+
+describe("Studio Module", () => {
+    describe("register", () => {
+        it("registers the studio command groups without throwing", () => {
+            const mockConfigurator = createMockConfigurator();
+
+            expect(() => new Module().register(testContext, mockConfigurator)).not.toThrow();
+
+            expect(mockConfigurator.command).toHaveBeenCalledWith("list");
+            expect(mockConfigurator.command).toHaveBeenCalledWith("pull");
+            expect(mockConfigurator.command).toHaveBeenCalledWith("push");
+            expect(mockConfigurator.command).toHaveBeenCalledWith("package");
+            expect(mockConfigurator.command).toHaveBeenCalledWith("packages");
+            expect(mockConfigurator.command).toHaveBeenCalledWith("widget");
+        });
+
+        it("wires an action handler for every leaf subcommand", () => {
+            const mockConfigurator = createMockConfigurator();
+
+            new Module().register(testContext, mockConfigurator);
+
+            // list (packages/spaces/assets) + pull (asset/package) + push (asset/assets/package/packages/widget)
+            const expectedLeafCommands = 10;
+            expect(mockConfigurator.action).toHaveBeenCalledTimes(expectedLeafCommands);
+            for (const call of mockConfigurator.action.mock.calls) {
+                expect(typeof call[0]).toBe("function");
+            }
+        });
+
+        it("deprecates the package push/pull/list commands, pointing at their config counterparts (never t2tc)", () => {
+            const mockConfigurator = createMockConfigurator();
+
+            new Module().register(testContext, mockConfigurator);
+
+            expect(mockConfigurator.deprecationNotice).toHaveBeenCalledTimes(4);
+            expect(mockConfigurator.deprecationNotice).toHaveBeenCalledWith(
+                "'pull package' is deprecated and will be removed in a future release. Use 'config package export' instead."
+            );
+            expect(mockConfigurator.deprecationNotice).toHaveBeenCalledWith(
+                "'push package' is deprecated and will be removed in a future release. Use 'config package import' instead."
+            );
+            expect(mockConfigurator.deprecationNotice).toHaveBeenCalledWith(
+                "'push packages' is deprecated and will be removed in a future release. Use 'config package import' (single package) instead."
+            );
+            expect(mockConfigurator.deprecationNotice).toHaveBeenCalledWith(
+                "'list packages' is deprecated and will be removed in a future release. Use 'config package list' instead."
+            );
+
+            for (const call of mockConfigurator.deprecationNotice.mock.calls) {
+                expect(call[0]).not.toMatch(/t2tc/);
+            }
+        });
+
+        it("prefixes the deprecated commands' descriptions with the recommended replacement", () => {
+            const mockConfigurator = createMockConfigurator();
+
+            new Module().register(testContext, mockConfigurator);
+
+            expect(mockConfigurator.description).toHaveBeenCalledWith(
+                "[Deprecated] Use 'config package export' instead. Command to pull a package"
+            );
+            expect(mockConfigurator.description).toHaveBeenCalledWith(
+                "[Deprecated] Use 'config package import' instead. Command to push a package to Studio"
+            );
+            expect(mockConfigurator.description).toHaveBeenCalledWith(
+                "[Deprecated] Use 'config package list' instead. Command to list all packages"
+            );
+            expect(mockConfigurator.description).toHaveBeenCalledWith(
+                "[Deprecated] Use 'config package import' (single package) instead. Command to push packages to Studio"
+            );
+        });
+    });
+});


### PR DESCRIPTION
#### Description

There have been cases where the agent reached for the old Studio package commands (`push` / `pull` / `list`) instead of the modern `config` commands, which caused issues and further agent confusion (SP-1233).

This PR marks the Studio package commands that have a clear `config` counterpart as **deprecated**, steering users (and the agent) toward the `config` equivalents. We deliberately point at `config` rather than `t2tc`, since `t2tc` has its own dedicated use cases that users should opt into explicitly.

| Deprecated Studio command | Recommended replacement |
| --- | --- |
| `pull package` | `config package export` |
| `push package` | `config package import` |
| `push packages` | `config package import` (single package) |
| `list packages` | `config package list` |

Each command now:
- shows a `[Deprecated] Use '<replacement>' instead. …` prefix in `--help`
- emits a runtime deprecation notice (via the existing `CommandConfig.deprecationNotice` mechanism) when invoked

No behaviour change — the commands still work exactly as before, they just warn.

The broader plan for deprecating/removing the rest of the Studio command group is tracked separately in SP-1375.

#### Relevant links

- Jira: https://celonis.atlassian.net/browse/SP-1233
- Follow-up (full Studio deprecation plan): https://celonis.atlassian.net/browse/SP-1375

#### Checklist

- [x] I have self-reviewed this PR
- [x] I have tested the change and proved that it works in different scenarios
- [ ] I have updated docs if needed

Made with [Cursor](https://cursor.com)