### PR TITLE
SP-1534: add description messages where they were missing

### DIFF
--- a/src/commands/action-flows/module.ts
+++ b/src/commands/action-flows/module.ts
@@ -11,7 +11,8 @@ import { SkillCommandService } from "./skill/skill-command.service";
 class Module extends IModule {
 
     public register(context: Context, configurator: Configurator): void {
-        const analyzeCommand = configurator.command("analyze");
+        const analyzeCommand = configurator.command("analyze")
+            .description("Analyze action flows and return its dependencies");
         analyzeCommand.command("action-flows")
             .description("Analyze Action Flows dependencies for a certain package")
             .requiredOption("--packageId <packageId>", "ID of the package from which you want to export Action Flows")

--- a/src/commands/data-pipeline/connection/connection.commands.ts
+++ b/src/commands/data-pipeline/connection/connection.commands.ts
@@ -16,14 +16,16 @@ export class ConnectionCommands {
             .requiredOption("--dataPoolId <dataPoolId>", "ID of the data pool")
             .action(this.listConnections);
 
-        const getCommand = configurator.command("get");
+        const getCommand = configurator.command("get")
+            .description("get data pool connection");
         getCommand.command("connection")
             .description("Programmatically read properties of your connections")
             .requiredOption("--dataPoolId <dataPoolId>", "Id of the data pool you want to update")
             .requiredOption("--connectionId <connectionId>", "Id of the connection you want to update")
             .action(this.getCommandProperties);
 
-        const setCommand = configurator.command("set");
+        const setCommand = configurator.command("set")
+            .description("set data pool connection");
         setCommand.command("connection")
             .description("Programmatically update properties of your connections")
             .requiredOption("--dataPoolId <dataPoolId>", "Id of the data pool you want to update")

--- a/src/commands/data-pipeline/data-pool/data-pool.commands.ts
+++ b/src/commands/data-pipeline/data-pool/data-pool.commands.ts
@@ -45,7 +45,8 @@ export class DataPoolCommands {
             .description("Command to push data pools")
             .action(this.pushDataPools);
 
-        const updateCommand = configurator.command("update");
+        const updateCommand = configurator.command("update")
+            .description("Update data pool");
         updateCommand.command("data-pool")
             .description("Command to update a data pool using a data pool configuration file")
             .requiredOption("--id <id>", "Id of the data pool you want to update")

--- a/src/commands/deployment/module.ts
+++ b/src/commands/deployment/module.ts
@@ -6,7 +6,8 @@ import { DeploymentService } from "./deployment.service";
 class Module extends IModule {
 
     public register(context: Context, configurator: Configurator): void {
-        const deploymentCommand = configurator.command("deployment").beta();
+        const deploymentCommand = configurator.command("deployment").beta()
+            .description("Create deployments, list their history, check active deployments, and retrieve deployables and targets");
 
         deploymentCommand.command("create")
             .beta()
@@ -18,7 +19,8 @@ class Module extends IModule {
             .option("--json", "Return the response as a JSON file")
             .action(this.createDeployment);
 
-        const listCommand = deploymentCommand.command("list").beta();
+        const listCommand = deploymentCommand.command("list")
+            .description("List deployment history, active deployments, deployables or targets").beta();
 
         listCommand.command("history")
             .beta()

--- a/src/content-cli.ts
+++ b/src/content-cli.ts
@@ -69,6 +69,10 @@ export function createProgram(context: Context, opts: CreateProgramOptions = {})
  */
 function configureRootCommands(configurator: Configurator): void {
     configurator.command("list").description("Commands to list content.").alias("ls");
+    configurator.command("export").description("Export resource: action flow or data pool");
+    configurator.command("import").description("Import resource: action flow or data pool");
+    configurator.command("pull").description("Pull resource: skill, bookmark, view bookmark, data pool or asset");
+    configurator.command("push").description("Push resource: asset, skill, bookmark, view bookmark, CTP or data pool");
 }
 
 async function run(): Promise<void> {


### PR DESCRIPTION
#### Description

Backfill help descriptions. Legacy root commands that are used by multiple modules were added to `configureRootCommands`. General commands that are only used by one module are added to the modules themselves.

#### Relevant links

- Jira: https://celonis.atlassian.net/browse/SP-1534

#### Checklist

- [x] I have self-reviewed this PR
- [ ] I have tested the change and proved that it works in different scenarios
- [ ] I have updated docs if needed
