### PR TITLE
Fix test failures from testing refactor fallout

### DIFF
--- a/tests/commands/configuration-management/config-validate.spec.ts
+++ b/tests/commands/configuration-management/config-validate.spec.ts
@@ -7,6 +7,7 @@ import { testContext } from "../../utls/test-context";
 import { loggingTestTransport } from "../../jest.setup";
 import { SchemaValidationResponse } from "../../../src/commands/configuration-management/interfaces/package-validation.interfaces";
 import { getJsonFromFile } from "../../utls/fs-utils";
+import * as fs from "fs";
 
 describe("Config validate", () => {
 
@@ -169,6 +170,8 @@ describe("Config validate", () => {
         };
 
         mockAxiosPost(VALIDATE_URL, response);
+
+        const mockWriteFileSync = jest.spyOn(fs, "writeFileSync");
 
         await new PackageValidationService(testContext).validatePackage("my-package", ["DATA_PIPELINES"], null, true);
 

--- a/tests/core/utils/file.service.spec.ts
+++ b/tests/core/utils/file.service.spec.ts
@@ -12,27 +12,18 @@ describe("FileService", () => {
     const symLinkSourceTempDir = path.join(os.tmpdir(), "file-service-symlink-source");
 
     beforeAll(() => {
-        fileService = new FileService();
+        rmTempDir(tempDir);
+        rmTempDir(symLinkSourceTempDir);
 
-        if (!fs.existsSync(tempDir)) {
-            fs.mkdirSync(tempDir, { recursive: true, mode: 0o700 });
-        }
-
-        if (!fs.existsSync(symLinkSourceTempDir)) {
-            fs.mkdirSync(symLinkSourceTempDir, { recursive: true, mode: 0o700 });
-        }
+        fs.mkdirSync(tempDir, { recursive: true, mode: 0o700 });
+        fs.mkdirSync(symLinkSourceTempDir, { recursive: true, mode: 0o700 });
 
         fileService = new FileService();
     });
 
     afterAll(() => {
-        if (fs.existsSync(tempDir)) {
-            rmTempDir(tempDir);
-        }
-
-        if (fs.existsSync(symLinkSourceTempDir)) {
-            rmTempDir(tempDir);
-        }
+        rmTempDir(tempDir);
+        rmTempDir(symLinkSourceTempDir);
     });
 
     describe("zipDirectoryInBatchExportFormat", () => {


### PR DESCRIPTION
#### Description

The recent testing refactors moved the suite toward using real files in temp directories and asserting on real process output, rather than filesystem mocks. A PR that merged afterwards added a `config validate` test written against the older mock-based style — it referenced an undefined `mockWriteFileSync`, which broke compilation of the whole spec and turned the test suite red.

This wires that test up correctly by spying on `fs.writeFileSync` (which, via `jest.spyOn`, still writes the real report file under the mocked temp `cwd`). While verifying, I also hardened the `FileService` spec: its fixed-name temp directories leaked between runs and caused `EEXIST` on repeated local runs, so setup/teardown now clean up reliably and the suite is idempotent.

This is a test-only change — no production code is touched.

#### Relevant links

- No JIRA ticket — test-suite fix.

#### Checklist

- [x] I have self-reviewed this PR
- [x] I have tested the change and proved that it works in different scenarios (full suite green over two consecutive runs, 52 suites / 458 tests)
- [ ] I have updated docs if needed (not needed — test-only)
