### PR TITLE
SP-1173: add CUI marking for files the CLI writes to disk

### DIFF
--- a/src/commands/studio/manager/space.manager.ts
+++ b/src/commands/studio/manager/space.manager.ts
@@ -4,15 +4,18 @@ import { BaseManager } from "../../../core/http/http-shared/base.manager";
 import { ManagerConfig } from "../../../core/http/http-shared/manager-config.interface";
 import { SpaceTransport } from "../interfaces/space.interface";
 import { logger } from "../../../core/utils/logger";
+import { CuiFileService } from "../../../core/utils/cui-file-service";
 
 export class SpaceManager extends BaseManager {
 
     private static BASE_URL = "/package-manager/api/spaces";
 
     private _jsonResponse: boolean;
+    private readonly cuiFileService: CuiFileService;
 
     constructor(context: Context) {
         super(context);
+        this.cuiFileService = new CuiFileService(context);
     }
 
     public get jsonResponse(): boolean {
@@ -30,11 +33,11 @@ export class SpaceManager extends BaseManager {
         };
     }
 
-    private listSpaces(nodes: SpaceTransport[]): void {
+    private async listSpaces(nodes: SpaceTransport[]): Promise<void> {
         if (this.jsonResponse) {
             const filename = uuidv4() + ".json";
-            this.writeToFileWithGivenName(JSON.stringify(nodes, ["id", "name"]), filename);
-            logger.info(this.fileDownloadedMessage + filename);
+            const writtenFilename = await this.cuiFileService.writeToFileWithGivenName(JSON.stringify(nodes, ["id", "name"]), filename);
+            logger.info(this.fileDownloadedMessage + writtenFilename);
         } else {
             nodes.forEach(node => {
                 logger.info(`${node.id} - Name: "${node.name}"`);

--- a/src/commands/studio/service/package.service.ts
+++ b/src/commands/studio/service/package.service.ts
@@ -6,7 +6,8 @@ import {
     PackageDependencyTransport,
     PackageManagerVariableType,
 } from "../interfaces/package-manager.interfaces";
-import { FileService, fileService } from "../../../core/utils/file-service";
+import { FileService } from "../../../core/utils/file-service";
+import { CuiFileService } from "../../../core/utils/cui-file-service";
 import { BatchExportNodeTransport } from "../interfaces/batch-export-node.interfaces";
 import { PackageDependenciesApi } from "../api/package-dependencies-api";
 import { DataModelService } from "./data-model.service";
@@ -20,12 +21,14 @@ export class PackageService {
 
     private dataModelService: DataModelService;
     private variableService: StudioVariableService;
+    private readonly cuiFileService: CuiFileService;
 
     constructor(context: Context) {
         this.packageApi = new PackageApi(context);
         this.packageDependenciesApi = new PackageDependenciesApi(context);
         this.dataModelService = new DataModelService(context);
         this.variableService = new StudioVariableService(context);
+        this.cuiFileService = new CuiFileService(context);
     }
 
     public async listPackages(): Promise<void> {
@@ -66,7 +69,7 @@ export class PackageService {
                 return nodeToExport;
             })
         }
-        this.exportListOfPackages(nodesListToExport, fieldsToInclude);
+        await this.exportListOfPackages(nodesListToExport, fieldsToInclude);
     }
 
     public async getNodesWithActiveVersion(nodes: BatchExportNodeTransport[]): Promise<BatchExportNodeTransport[]> {
@@ -83,9 +86,9 @@ export class PackageService {
         return await this.packageDependenciesApi.findPackageDependenciesByIds(draftIdByNodeId);
     }
 
-    private exportListOfPackages(nodes: BatchExportNodeTransport[], fieldsToInclude: string[]): void {
+    private async exportListOfPackages(nodes: BatchExportNodeTransport[], fieldsToInclude: string[]): Promise<void> {
         const filename = uuidv4() + ".json";
-        fileService.writeToFileWithGivenName(JSON.stringify(nodes, fieldsToInclude), filename);
-        logger.info(FileService.fileDownloadedMessage + filename);
+        const writtenFilename = await this.cuiFileService.writeToFileWithGivenName(JSON.stringify(nodes, fieldsToInclude), filename);
+        logger.info(FileService.fileDownloadedMessage + writtenFilename);
     }
 }

--- a/src/core/http/http-client.ts
+++ b/src/core/http/http-client.ts
@@ -35,6 +35,23 @@ export class HttpClient {
         })
     }
 
+    public async getStatusAndData(url: string): Promise<{ status: number; data: any }> {
+        const fullUrl = this.resolveUrl(url);
+        logger.debug(`HttpClient - GET ${fullUrl}`);
+        return this.axios.get(fullUrl, {
+            headers: this.buildHeaders(),
+            validateStatus: () => true,
+        }).then(response => {
+            logger.debug(`Response ${response.status}`);
+            return { status: response.status, data: response.data };
+        }).catch(err => {
+            if (err.response) {
+                return { status: err.response.status, data: err.response.data };
+            }
+            throw new FatalError(err);
+        });
+    }
+
     public async getFile(url: string): Promise<any> {
         return new Promise<any>((resolve, reject) => {
             this.axios.get(this.resolveUrl(url), {

--- a/src/core/http/http-shared/base.manager.ts
+++ b/src/core/http/http-shared/base.manager.ts
@@ -82,18 +82,14 @@ export abstract class BaseManager {
     }
 
     public async findAll(): Promise<any> {
-        return new Promise<any>((resolve, reject) => {
-            this.httpClient()
-                .get(this.getConfig().findAllUrl)
-                .then(data => {
-                    this.getConfig().onFindAll(data);
-                    resolve(data);
-                })
-                .catch(err => {
-                    logger.error(new FatalError(err));
-                    reject();
-                });
-        });
+        try {
+            const data = await this.httpClient().get(this.getConfig().findAllUrl);
+            await this.getConfig().onFindAll(data);
+            return data;
+        } catch (err) {
+            logger.error(new FatalError(err));
+            return Promise.reject();
+        }
     }
 
     protected writeToFile(data: any): string {

--- a/src/core/http/http-shared/base.manager.ts
+++ b/src/core/http/http-shared/base.manager.ts
@@ -88,7 +88,7 @@ export abstract class BaseManager {
             return data;
         } catch (err) {
             logger.error(new FatalError(err));
-            return Promise.reject();
+            throw err;
         }
     }
 

--- a/src/core/http/http-shared/manager-config.interface.ts
+++ b/src/core/http/http-shared/manager-config.interface.ts
@@ -6,6 +6,6 @@ export interface ManagerConfig {
     exportFileName?: string;
     onPushSuccessMessage?: (data: any) => string;
     onUpdateSuccessMessage?: () => string;
-    onFindAll?: (data: any) => void;
+    onFindAll?: (data: any) => void | Promise<void>;
     onFindAllAndExport?: (data: any) => void;
 }

--- a/src/core/utils/cui-api.ts
+++ b/src/core/utils/cui-api.ts
@@ -7,7 +7,7 @@ export interface CuiPdfCoverResponse {
     coverPage?: { pdfContent: string; encoding: string };
 }
 
-export class CuiService {
+export class CuiApi {
     private static readonly CUI_PDF_COVER_SHEET_URL = "/api/team/cui-settings/cui-pdf-cover";
 
     private static readonly STATUS_OK = 200;
@@ -21,22 +21,22 @@ export class CuiService {
     }
 
     public async getCuiPdfCover(): Promise<CuiPdfCoverResponse | null> {
-        const { status, data } = await this.httpClient().getStatusAndData(CuiService.CUI_PDF_COVER_SHEET_URL);
+        const { status, data } = await this.httpClient().getStatusAndData(CuiApi.CUI_PDF_COVER_SHEET_URL);
 
-        if (status === CuiService.STATUS_FORBIDDEN) {
+        if (status === CuiApi.STATUS_FORBIDDEN) {
             logger.debug("CUI marking does not apply, the feature flag is disabled");
             return null;
         }
 
-        if (status === CuiService.STATUS_NO_CONTENT) {
+        if (status === CuiApi.STATUS_NO_CONTENT) {
             logger.debug("CUI marking does not apply, the team has CUI disabled");
             return null;
         }
 
-        if (status !== CuiService.STATUS_OK) {
-            throw new FatalError("Problem fetching cui pdf cover");
+        if (status === CuiApi.STATUS_OK && data) {
+            return data as CuiPdfCoverResponse;
         }
 
-        return data ? (data as CuiPdfCoverResponse) : null;
+        throw new FatalError("Problem fetching cui pdf cover");
     }
 }

--- a/src/core/utils/cui-file-service.ts
+++ b/src/core/utils/cui-file-service.ts
@@ -1,0 +1,81 @@
+import * as path from "path";
+import AdmZip = require("adm-zip");
+import { Context } from "../command/cli-context";
+import { CuiPdfCoverResponse, CuiService } from "./cui-service";
+import { fileService } from "./file-service";
+import { FileConstants } from "./file.constants";
+import { FatalError } from "./logger";
+
+export class CuiFileService {
+    public static readonly COVER_SHEET_FILE_NAME = "CUI_Cover_Sheet.pdf";
+    public static readonly CLASSIFIED_PREFIX = "CUI - ";
+    public static readonly UNCLASSIFIED_PREFIX = "Unclassified - ";
+
+    private static readonly BASE64_ENCODING = "base64";
+
+    private readonly cuiService: CuiService;
+
+    constructor(context: Context) {
+        this.cuiService = new CuiService(context);
+    }
+
+    public async writeToFileWithGivenName(data: string, filename: string): Promise<string> {
+        const cover = await this.cuiService.getCuiPdfCover();
+
+        if (cover === null) {
+            fileService.writeToFileWithGivenName(data, filename);
+            return filename;
+        }
+
+        if (!this.isClassified(cover)) {
+            const unclassifiedName = this.prefixFileName(filename, CuiFileService.UNCLASSIFIED_PREFIX);
+            fileService.writeToFileWithGivenName(data, unclassifiedName);
+            return unclassifiedName;
+        }
+
+        return this.writeClassifiedArchive(filename, data, cover);
+    }
+
+    private writeClassifiedArchive(filename: string, data: string, cover: CuiPdfCoverResponse): string {
+        const zip = new AdmZip();
+        zip.addFile(path.basename(filename), Buffer.from(data, "utf-8"), "", FileConstants.DEFAULT_FILE_PERMISSIONS);
+        zip.addFile(
+            CuiFileService.COVER_SHEET_FILE_NAME,
+            this.decodeCoverPage(cover),
+            "",
+            FileConstants.DEFAULT_FILE_PERMISSIONS
+        );
+
+        const archiveName = this.buildClassifiedArchiveName(filename);
+        fileService.writeBufferToFileWithGivenName(zip.toBuffer(), archiveName);
+
+        return archiveName;
+    }
+
+    private decodeCoverPage(cover: CuiPdfCoverResponse): Buffer {
+        const coverPage = cover.coverPage;
+        if (!coverPage?.pdfContent) {
+            throw new FatalError("CUI marking applies but the response contained no cover page.");
+        }
+        if (coverPage.encoding !== CuiFileService.BASE64_ENCODING) {
+            throw new FatalError(`Unsupported CUI cover page encoding: ${coverPage.encoding}`);
+        }
+
+        return Buffer.from(coverPage.pdfContent, CuiFileService.BASE64_ENCODING);
+    }
+
+    private isClassified(cover: CuiPdfCoverResponse): boolean {
+        return (cover.resolvedCuiMarking?.categories?.length ?? 0) > 0;
+    }
+
+    private buildClassifiedArchiveName(filename: string): string {
+        const baseName = path.basename(filename);
+        const nameWithoutExtension = baseName.slice(0, baseName.length - path.extname(baseName).length);
+
+        return path.join(path.dirname(filename), `${CuiFileService.CLASSIFIED_PREFIX}${nameWithoutExtension}.zip`);
+    }
+
+    private prefixFileName(filename: string, prefix: string): string {
+        return path.join(path.dirname(filename), `${prefix}${path.basename(filename)}`);
+    }
+}

--- a/src/core/utils/cui-file-service.ts
+++ b/src/core/utils/cui-file-service.ts
@@ -1,4 +1,4 @@
-import * as path from "path";
+import * as path from "node:path";
 import AdmZip = require("adm-zip");
 import { Context } from "../command/cli-context";
 import { CuiPdfCoverResponse, CuiService } from "./cui-service";

--- a/src/core/utils/cui-file-service.ts
+++ b/src/core/utils/cui-file-service.ts
@@ -1,7 +1,7 @@
 import * as path from "node:path";
 import AdmZip = require("adm-zip");
 import { Context } from "../command/cli-context";
-import { CuiPdfCoverResponse, CuiService } from "./cui-service";
+import { CuiApi, CuiPdfCoverResponse } from "./cui-api";
 import { fileService } from "./file-service";
 import { FileConstants } from "./file.constants";
 import { FatalError } from "./logger";
@@ -13,14 +13,14 @@ export class CuiFileService {
 
     private static readonly BASE64_ENCODING = "base64";
 
-    private readonly cuiService: CuiService;
+    private readonly cuiApi: CuiApi;
 
     constructor(context: Context) {
-        this.cuiService = new CuiService(context);
+        this.cuiApi = new CuiApi(context);
     }
 
     public async writeToFileWithGivenName(data: string, filename: string): Promise<string> {
-        const cover = await this.cuiService.getCuiPdfCover();
+        const cover = await this.cuiApi.getCuiPdfCover();
 
         if (cover === null) {
             fileService.writeToFileWithGivenName(data, filename);

--- a/src/core/utils/cui-service.ts
+++ b/src/core/utils/cui-service.ts
@@ -2,27 +2,13 @@ import { HttpClient } from "../http/http-client";
 import { FatalError, logger } from "./logger";
 import { Context } from "../command/cli-context";
 
-export interface CuiCategory {
-    code: string;
-    name: string;
-}
-
-export interface ResolvedCuiMarking {
-    categories?: CuiCategory[];
-}
-
-export interface CuiCoverPage {
-    pdfContent: string;
-    encoding: string;
-}
-
 export interface CuiPdfCoverResponse {
-    resolvedCuiMarking?: ResolvedCuiMarking;
-    coverPage?: CuiCoverPage;
+    resolvedCuiMarking?: { categories?: unknown[] };
+    coverPage?: { pdfContent: string; encoding: string };
 }
 
 export class CuiService {
-    private static readonly COVER_SHEET_URL = "/api/team/cui-settings/cui-pdf-cover";
+    private static readonly CUI_PDF_COVER_SHEET_URL = "/api/team/cui-settings/cui-pdf-cover";
 
     private static readonly STATUS_OK = 200;
     private static readonly STATUS_NO_CONTENT = 204;
@@ -35,7 +21,7 @@ export class CuiService {
     }
 
     public async getCuiPdfCover(): Promise<CuiPdfCoverResponse | null> {
-        const { status, data } = await this.httpClient().getStatusAndData(CuiService.COVER_SHEET_URL);
+        const { status, data } = await this.httpClient().getStatusAndData(CuiService.CUI_PDF_COVER_SHEET_URL);
 
         if (status === CuiService.STATUS_FORBIDDEN) {
             logger.debug("CUI marking does not apply, the feature flag is disabled");
@@ -48,17 +34,9 @@ export class CuiService {
         }
 
         if (status !== CuiService.STATUS_OK) {
-            const detail = this.describeBody(data) || `Backend responded with status code ${status}`;
-            throw new FatalError(`Problem fetching cui: ${detail}`);
+            throw new FatalError("Problem fetching cui pdf cover");
         }
 
         return data ? (data as CuiPdfCoverResponse) : null;
-    }
-
-    private describeBody(data: any): string {
-        if (!data) {
-            return "";
-        }
-        return `: ${typeof data === "string" ? data : JSON.stringify(data)}`;
     }
 }

--- a/src/core/utils/cui-service.ts
+++ b/src/core/utils/cui-service.ts
@@ -26,7 +26,6 @@ export class CuiService {
 
     private static readonly STATUS_OK = 200;
     private static readonly STATUS_NO_CONTENT = 204;
-    private static readonly STATUS_FORBIDDEN = 403;
 
     private readonly httpClient: () => HttpClient;
 
@@ -35,18 +34,19 @@ export class CuiService {
     }
 
     /**
-     * Returns null when no marking applies: 403 (team.cui-settings not enabled) or 204 (CUI disabled).
+     * Returns null when the team has CUI disabled.
      */
     public async getCuiPdfCover(): Promise<CuiPdfCoverResponse | null> {
         const { status, data } = await this.httpClient().getStatusAndData(CuiService.COVER_SHEET_URL);
 
-        if (status === CuiService.STATUS_FORBIDDEN || status === CuiService.STATUS_NO_CONTENT) {
-            logger.debug(`CUI marking does not apply, cover sheet endpoint responded with ${status}${this.describeBody(data)}`);
+        if (status === CuiService.STATUS_NO_CONTENT) {
+            logger.debug("CUI marking does not apply, the team has CUI disabled");
             return null;
         }
 
         if (status !== CuiService.STATUS_OK) {
-            throw new FatalError(`Problem fetching cui: ${this.describeBody(data) || `Backend responded with status code ${status}`}`);
+            const detail = this.describeBody(data) || `Backend responded with status code ${status}`;
+            throw new FatalError(`Problem fetching cui: ${detail}`);
         }
 
         return data ? (data as CuiPdfCoverResponse) : null;

--- a/src/core/utils/cui-service.ts
+++ b/src/core/utils/cui-service.ts
@@ -26,6 +26,7 @@ export class CuiService {
 
     private static readonly STATUS_OK = 200;
     private static readonly STATUS_NO_CONTENT = 204;
+    private static readonly STATUS_FORBIDDEN = 403;
 
     private readonly httpClient: () => HttpClient;
 
@@ -33,11 +34,13 @@ export class CuiService {
         this.httpClient = () => context.httpClient;
     }
 
-    /**
-     * Returns null when the team has CUI disabled.
-     */
     public async getCuiPdfCover(): Promise<CuiPdfCoverResponse | null> {
         const { status, data } = await this.httpClient().getStatusAndData(CuiService.COVER_SHEET_URL);
+
+        if (status === CuiService.STATUS_FORBIDDEN) {
+            logger.debug("CUI marking does not apply, the feature flag is disabled");
+            return null;
+        }
 
         if (status === CuiService.STATUS_NO_CONTENT) {
             logger.debug("CUI marking does not apply, the team has CUI disabled");

--- a/src/core/utils/cui-service.ts
+++ b/src/core/utils/cui-service.ts
@@ -1,0 +1,61 @@
+import { HttpClient } from "../http/http-client";
+import { FatalError, logger } from "./logger";
+import { Context } from "../command/cli-context";
+
+export interface CuiCategory {
+    code: string;
+    name: string;
+}
+
+export interface ResolvedCuiMarking {
+    categories?: CuiCategory[];
+}
+
+export interface CuiCoverPage {
+    pdfContent: string;
+    encoding: string;
+}
+
+export interface CuiPdfCoverResponse {
+    resolvedCuiMarking?: ResolvedCuiMarking;
+    coverPage?: CuiCoverPage;
+}
+
+export class CuiService {
+    private static readonly COVER_SHEET_URL = "/api/team/cui-settings/cui-pdf-cover";
+
+    private static readonly STATUS_OK = 200;
+    private static readonly STATUS_NO_CONTENT = 204;
+    private static readonly STATUS_FORBIDDEN = 403;
+
+    private readonly httpClient: () => HttpClient;
+
+    constructor(context: Context) {
+        this.httpClient = () => context.httpClient;
+    }
+
+    /**
+     * Returns null when no marking applies: 403 (team.cui-settings not enabled) or 204 (CUI disabled).
+     */
+    public async getCuiPdfCover(): Promise<CuiPdfCoverResponse | null> {
+        const { status, data } = await this.httpClient().getStatusAndData(CuiService.COVER_SHEET_URL);
+
+        if (status === CuiService.STATUS_FORBIDDEN || status === CuiService.STATUS_NO_CONTENT) {
+            logger.debug(`CUI marking does not apply, cover sheet endpoint responded with ${status}${this.describeBody(data)}`);
+            return null;
+        }
+
+        if (status !== CuiService.STATUS_OK) {
+            throw new FatalError(`Problem fetching cui: ${this.describeBody(data) || `Backend responded with status code ${status}`}`);
+        }
+
+        return data ? (data as CuiPdfCoverResponse) : null;
+    }
+
+    private describeBody(data: any): string {
+        if (!data) {
+            return "";
+        }
+        return `: ${typeof data === "string" ? data : JSON.stringify(data)}`;
+    }
+}

--- a/tests/commands/studio/list-cui-marking.spec.ts
+++ b/tests/commands/studio/list-cui-marking.spec.ts
@@ -1,0 +1,126 @@
+import { resolve } from "node:path";
+import { readFileSync } from "node:fs";
+import AdmZip = require("adm-zip");
+import { mockAxiosGet, mockAxiosGetWithStatus, mockedAxiosInstance } from "../../utls/http-requests-mock";
+import { SpaceCommandService } from "../../../src/commands/studio/command-service/space-command.service";
+import { PackageCommandService } from "../../../src/commands/studio/command-service/package-command.service";
+import { testContext } from "../../utls/test-context";
+import { loggingTestTransport } from "../../jest.setup";
+import { FileService } from "../../../src/core/utils/file-service";
+import { CuiFileService } from "../../../src/core/utils/cui-file-service";
+
+const SPACES_URL = "https://myTeam.celonis.cloud/package-manager/api/spaces";
+const PACKAGES_URL = "https://myTeam.celonis.cloud/package-manager/api/packages";
+const COVER_URL = "https://myTeam.celonis.cloud/api/team/cui-settings/cui-pdf-cover";
+
+const SPACES = [{ id: "space-1", name: "My Space" }];
+const PACKAGES = [{ key: "pkg-1", name: "My Package", rootNodeKey: "pkg-1" }];
+const LISTED_PACKAGES = [{ key: "pkg-1", name: "My Package" }];
+const PDF_BYTES = Buffer.from("%PDF-1.4 cover sheet");
+
+function classifiedCover(): object {
+    return {
+        resolvedCuiMarking: { categories: [{ code: "PRVCY", name: "Privacy" }] },
+        coverPage: { pdfContent: PDF_BYTES.toString("base64"), encoding: "base64" },
+    };
+}
+
+function loggedFileName(): string {
+    return loggingTestTransport.logMessages[0].message.split(FileService.fileDownloadedMessage)[1];
+}
+
+function readWrittenJson(filename: string): any {
+    return JSON.parse(readFileSync(resolve(process.cwd(), filename), "utf-8"));
+}
+
+function payloadFromArchive(filename: string): any {
+    const archive = new AdmZip(readFileSync(resolve(process.cwd(), filename)));
+    const entries = archive.getEntries().map(entry => entry.entryName);
+
+    expect(entries).toContain(CuiFileService.COVER_SHEET_FILE_NAME);
+    expect(archive.getEntry(CuiFileService.COVER_SHEET_FILE_NAME).getData().equals(PDF_BYTES)).toBe(true);
+
+    const payloadEntry = entries.find(entry => entry.endsWith(".json"));
+    return JSON.parse(archive.getEntry(payloadEntry).getData().toString());
+}
+
+function coverWasRequested(): boolean {
+    return (mockedAxiosInstance.get as jest.Mock).mock.calls.some(call => call[0] === COVER_URL);
+}
+
+describe("CUI marking of Studio listings", () => {
+
+    describe("list spaces --json", () => {
+        const listSpaces = () => new SpaceCommandService(testContext).listSpaces(true);
+
+        beforeEach(() => {
+            mockAxiosGet(SPACES_URL, SPACES);
+        });
+
+        it("Should wrap the listing and the cover sheet into a CUI archive when classified", async () => {
+            mockAxiosGetWithStatus(COVER_URL, 200, classifiedCover());
+
+            await listSpaces();
+
+            const filename = loggedFileName();
+            expect(filename.startsWith(CuiFileService.CLASSIFIED_PREFIX)).toBe(true);
+            expect(filename.endsWith(".zip")).toBe(true);
+            expect(payloadFromArchive(filename)).toEqual(SPACES);
+        });
+
+        it("Should keep the original filename when no marking applies", async () => {
+            mockAxiosGetWithStatus(COVER_URL, 204, "");
+
+            await listSpaces();
+
+            const filename = loggedFileName();
+            expect(filename.startsWith(CuiFileService.UNCLASSIFIED_PREFIX)).toBe(false);
+            expect(filename.startsWith(CuiFileService.CLASSIFIED_PREFIX)).toBe(false);
+            expect(readWrittenJson(filename)).toEqual(SPACES);
+        });
+
+        it("Should not probe CUI when the listing only goes to the console", async () => {
+            await new SpaceCommandService(testContext).listSpaces(false);
+
+            expect(loggingTestTransport.logMessages[0].message).toContain(`space-1 - Name: "My Space"`);
+            expect(coverWasRequested()).toBe(false);
+        });
+    });
+
+    describe("list packages --json", () => {
+        const listPackages = () => new PackageCommandService(testContext).listPackages(true, false, []);
+
+        beforeEach(() => {
+            mockAxiosGet(PACKAGES_URL, PACKAGES);
+        });
+
+        it("Should wrap the listing and the cover sheet into a CUI archive when classified", async () => {
+            mockAxiosGetWithStatus(COVER_URL, 200, classifiedCover());
+
+            await listPackages();
+
+            const filename = loggedFileName();
+            expect(filename.startsWith(CuiFileService.CLASSIFIED_PREFIX)).toBe(true);
+            expect(filename.endsWith(".zip")).toBe(true);
+            expect(payloadFromArchive(filename)).toEqual(LISTED_PACKAGES);
+        });
+
+        it("Should keep the original filename when no marking applies", async () => {
+            mockAxiosGetWithStatus(COVER_URL, 204, "");
+
+            await listPackages();
+
+            const filename = loggedFileName();
+            expect(filename.startsWith(CuiFileService.UNCLASSIFIED_PREFIX)).toBe(false);
+            expect(filename.startsWith(CuiFileService.CLASSIFIED_PREFIX)).toBe(false);
+            expect(readWrittenJson(filename)).toEqual(LISTED_PACKAGES);
+        });
+
+        it("Should not probe CUI when the listing only goes to the console", async () => {
+            await new PackageCommandService(testContext).listPackages(false, false, []);
+
+            expect(loggingTestTransport.logMessages[0].message).toContain(`My Package - Key: "pkg-1"`);
+            expect(coverWasRequested()).toBe(false);
+        });
+    });
+});

--- a/tests/core/utils/cui-file-service.spec.ts
+++ b/tests/core/utils/cui-file-service.spec.ts
@@ -1,0 +1,102 @@
+import { accessSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import AdmZip = require("adm-zip");
+import { CuiFileService } from "../../../src/core/utils/cui-file-service";
+import { FatalError } from "../../../src/core/utils/logger";
+import { testContext } from "../../utls/test-context";
+import { mockAxiosGetError, mockAxiosGetWithStatus } from "../../utls/http-requests-mock";
+
+describe("CuiFileService", () => {
+    const COVER_URL = "https://myTeam.celonis.cloud/api/team/cui-settings/cui-pdf-cover";
+    const PDF_BYTES = Buffer.from("%PDF-1.4 cover sheet");
+    const PAYLOAD = JSON.stringify({ key: "pkg-1" });
+
+    let cuiFileService: CuiFileService;
+
+    const coverResponse = (categories: Array<{ code: string; name: string }>) => ({
+        resolvedCuiMarking: { categories },
+        coverPage: {
+            pdfContent: PDF_BYTES.toString("base64"),
+            encoding: "base64",
+        },
+    });
+
+    const readFile = (filename: string): Buffer => readFileSync(resolve(process.cwd(), filename));
+
+    beforeEach(() => {
+        cuiFileService = new CuiFileService(testContext);
+    });
+
+    describe("when CUI marking does not apply", () => {
+        it("Should keep the original filename when the feature is not enabled for the team", async () => {
+            mockAxiosGetError(COVER_URL, 403, { errorCode: "feature-disabled" });
+
+            const filename = await cuiFileService.writeToFileWithGivenName(PAYLOAD, "report.json");
+
+            expect(filename).toEqual("report.json");
+            expect(readFile("report.json").toString()).toEqual(PAYLOAD);
+        });
+
+        it("Should keep the original filename when the team has CUI disabled", async () => {
+            mockAxiosGetWithStatus(COVER_URL, 204, "");
+
+            const filename = await cuiFileService.writeToFileWithGivenName(PAYLOAD, "no-marking.json");
+
+            expect(filename).toEqual("no-marking.json");
+            expect(readFile("no-marking.json").toString()).toEqual(PAYLOAD);
+        });
+
+        it("Should fail on an unexpected backend error", async () => {
+            mockAxiosGetError(COVER_URL, 500, { message: "boom" });
+
+            await expect(cuiFileService.writeToFileWithGivenName(PAYLOAD, "broken.json")).rejects.toThrow(FatalError);
+            expect(() => accessSync(resolve(process.cwd(), "broken.json"))).toThrow();
+        });
+    });
+
+    describe("when the content is unclassified", () => {
+        it("Should only prefix the filename and write no cover sheet", async () => {
+            mockAxiosGetWithStatus(COVER_URL, 200, coverResponse([]));
+
+            const filename = await cuiFileService.writeToFileWithGivenName(PAYLOAD, "packages.json");
+
+            expect(filename).toEqual("Unclassified - packages.json");
+            expect(readFile(filename).toString()).toEqual(PAYLOAD);
+            expect(() => accessSync(resolve(process.cwd(), CuiFileService.COVER_SHEET_FILE_NAME))).toThrow();
+        });
+    });
+
+    describe("when the content is classified", () => {
+        it("Should wrap the payload and the decoded cover sheet into a CUI archive", async () => {
+            mockAxiosGetWithStatus(COVER_URL, 200, coverResponse([{ code: "PRVCY", name: "Privacy" }]));
+
+            const filename = await cuiFileService.writeToFileWithGivenName(PAYLOAD, "packages.json");
+
+            expect(filename).toEqual("CUI - packages.zip");
+
+            const zip = new AdmZip(readFile(filename));
+            expect(zip.getEntries().map(entry => entry.entryName).sort())
+                .toEqual([CuiFileService.COVER_SHEET_FILE_NAME, "packages.json"]);
+            expect(zip.getEntry("packages.json").getData().toString()).toEqual(PAYLOAD);
+            expect(zip.getEntry(CuiFileService.COVER_SHEET_FILE_NAME).getData().equals(PDF_BYTES)).toBe(true);
+        });
+
+        it("Should fail when the cover page uses an unsupported encoding", async () => {
+            const response = coverResponse([{ code: "PRVCY", name: "Privacy" }]);
+            response.coverPage.encoding = "hex";
+            mockAxiosGetWithStatus(COVER_URL, 200, response);
+
+            await expect(cuiFileService.writeToFileWithGivenName(PAYLOAD, "packages.json"))
+                .rejects.toThrow("Unsupported CUI cover page encoding: hex");
+        });
+
+        it("Should fail when the marking applies but no cover page was returned", async () => {
+            mockAxiosGetWithStatus(COVER_URL, 200, {
+                resolvedCuiMarking: { categories: [{ code: "PRVCY", name: "Privacy" }] },
+            });
+
+            await expect(cuiFileService.writeToFileWithGivenName(PAYLOAD, "packages.json"))
+                .rejects.toThrow("CUI marking applies but the response contained no cover page.");
+        });
+    });
+});

--- a/tests/core/utils/cui-file-service.spec.ts
+++ b/tests/core/utils/cui-file-service.spec.ts
@@ -28,15 +28,6 @@ describe("CuiFileService", () => {
     });
 
     describe("when CUI marking does not apply", () => {
-        it("Should keep the original filename when the feature is not enabled for the team", async () => {
-            mockAxiosGetError(COVER_URL, 403, { errorCode: "feature-disabled" });
-
-            const filename = await cuiFileService.writeToFileWithGivenName(PAYLOAD, "report.json");
-
-            expect(filename).toEqual("report.json");
-            expect(readFile("report.json").toString()).toEqual(PAYLOAD);
-        });
-
         it("Should keep the original filename when the team has CUI disabled", async () => {
             mockAxiosGetWithStatus(COVER_URL, 204, "");
 
@@ -51,6 +42,13 @@ describe("CuiFileService", () => {
 
             await expect(cuiFileService.writeToFileWithGivenName(PAYLOAD, "broken.json")).rejects.toThrow(FatalError);
             expect(() => accessSync(resolve(process.cwd(), "broken.json"))).toThrow();
+        });
+
+        it("Should fail when the cover endpoint is not reachable", async () => {
+            mockAxiosGetError(COVER_URL, 403, { errorCode: "feature-disabled" });
+
+            await expect(cuiFileService.writeToFileWithGivenName(PAYLOAD, "forbidden.json")).rejects.toThrow(FatalError);
+            expect(() => accessSync(resolve(process.cwd(), "forbidden.json"))).toThrow();
         });
     });
 

--- a/tests/core/utils/cui-file-service.spec.ts
+++ b/tests/core/utils/cui-file-service.spec.ts
@@ -52,6 +52,13 @@ describe("CuiFileService", () => {
             await expect(cuiFileService.writeToFileWithGivenName(PAYLOAD, "broken.json")).rejects.toThrow(FatalError);
             expect(() => accessSync(resolve(process.cwd(), "broken.json"))).toThrow();
         });
+
+        it("Should fail when the marking applies but the response body is empty", async () => {
+            mockAxiosGetWithStatus(COVER_URL, 200, "");
+
+            await expect(cuiFileService.writeToFileWithGivenName(PAYLOAD, "empty-cover.json")).rejects.toThrow(FatalError);
+            expect(() => accessSync(resolve(process.cwd(), "empty-cover.json"))).toThrow();
+        });
     });
 
     describe("when the content is unclassified", () => {

--- a/tests/core/utils/cui-file-service.spec.ts
+++ b/tests/core/utils/cui-file-service.spec.ts
@@ -28,6 +28,15 @@ describe("CuiFileService", () => {
     });
 
     describe("when CUI marking does not apply", () => {
+        it("Should keep the original filename when the feature flag is disabled", async () => {
+            mockAxiosGetError(COVER_URL, 403, { errorCode: "feature-disabled" });
+
+            const filename = await cuiFileService.writeToFileWithGivenName(PAYLOAD, "report.json");
+
+            expect(filename).toEqual("report.json");
+            expect(readFile("report.json").toString()).toEqual(PAYLOAD);
+        });
+
         it("Should keep the original filename when the team has CUI disabled", async () => {
             mockAxiosGetWithStatus(COVER_URL, 204, "");
 
@@ -42,13 +51,6 @@ describe("CuiFileService", () => {
 
             await expect(cuiFileService.writeToFileWithGivenName(PAYLOAD, "broken.json")).rejects.toThrow(FatalError);
             expect(() => accessSync(resolve(process.cwd(), "broken.json"))).toThrow();
-        });
-
-        it("Should fail when the cover endpoint is not reachable", async () => {
-            mockAxiosGetError(COVER_URL, 403, { errorCode: "feature-disabled" });
-
-            await expect(cuiFileService.writeToFileWithGivenName(PAYLOAD, "forbidden.json")).rejects.toThrow(FatalError);
-            expect(() => accessSync(resolve(process.cwd(), "forbidden.json"))).toThrow();
         });
     });
 

--- a/tests/utls/http-requests-mock.ts
+++ b/tests/utls/http-requests-mock.ts
@@ -4,7 +4,10 @@ import { AxiosInitializer } from "../../src/core/http/axios-initializer";
 
 const mockedAxiosInstance = {} as AxiosInstance;
 
+const CUI_PDF_COVER_PATH = "/api/team/cui-settings/cui-pdf-cover";
+
 const mockedGetResponseByUrl = new Map<string, any>();
+const mockedGetStatusByUrl = new Map<string, number>();
 const mockedGetErrorByUrl = new Map<string, { status: number; data: any }>();
 const mockedPostResponseByUrl = new Map<string, any>();
 const mockedPostErrorByUrl = new Map<string, { status: number; data: any }>();
@@ -25,19 +28,25 @@ const mockAxios = () : void => {
             return Promise.reject({ response: { status, data } });
         }
         if (mockedGetResponseByUrl.has(requestUrl)) {
-            const response = { data: mockedGetResponseByUrl.get(requestUrl) };
+            const data = mockedGetResponseByUrl.get(requestUrl);
+            const status = mockedGetStatusByUrl.get(requestUrl) ?? 200;
 
-            if (response.data instanceof Buffer) {
+            if (data instanceof Buffer) {
                 const readableStream = new Readable();
-                readableStream.push(response.data)
+                readableStream.push(data)
                 readableStream.push(null);
                 return Promise.resolve({
                     status: 200,
                     data: readableStream,
                 });
             } else {
-                return Promise.resolve(response);
+                return Promise.resolve({ status, data });
             }
+        }
+        // CUI marking is probed on every user-facing write. Unless a test opts in,
+        // answer 204 so the CLI keeps the original filename.
+        if (requestUrl.endsWith(CUI_PDF_COVER_PATH)) {
+            return Promise.resolve({ status: 204, data: "" });
         }
         fail("API call not mocked.")
     });
@@ -59,6 +68,13 @@ const mockAxios = () : void => {
 
 const mockAxiosGet = (url: string, responseData: any) => {
     mockedGetResponseByUrl.set(url, responseData);
+    mockedGetStatusByUrl.delete(url);
+    mockedGetErrorByUrl.delete(url);
+};
+
+const mockAxiosGetWithStatus = (url: string, status: number, responseData: any) => {
+    mockedGetResponseByUrl.set(url, responseData);
+    mockedGetStatusByUrl.set(url, status);
     mockedGetErrorByUrl.delete(url);
 };
 
@@ -104,6 +120,7 @@ const mockAxiosDelete = (url: string) => {
 
 afterEach(() => {
     mockedGetResponseByUrl.clear();
+    mockedGetStatusByUrl.clear();
     mockedGetErrorByUrl.clear();
     mockedPostResponseByUrl.clear();
     mockedPostErrorByUrl.clear();
@@ -115,6 +132,7 @@ export {
     mockedAxiosInstance,
     mockAxios,
     mockAxiosGet,
+    mockAxiosGetWithStatus,
     mockAxiosGetError,
     mockAxiosPost,
     mockAxiosPostError,


### PR DESCRIPTION
#### Description

Every user-facing file content-cli writes to disk has to carry the team's CUI (Controlled Unclassified Information) marking. This PR adds the mechanism and wires up `list spaces --json` and `list packages --json`. The remaining writers follow in later PRs.

What a user gets depends on the team's CUI settings:

| Team setting | Artifact |
|---|---|
| marking does not apply | original filename, unchanged |
| marking applies, no categories | `Unclassified - <name>` |
| marking applies, with categories | `CUI - <name>.zip`, holding the payload plus `CUI_Cover_Sheet.pdf` |
| marking cannot be resolved | nothing written, the command fails |

This ships inert in production: the cover endpoint is allowlisted for staging only, so production keeps taking the unmarked path until the matching rule lands. Commands that only print to the console never probe the endpoint.

#### Scope: how the write is triggered

| Trigger | Commands | CUI marking |
|---|---|---|
| `--json` listings and reports | `list spaces`, `list packages` | **This PR**, together with the marking mechanism |
| `--json` listings and reports | `list assets/assignments/data-pools`, `config *`, `t2tc package list/diff`, `deployment *`, `asset-registry *` | To follow in [#407](https://github.com/celonis/content-cli/pull/407) |
| `-o, --outputToJsonFile` reports | `analyze/import action-flows`, `export data-pool`, `import data-pools`, `t2tc package import` report | To follow in [#410](https://github.com/celonis/content-cli/pull/410) |
| artifact is already an archive | `config package export --zip`, `config branch export --zip`, `t2tc package export`, `export action-flows`, `pull package` | To follow in [#411](https://github.com/celonis/content-cli/pull/411) |
| single non-archive export | `pull asset/skill/data-pool/view-bookmarks/bookmarks`, `export bookmarks` | To follow in [#412](https://github.com/celonis/content-cli/pull/412) |
| output is a directory | `config package export`, `config branch export`, `t2tc package export --unzip` | To follow in [#413](https://github.com/celonis/content-cli/pull/413): cover sheet into the directory, prefix the directory name |
| `--gitBranch` variants | `config package export`, `config branch export`, `t2tc package export` | Out of scope, nothing reaches local disk |
| no output flag | console-only listings, profile/git-profile/log files | Out of scope |

Two things were left to settle here and both are answered further up the stack: an artifact that is already a zip gets the cover sheet merged in rather than nested ([#411](https://github.com/celonis/content-cli/pull/411)), and directory output keeps the cover sheet inside the directory with the directory name prefixed.

#### Relevant links

- Jira: [SP-1173](https://celonis.atlassian.net/browse/SP-1173)
- Backend endpoint: [celonis/cloud-team#5659](https://github.com/celonis/cloud-team/pull/5659) ([VEX-3192](https://celonis.atlassian.net/browse/VEX-3192))
- Gateway allowlist (staging): [celonis/policy-guard#127](https://github.com/celonis/policy-guard/pull/127)

#### Checklist

- [x] I have self-reviewed this PR
- [x] I have tested the change and proved that it works in different scenarios
- [ ] I have updated docs if needed

[SP-1173]: https://celonis.atlassian.net/browse/SP-1173?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes what files land on disk and their names for JSON listings, with an extra API call per write; scope is limited to two commands and fails closed when cover fetch fails.
> 
> **Overview**
> Adds **CUI (Controlled Unclassified Information) marking** for disk writes from `list spaces --json` and `list packages --json`, with a reusable path for later commands.
> 
> Before writing JSON, the CLI calls the team **CUI PDF cover** API. Outcomes: **no marking** (unchanged filename), **unclassified** (`Unclassified - …`), or **classified** (`CUI - ….zip` containing the JSON plus `CUI_Cover_Sheet.pdf`). If marking cannot be resolved, the command **fails** and nothing is written. **Console-only** listings skip the CUI probe.
> 
> New pieces: `CuiApi` / `CuiFileService`, `HttpClient.getStatusAndData` for status-aware GETs, and `BaseManager.findAll` awaiting async `onFindAll` handlers. Test mocks default the cover endpoint to 204 so existing tests stay unmarked unless they opt in.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac4b2551c96329616611556cd81f133d95b98f7d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->