### PR TITLE
SP-1173: decide CUI marking from the cover response status

### DIFF
--- a/docs/cui-marking.md
+++ b/docs/cui-marking.md
@@ -11,20 +11,19 @@ Example: `list packages --json` would otherwise write `packages.json`.
 | Cover response | Meaning | Outcome |
 |---|---|---|
 | **403** | Feature flag disabled | `packages.json` |
-| **204** | Unclassified | `Unclassified - packages.json` |
 | **200** | Classified | `CUI - packages.zip` containing `packages.json` and `CUI_Cover_Sheet.pdf` |
-| Any other response | Fail closed | Nothing written; the command errors |
+| Any other response, including **204** | Fail closed | Nothing written; the command errors |
 
-The status code alone decides the outcome. Any failure of the cover call, including an unexpected status or a **200** without a usable cover page, aborts the command and leaves no output behind.
+The status code alone decides the outcome. Marked content is always classified: there is no unclassified artifact. Any other answer, whether a **204**, an unexpected status, a transport failure, or a **200** without a usable cover page, aborts the command and leaves no output behind.
 
 ## Scope: how the write is triggered
 
-| Trigger | Commands | Example (unclassified) | Example (classified) |
-|---|---|---|---|
-| `--json` listings and reports | `list spaces`, `list packages`, `list assets` / `assignments` / `data-pools`, `config *`, `t2tc package list` / `diff`, `deployment *`, `asset-registry *` | `list packages --json` → `Unclassified - packages.json` | `list packages --json` → `CUI - packages.zip` containing `packages.json` and `CUI_Cover_Sheet.pdf` |
-| `-o, --outputToJsonFile` reports | `analyze` / `import action-flows`, `export data-pool`, `import data-pools`, `t2tc package import` report | `export data-pool -o` → `Unclassified - <report>.json` | `export data-pool -o` → `CUI - <report>.zip` containing the JSON and `CUI_Cover_Sheet.pdf` |
-| Artifact is already an archive | `config package export --zip`, `config branch export --zip`, `t2tc package export`, `export action-flows`, `pull package` | `config package export --zip` → `Unclassified - my-package.zip` | `config package export --zip` → `CUI - my-package.zip` with `CUI_Cover_Sheet.pdf` inside the archive |
-| Single non-archive export | `pull asset` / `skill` / `data-pool` / `view-bookmarks` / `bookmarks`, `export bookmarks` | `pull asset` → `Unclassified - asset_<key>.yml` | `pull asset` → `CUI - asset_<key>.zip` containing the YAML and `CUI_Cover_Sheet.pdf` |
-| Output is a directory | `config package export`, `config branch export`, `t2tc package export --unzip` | `config package export` → `Unclassified - my-package/` | `config package export` → `CUI - my-package/` with `CUI_Cover_Sheet.pdf` inside |
-| `--gitBranch` variants | `config package export`, `config branch export`, `t2tc package export` | Out of scope | Out of scope |
-| No output flag | Console-only listings, profile / git-profile / log files | Out of scope | Out of scope |
+| Trigger | Commands | Example when classified |
+|---|---|---|
+| `--json` listings and reports | `list spaces`, `list packages`, `list assets` / `assignments` / `data-pools`, `config *`, `t2tc package list` / `diff`, `deployment *`, `asset-registry *` | `list packages --json` → `CUI - packages.zip` containing `packages.json` and `CUI_Cover_Sheet.pdf` |
+| `-o, --outputToJsonFile` reports | `analyze` / `import action-flows`, `export data-pool`, `import data-pools`, `t2tc package import` report | `export data-pool -o` → `CUI - <report>.zip` containing the JSON and `CUI_Cover_Sheet.pdf` |
+| Artifact is already an archive | `config package export --zip`, `config branch export --zip`, `t2tc package export`, `export action-flows`, `pull package` | `config package export --zip` → `CUI - my-package.zip` with `CUI_Cover_Sheet.pdf` inside the archive |
+| Single non-archive export | `pull asset` / `skill` / `data-pool` / `view-bookmarks` / `bookmarks`, `export bookmarks` | `pull asset` → `CUI - asset_<key>.zip` containing the YAML and `CUI_Cover_Sheet.pdf` |
+| Output is a directory | `config package export`, `config branch export`, `t2tc package export --unzip` | `config package export` → `CUI - my-package/` with `CUI_Cover_Sheet.pdf` inside |
+| `--gitBranch` variants | `config package export`, `config branch export`, `t2tc package export` | Out of scope |
+| No output flag | Console-only listings, profile / git-profile / log files | Out of scope |

--- a/docs/cui-marking.md
+++ b/docs/cui-marking.md
@@ -11,12 +11,11 @@ Example: `list packages --json` would otherwise write `packages.json`.
 | Cover response | Meaning | Outcome |
 |---|---|---|
 | **403** | Feature flag disabled | `packages.json` |
-| **204** | Team has CUI disabled | `packages.json` |
-| **200**, no categories | Marking applies, unclassified | `Unclassified - packages.json` |
-| **200**, with categories | Marking applies, classified | `CUI - packages.zip` containing `packages.json` and `CUI_Cover_Sheet.pdf` |
-| Unexpected response | Fail closed | Nothing written; the command errors |
+| **204** | Unclassified | `Unclassified - packages.json` |
+| **200** | Classified | `CUI - packages.zip` containing `packages.json` and `CUI_Cover_Sheet.pdf` |
+| Any other response | Fail closed | Nothing written; the command errors |
 
-**403** and **204** both leave the artifact unmarked. They are not the same as **200 with no categories**, which still renames it to `Unclassified - …`.
+The status code alone decides the outcome. Any failure of the cover call, including an unexpected status or a **200** without a usable cover page, aborts the command and leaves no output behind.
 
 ## Scope: how the write is triggered
 

--- a/src/core/utils/cui-api.ts
+++ b/src/core/utils/cui-api.ts
@@ -8,20 +8,17 @@ export interface CuiPdfCoverResponse {
 
 export enum CuiMarking {
     DISABLED = "DISABLED",
-    UNCLASSIFIED = "UNCLASSIFIED",
     CLASSIFIED = "CLASSIFIED",
 }
 
 export type CuiMarkingDecision =
     | { marking: CuiMarking.DISABLED }
-    | { marking: CuiMarking.UNCLASSIFIED }
     | { marking: CuiMarking.CLASSIFIED; cover: CuiPdfCoverResponse };
 
 export class CuiApi {
     private static readonly CUI_PDF_COVER_SHEET_URL = "/api/team/cui-settings/cui-pdf-cover";
 
     private static readonly STATUS_OK = 200;
-    private static readonly STATUS_NO_CONTENT = 204;
     private static readonly STATUS_FORBIDDEN = 403;
 
     private readonly httpClient: () => HttpClient;
@@ -36,11 +33,6 @@ export class CuiApi {
         if (status === CuiApi.STATUS_FORBIDDEN) {
             logger.debug("CUI marking does not apply, the feature flag is disabled");
             return { marking: CuiMarking.DISABLED };
-        }
-
-        if (status === CuiApi.STATUS_NO_CONTENT) {
-            logger.debug("CUI marking applies, the content is unclassified");
-            return { marking: CuiMarking.UNCLASSIFIED };
         }
 
         if (status === CuiApi.STATUS_OK && data) {

--- a/src/core/utils/cui-api.ts
+++ b/src/core/utils/cui-api.ts
@@ -3,9 +3,19 @@ import { FatalError, logger } from "./logger";
 import { Context } from "../command/cli-context";
 
 export interface CuiPdfCoverResponse {
-    resolvedCuiMarking?: { categories?: unknown[] };
     coverPage?: { pdfContent: string; encoding: string };
 }
+
+export enum CuiMarking {
+    DISABLED = "DISABLED",
+    UNCLASSIFIED = "UNCLASSIFIED",
+    CLASSIFIED = "CLASSIFIED",
+}
+
+export type CuiMarkingDecision =
+    | { marking: CuiMarking.DISABLED }
+    | { marking: CuiMarking.UNCLASSIFIED }
+    | { marking: CuiMarking.CLASSIFIED; cover: CuiPdfCoverResponse };
 
 export class CuiApi {
     private static readonly CUI_PDF_COVER_SHEET_URL = "/api/team/cui-settings/cui-pdf-cover";
@@ -20,21 +30,21 @@ export class CuiApi {
         this.httpClient = () => context.httpClient;
     }
 
-    public async getCuiPdfCover(): Promise<CuiPdfCoverResponse | null> {
+    public async getCuiMarking(): Promise<CuiMarkingDecision> {
         const { status, data } = await this.httpClient().getStatusAndData(CuiApi.CUI_PDF_COVER_SHEET_URL);
 
         if (status === CuiApi.STATUS_FORBIDDEN) {
             logger.debug("CUI marking does not apply, the feature flag is disabled");
-            return null;
+            return { marking: CuiMarking.DISABLED };
         }
 
         if (status === CuiApi.STATUS_NO_CONTENT) {
-            logger.debug("CUI marking does not apply, the team has CUI disabled");
-            return null;
+            logger.debug("CUI marking applies, the content is unclassified");
+            return { marking: CuiMarking.UNCLASSIFIED };
         }
 
         if (status === CuiApi.STATUS_OK && data) {
-            return data as CuiPdfCoverResponse;
+            return { marking: CuiMarking.CLASSIFIED, cover: data as CuiPdfCoverResponse };
         }
 
         throw new FatalError("Problem fetching cui pdf cover");

--- a/src/core/utils/cui-file-service.ts
+++ b/src/core/utils/cui-file-service.ts
@@ -9,7 +9,6 @@ import { FatalError } from "./logger";
 export class CuiFileService {
     public static readonly COVER_SHEET_FILE_NAME = "CUI_Cover_Sheet.pdf";
     public static readonly CLASSIFIED_PREFIX = "CUI - ";
-    public static readonly UNCLASSIFIED_PREFIX = "Unclassified - ";
 
     private static readonly BASE64_ENCODING = "base64";
 
@@ -65,13 +64,6 @@ export class CuiFileService {
         if (decision.marking === CuiMarking.DISABLED) {
             write(filename);
             return filename;
-        }
-
-        if (decision.marking === CuiMarking.UNCLASSIFIED) {
-            const unclassifiedName = this.prefixFileName(filename, CuiFileService.UNCLASSIFIED_PREFIX);
-            write(unclassifiedName);
-
-            return unclassifiedName;
         }
 
         return onClassified(decision.cover);

--- a/src/core/utils/cui-file-service.ts
+++ b/src/core/utils/cui-file-service.ts
@@ -1,7 +1,7 @@
 import * as path from "node:path";
 import AdmZip = require("adm-zip");
 import { Context } from "../command/cli-context";
-import { CuiApi, CuiPdfCoverResponse } from "./cui-api";
+import { CuiApi, CuiMarking, CuiPdfCoverResponse } from "./cui-api";
 import { fileService } from "./file-service";
 import { FileConstants } from "./file.constants";
 import { FatalError } from "./logger";
@@ -60,21 +60,21 @@ export class CuiFileService {
         filename: string,
         onClassified: (cover: CuiPdfCoverResponse) => string
     ): Promise<string> {
-        const cover = await this.cuiApi.getCuiPdfCover();
+        const decision = await this.cuiApi.getCuiMarking();
 
-        if (!cover) {
+        if (decision.marking === CuiMarking.DISABLED) {
             write(filename);
             return filename;
         }
 
-        if (!this.isClassified(cover)) {
+        if (decision.marking === CuiMarking.UNCLASSIFIED) {
             const unclassifiedName = this.prefixFileName(filename, CuiFileService.UNCLASSIFIED_PREFIX);
             write(unclassifiedName);
 
             return unclassifiedName;
         }
 
-        return onClassified(cover);
+        return onClassified(decision.cover);
     }
 
     private writeClassifiedArchive(filename: string, data: string, cover: CuiPdfCoverResponse): string {
@@ -111,10 +111,6 @@ export class CuiFileService {
         }
 
         return Buffer.from(coverPage.pdfContent, CuiFileService.BASE64_ENCODING);
-    }
-
-    private isClassified(cover: CuiPdfCoverResponse): boolean {
-        return (cover.resolvedCuiMarking?.categories?.length ?? 0) > 0;
     }
 
     private buildClassifiedArchiveName(filename: string): string {

--- a/tests/commands/cui-marking-directory-exports.spec.ts
+++ b/tests/commands/cui-marking-directory-exports.spec.ts
@@ -46,17 +46,6 @@ function exists(...segments: string[]): boolean {
     return existsSync(resolve(process.cwd(), ...segments));
 }
 
-function markAsUnclassified(): void {
-    mockAxiosGetWithStatus(COVER_URL, 204, "");
-}
-
-function unclassifiedDirectory(prefix: string, expectedName: string): string {
-    const directoryName = loggedDirectoryName(prefix);
-    expect(directoryName).toEqual(`${CuiFileService.UNCLASSIFIED_PREFIX}${expectedName}`);
-
-    return directoryName;
-}
-
 function buildPackageZip(packageKey: string): Buffer {
     const zip = new AdmZip();
     zip.addFile("package.json", Buffer.from(JSON.stringify({ key: packageKey, name: "My Package" })));
@@ -91,19 +80,6 @@ describe("CUI marking of directory exports", () => {
         const directoryName = markedDirectory(EXPORT_MESSAGE, packageKey);
         expect(exists(directoryName, "package.json")).toBe(true);
         expect(exists(directoryName, "nodes", "node-1.json")).toBe(true);
-        expect(exists(packageKey)).toBe(false);
-    });
-
-    it("Should only prefix the directory when the content is unclassified", async () => {
-        markAsUnclassified();
-        const packageKey = "pkg-unclassified";
-        mockAxiosGet(`https://myTeam.celonis.cloud/pacman/api/core/staging/packages/${packageKey}/export-file`, buildPackageZip(packageKey));
-
-        await new SinglePackageExportService(testContext).exportPackage(packageKey, false, null);
-
-        const directoryName = unclassifiedDirectory(EXPORT_MESSAGE, packageKey);
-        expect(exists(directoryName, "nodes", "node-1.json")).toBe(true);
-        expect(exists(directoryName, CuiFileService.COVER_SHEET_FILE_NAME)).toBe(false);
         expect(exists(packageKey)).toBe(false);
     });
 

--- a/tests/commands/cui-marking-directory-exports.spec.ts
+++ b/tests/commands/cui-marking-directory-exports.spec.ts
@@ -46,6 +46,17 @@ function exists(...segments: string[]): boolean {
     return existsSync(resolve(process.cwd(), ...segments));
 }
 
+function markAsUnclassified(): void {
+    mockAxiosGetWithStatus(COVER_URL, 204, "");
+}
+
+function unclassifiedDirectory(prefix: string, expectedName: string): string {
+    const directoryName = loggedDirectoryName(prefix);
+    expect(directoryName).toEqual(`${CuiFileService.UNCLASSIFIED_PREFIX}${expectedName}`);
+
+    return directoryName;
+}
+
 function buildPackageZip(packageKey: string): Buffer {
     const zip = new AdmZip();
     zip.addFile("package.json", Buffer.from(JSON.stringify({ key: packageKey, name: "My Package" })));
@@ -80,6 +91,19 @@ describe("CUI marking of directory exports", () => {
         const directoryName = markedDirectory(EXPORT_MESSAGE, packageKey);
         expect(exists(directoryName, "package.json")).toBe(true);
         expect(exists(directoryName, "nodes", "node-1.json")).toBe(true);
+        expect(exists(packageKey)).toBe(false);
+    });
+
+    it("Should only prefix the directory when the content is unclassified", async () => {
+        markAsUnclassified();
+        const packageKey = "pkg-unclassified";
+        mockAxiosGet(`https://myTeam.celonis.cloud/pacman/api/core/staging/packages/${packageKey}/export-file`, buildPackageZip(packageKey));
+
+        await new SinglePackageExportService(testContext).exportPackage(packageKey, false, null);
+
+        const directoryName = unclassifiedDirectory(EXPORT_MESSAGE, packageKey);
+        expect(exists(directoryName, "nodes", "node-1.json")).toBe(true);
+        expect(exists(directoryName, CuiFileService.COVER_SHEET_FILE_NAME)).toBe(false);
         expect(exists(packageKey)).toBe(false);
     });
 

--- a/tests/commands/cui-marking-directory-exports.spec.ts
+++ b/tests/commands/cui-marking-directory-exports.spec.ts
@@ -23,7 +23,6 @@ const BRANCH = "feature-a";
 
 function markAsClassified(): void {
     mockAxiosGetWithStatus(COVER_URL, 200, {
-        resolvedCuiMarking: { categories: [{ code: "PRVCY", name: "Privacy" }] },
         coverPage: { pdfContent: PDF_BYTES.toString("base64"), encoding: "base64" },
     });
 }

--- a/tests/commands/cui-marking-json-commands.spec.ts
+++ b/tests/commands/cui-marking-json-commands.spec.ts
@@ -1,11 +1,12 @@
 import { resolve } from "node:path";
 import { readFileSync } from "node:fs";
 import AdmZip = require("adm-zip");
-import { mockAxiosGet, mockAxiosGetWithStatus, mockAxiosPost } from "../utls/http-requests-mock";
+import { mockAxiosGet, mockAxiosGetError, mockAxiosGetWithStatus, mockAxiosPost } from "../utls/http-requests-mock";
 import { testContext } from "../utls/test-context";
 import { loggingTestTransport } from "../jest.setup";
 import { FileService } from "../../src/core/utils/file-service";
 import { CuiFileService } from "../../src/core/utils/cui-file-service";
+import { FatalError } from "../../src/core/utils/logger";
 import { ConfigUtils } from "../utls/config-utils";
 import { zipToTempFolder } from "../utls/fs-utils";
 import { DeploymentService } from "../../src/commands/deployment/deployment.service";
@@ -48,6 +49,18 @@ function markedPayload(prefix?: string): any {
     return payloadFromArchive(loggedFileName(prefix));
 }
 
+function markAsUnclassified(): void {
+    mockAxiosGetWithStatus(COVER_URL, 204, "");
+}
+
+function unclassifiedPayload(prefix?: string): any {
+    const filename = loggedFileName(prefix);
+    expect(filename.startsWith(CuiFileService.UNCLASSIFIED_PREFIX)).toBe(true);
+    expect(filename.endsWith(".json")).toBe(true);
+
+    return JSON.parse(readFileSync(resolve(process.cwd(), filename), "utf-8"));
+}
+
 describe("CUI marking of --json commands", () => {
 
     beforeEach(() => {
@@ -61,6 +74,24 @@ describe("CUI marking of --json commands", () => {
         await new DeploymentService(testContext).getTargets(true, "app-package", "package-key");
 
         expect(markedPayload()).toEqual(targets);
+    });
+
+    it("Should only prefix the listing when the content is unclassified", async () => {
+        markAsUnclassified();
+        const targets = [{ id: "target-1", name: "First target" }];
+        mockAxiosGet("https://myTeam.celonis.cloud/pacman/api/deployments/targets?deployableType=app-package&packageKey=package-key", targets);
+
+        await new DeploymentService(testContext).getTargets(true, "app-package", "package-key");
+
+        expect(unclassifiedPayload()).toEqual(targets);
+    });
+
+    it("Should fail the command without writing anything when the cover call fails", async () => {
+        mockAxiosGetError(COVER_URL, 500, { message: "boom" });
+        mockAxiosGet("https://myTeam.celonis.cloud/pacman/api/deployments/targets?deployableType=app-package&packageKey=package-key", []);
+
+        await expect(new DeploymentService(testContext).getTargets(true, "app-package", "package-key")).rejects.toThrow(FatalError);
+        expect(loggingTestTransport.logMessages.some(entry => entry.message.includes(FileService.fileDownloadedMessage))).toBe(false);
     });
 
     it("Should mark configuration node listings", async () => {

--- a/tests/commands/cui-marking-json-commands.spec.ts
+++ b/tests/commands/cui-marking-json-commands.spec.ts
@@ -24,7 +24,6 @@ const PDF_BYTES = Buffer.from("%PDF-1.4 cover sheet");
 
 function markAsClassified(): void {
     mockAxiosGetWithStatus(COVER_URL, 200, {
-        resolvedCuiMarking: { categories: [{ code: "PRVCY", name: "Privacy" }] },
         coverPage: { pdfContent: PDF_BYTES.toString("base64"), encoding: "base64" },
     });
 }

--- a/tests/commands/cui-marking-json-commands.spec.ts
+++ b/tests/commands/cui-marking-json-commands.spec.ts
@@ -49,18 +49,6 @@ function markedPayload(prefix?: string): any {
     return payloadFromArchive(loggedFileName(prefix));
 }
 
-function markAsUnclassified(): void {
-    mockAxiosGetWithStatus(COVER_URL, 204, "");
-}
-
-function unclassifiedPayload(prefix?: string): any {
-    const filename = loggedFileName(prefix);
-    expect(filename.startsWith(CuiFileService.UNCLASSIFIED_PREFIX)).toBe(true);
-    expect(filename.endsWith(".json")).toBe(true);
-
-    return JSON.parse(readFileSync(resolve(process.cwd(), filename), "utf-8"));
-}
-
 describe("CUI marking of --json commands", () => {
 
     beforeEach(() => {
@@ -74,16 +62,6 @@ describe("CUI marking of --json commands", () => {
         await new DeploymentService(testContext).getTargets(true, "app-package", "package-key");
 
         expect(markedPayload()).toEqual(targets);
-    });
-
-    it("Should only prefix the listing when the content is unclassified", async () => {
-        markAsUnclassified();
-        const targets = [{ id: "target-1", name: "First target" }];
-        mockAxiosGet("https://myTeam.celonis.cloud/pacman/api/deployments/targets?deployableType=app-package&packageKey=package-key", targets);
-
-        await new DeploymentService(testContext).getTargets(true, "app-package", "package-key");
-
-        expect(unclassifiedPayload()).toEqual(targets);
     });
 
     it("Should fail the command without writing anything when the cover call fails", async () => {

--- a/tests/commands/cui-marking-output-to-json-file.spec.ts
+++ b/tests/commands/cui-marking-output-to-json-file.spec.ts
@@ -45,18 +45,6 @@ function markedPayload(prefix?: string): any {
     return payloadFromArchive(loggedFileName(prefix));
 }
 
-function markAsUnclassified(): void {
-    mockAxiosGetWithStatus(COVER_URL, 204, "");
-}
-
-function unclassifiedPayload(prefix?: string): any {
-    const filename = loggedFileName(prefix);
-    expect(filename.startsWith(CuiFileService.UNCLASSIFIED_PREFIX)).toBe(true);
-    expect(filename.endsWith(".json")).toBe(true);
-
-    return JSON.parse(readFileSync(resolve(process.cwd(), filename), "utf-8"));
-}
-
 describe("CUI marking of --outputToJsonFile commands", () => {
 
     beforeEach(() => {
@@ -88,16 +76,6 @@ describe("CUI marking of --outputToJsonFile commands", () => {
         await new DataPoolCommandService(testContext).exportDataPool(POOL_ID, true);
 
         expect(markedPayload()).toEqual(dataPool);
-    });
-
-    it("Should only prefix the report when the content is unclassified", async () => {
-        markAsUnclassified();
-        const dataPool = { id: POOL_ID, name: "Pool 1", objects: [] };
-        mockAxiosGet(`https://myTeam.celonis.cloud/integration/api/pools/${POOL_ID}/v2/export`, dataPool);
-
-        await new DataPoolCommandService(testContext).exportDataPool(POOL_ID, true);
-
-        expect(unclassifiedPayload()).toEqual(dataPool);
     });
 
     it("Should mark the data pool batch import report", async () => {

--- a/tests/commands/cui-marking-output-to-json-file.spec.ts
+++ b/tests/commands/cui-marking-output-to-json-file.spec.ts
@@ -21,7 +21,6 @@ const POOL_ID = "pool-1";
 
 function markAsClassified(): void {
     mockAxiosGetWithStatus(COVER_URL, 200, {
-        resolvedCuiMarking: { categories: [{ code: "PRVCY", name: "Privacy" }] },
         coverPage: { pdfContent: PDF_BYTES.toString("base64"), encoding: "base64" },
     });
 }

--- a/tests/commands/cui-marking-output-to-json-file.spec.ts
+++ b/tests/commands/cui-marking-output-to-json-file.spec.ts
@@ -45,6 +45,18 @@ function markedPayload(prefix?: string): any {
     return payloadFromArchive(loggedFileName(prefix));
 }
 
+function markAsUnclassified(): void {
+    mockAxiosGetWithStatus(COVER_URL, 204, "");
+}
+
+function unclassifiedPayload(prefix?: string): any {
+    const filename = loggedFileName(prefix);
+    expect(filename.startsWith(CuiFileService.UNCLASSIFIED_PREFIX)).toBe(true);
+    expect(filename.endsWith(".json")).toBe(true);
+
+    return JSON.parse(readFileSync(resolve(process.cwd(), filename), "utf-8"));
+}
+
 describe("CUI marking of --outputToJsonFile commands", () => {
 
     beforeEach(() => {
@@ -76,6 +88,16 @@ describe("CUI marking of --outputToJsonFile commands", () => {
         await new DataPoolCommandService(testContext).exportDataPool(POOL_ID, true);
 
         expect(markedPayload()).toEqual(dataPool);
+    });
+
+    it("Should only prefix the report when the content is unclassified", async () => {
+        markAsUnclassified();
+        const dataPool = { id: POOL_ID, name: "Pool 1", objects: [] };
+        mockAxiosGet(`https://myTeam.celonis.cloud/integration/api/pools/${POOL_ID}/v2/export`, dataPool);
+
+        await new DataPoolCommandService(testContext).exportDataPool(POOL_ID, true);
+
+        expect(unclassifiedPayload()).toEqual(dataPool);
     });
 
     it("Should mark the data pool batch import report", async () => {

--- a/tests/commands/cui-marking-single-file-exports.spec.ts
+++ b/tests/commands/cui-marking-single-file-exports.spec.ts
@@ -26,7 +26,6 @@ const PACKAGE_KEY = "my-package";
 
 function markAsClassified(): void {
     mockAxiosGetWithStatus(COVER_URL, 200, {
-        resolvedCuiMarking: { categories: [{ code: "PRVCY", name: "Privacy" }] },
         coverPage: { pdfContent: PDF_BYTES.toString("base64"), encoding: "base64" },
     });
 }

--- a/tests/commands/cui-marking-single-file-exports.spec.ts
+++ b/tests/commands/cui-marking-single-file-exports.spec.ts
@@ -53,6 +53,17 @@ function markedJson(expectedName: string, entryName: string): any {
     return JSON.parse(markedEntry(expectedName, entryName));
 }
 
+function markAsUnclassified(): void {
+    mockAxiosGetWithStatus(COVER_URL, 204, "");
+}
+
+function unclassifiedFile(expectedName: string): string {
+    const filename = loggedFileName();
+    expect(filename).toEqual(`${CuiFileService.UNCLASSIFIED_PREFIX}${expectedName}`);
+
+    return readFileSync(resolve(process.cwd(), filename), "utf-8");
+}
+
 describe("CUI marking of single-file exports", () => {
 
     beforeEach(() => {
@@ -66,6 +77,16 @@ describe("CUI marking of single-file exports", () => {
         await new AssetCommandService(testContext).pullAsset(`${PACKAGE_KEY}.asset-1`);
 
         expect(parse(markedEntry("asset_asset-1", "asset_asset-1.yml"))).toEqual(asset);
+    });
+
+    it("Should only prefix the export when the content is unclassified", async () => {
+        markAsUnclassified();
+        const asset = { key: "asset-1", name: "My Asset", rootNodeKey: PACKAGE_KEY };
+        mockAxiosGet(`https://myTeam.celonis.cloud/package-manager/api/nodes/asset/export/${PACKAGE_KEY}.asset-1`, asset);
+
+        await new AssetCommandService(testContext).pullAsset(`${PACKAGE_KEY}.asset-1`);
+
+        expect(parse(unclassifiedFile("asset_asset-1.yml"))).toEqual(asset);
     });
 
     it("Should mark the exported skill", async () => {

--- a/tests/commands/cui-marking-single-file-exports.spec.ts
+++ b/tests/commands/cui-marking-single-file-exports.spec.ts
@@ -53,17 +53,6 @@ function markedJson(expectedName: string, entryName: string): any {
     return JSON.parse(markedEntry(expectedName, entryName));
 }
 
-function markAsUnclassified(): void {
-    mockAxiosGetWithStatus(COVER_URL, 204, "");
-}
-
-function unclassifiedFile(expectedName: string): string {
-    const filename = loggedFileName();
-    expect(filename).toEqual(`${CuiFileService.UNCLASSIFIED_PREFIX}${expectedName}`);
-
-    return readFileSync(resolve(process.cwd(), filename), "utf-8");
-}
-
 describe("CUI marking of single-file exports", () => {
 
     beforeEach(() => {
@@ -77,16 +66,6 @@ describe("CUI marking of single-file exports", () => {
         await new AssetCommandService(testContext).pullAsset(`${PACKAGE_KEY}.asset-1`);
 
         expect(parse(markedEntry("asset_asset-1", "asset_asset-1.yml"))).toEqual(asset);
-    });
-
-    it("Should only prefix the export when the content is unclassified", async () => {
-        markAsUnclassified();
-        const asset = { key: "asset-1", name: "My Asset", rootNodeKey: PACKAGE_KEY };
-        mockAxiosGet(`https://myTeam.celonis.cloud/package-manager/api/nodes/asset/export/${PACKAGE_KEY}.asset-1`, asset);
-
-        await new AssetCommandService(testContext).pullAsset(`${PACKAGE_KEY}.asset-1`);
-
-        expect(parse(unclassifiedFile("asset_asset-1.yml"))).toEqual(asset);
     });
 
     it("Should mark the exported skill", async () => {

--- a/tests/commands/cui-marking-zip-commands.spec.ts
+++ b/tests/commands/cui-marking-zip-commands.spec.ts
@@ -51,17 +51,6 @@ function entryNames(archive: AdmZip): string[] {
     return archive.getEntries().map(entry => entry.entryName).sort();
 }
 
-function markAsUnclassified(): void {
-    mockAxiosGetWithStatus(COVER_URL, 204, "");
-}
-
-function unclassifiedArchive(expectedName: string): AdmZip {
-    const filename = loggedFileName();
-    expect(filename).toEqual(`${CuiFileService.UNCLASSIFIED_PREFIX}${expectedName}`);
-
-    return new AdmZip(readFileSync(resolve(process.cwd(), filename)));
-}
-
 function buildPackageZip(): Buffer {
     const zip = new AdmZip();
     zip.addFile("package.json", Buffer.from(JSON.stringify({ key: PACKAGE_KEY, name: "My Package" })));
@@ -98,15 +87,6 @@ describe("CUI marking of archive exports", () => {
             "nodes/node-1.json",
             "package.json",
         ]);
-    });
-
-    it("Should only prefix the archive when the content is unclassified", async () => {
-        markAsUnclassified();
-        mockAxiosGet(`https://myTeam.celonis.cloud/pacman/api/core/staging/packages/${PACKAGE_KEY}/export-file`, buildPackageZip());
-
-        await new SinglePackageExportService(testContext).exportPackage(PACKAGE_KEY, true, null);
-
-        expect(entryNames(unclassifiedArchive(`${PACKAGE_KEY}.zip`))).toEqual(["nodes/node-1.json", "package.json"]);
     });
 
     it("Should mark the archive of config branch export --zip", async () => {

--- a/tests/commands/cui-marking-zip-commands.spec.ts
+++ b/tests/commands/cui-marking-zip-commands.spec.ts
@@ -27,7 +27,6 @@ const T2TC_DOWNLOAD_MESSAGE = "File downloaded successfully. New filename: ";
 
 function markAsClassified(): void {
     mockAxiosGetWithStatus(COVER_URL, 200, {
-        resolvedCuiMarking: { categories: [{ code: "PRVCY", name: "Privacy" }] },
         coverPage: { pdfContent: PDF_BYTES.toString("base64"), encoding: "base64" },
     });
 }

--- a/tests/commands/cui-marking-zip-commands.spec.ts
+++ b/tests/commands/cui-marking-zip-commands.spec.ts
@@ -51,6 +51,17 @@ function entryNames(archive: AdmZip): string[] {
     return archive.getEntries().map(entry => entry.entryName).sort();
 }
 
+function markAsUnclassified(): void {
+    mockAxiosGetWithStatus(COVER_URL, 204, "");
+}
+
+function unclassifiedArchive(expectedName: string): AdmZip {
+    const filename = loggedFileName();
+    expect(filename).toEqual(`${CuiFileService.UNCLASSIFIED_PREFIX}${expectedName}`);
+
+    return new AdmZip(readFileSync(resolve(process.cwd(), filename)));
+}
+
 function buildPackageZip(): Buffer {
     const zip = new AdmZip();
     zip.addFile("package.json", Buffer.from(JSON.stringify({ key: PACKAGE_KEY, name: "My Package" })));
@@ -87,6 +98,15 @@ describe("CUI marking of archive exports", () => {
             "nodes/node-1.json",
             "package.json",
         ]);
+    });
+
+    it("Should only prefix the archive when the content is unclassified", async () => {
+        markAsUnclassified();
+        mockAxiosGet(`https://myTeam.celonis.cloud/pacman/api/core/staging/packages/${PACKAGE_KEY}/export-file`, buildPackageZip());
+
+        await new SinglePackageExportService(testContext).exportPackage(PACKAGE_KEY, true, null);
+
+        expect(entryNames(unclassifiedArchive(`${PACKAGE_KEY}.zip`))).toEqual(["nodes/node-1.json", "package.json"]);
     });
 
     it("Should mark the archive of config branch export --zip", async () => {

--- a/tests/commands/studio/list-cui-marking.spec.ts
+++ b/tests/commands/studio/list-cui-marking.spec.ts
@@ -1,7 +1,7 @@
 import { resolve } from "node:path";
 import { readFileSync } from "node:fs";
 import AdmZip = require("adm-zip");
-import { mockAxiosGet, mockAxiosGetWithStatus, mockedAxiosInstance } from "../../utls/http-requests-mock";
+import { mockAxiosGet, mockAxiosGetError, mockAxiosGetWithStatus, mockedAxiosInstance } from "../../utls/http-requests-mock";
 import { SpaceCommandService } from "../../../src/commands/studio/command-service/space-command.service";
 import { PackageCommandService } from "../../../src/commands/studio/command-service/package-command.service";
 import { testContext } from "../../utls/test-context";
@@ -20,7 +20,6 @@ const PDF_BYTES = Buffer.from("%PDF-1.4 cover sheet");
 
 function classifiedCover(): object {
     return {
-        resolvedCuiMarking: { categories: [{ code: "PRVCY", name: "Privacy" }] },
         coverPage: { pdfContent: PDF_BYTES.toString("base64"), encoding: "base64" },
     };
 }
@@ -68,14 +67,24 @@ describe("CUI marking of Studio listings", () => {
             expect(payloadFromArchive(filename)).toEqual(SPACES);
         });
 
-        it("Should keep the original filename when no marking applies", async () => {
-            mockAxiosGetWithStatus(COVER_URL, 204, "");
+        it("Should keep the original filename when the feature flag is disabled", async () => {
+            mockAxiosGetError(COVER_URL, 403, { errorCode: "feature-disabled" });
 
             await listSpaces();
 
             const filename = loggedFileName();
             expect(filename.startsWith(CuiFileService.UNCLASSIFIED_PREFIX)).toBe(false);
             expect(filename.startsWith(CuiFileService.CLASSIFIED_PREFIX)).toBe(false);
+            expect(readWrittenJson(filename)).toEqual(SPACES);
+        });
+
+        it("Should only prefix the listing when the content is unclassified", async () => {
+            mockAxiosGetWithStatus(COVER_URL, 204, "");
+
+            await listSpaces();
+
+            const filename = loggedFileName();
+            expect(filename.startsWith(CuiFileService.UNCLASSIFIED_PREFIX)).toBe(true);
             expect(readWrittenJson(filename)).toEqual(SPACES);
         });
 
@@ -105,14 +114,24 @@ describe("CUI marking of Studio listings", () => {
             expect(payloadFromArchive(filename)).toEqual(LISTED_PACKAGES);
         });
 
-        it("Should keep the original filename when no marking applies", async () => {
-            mockAxiosGetWithStatus(COVER_URL, 204, "");
+        it("Should keep the original filename when the feature flag is disabled", async () => {
+            mockAxiosGetError(COVER_URL, 403, { errorCode: "feature-disabled" });
 
             await listPackages();
 
             const filename = loggedFileName();
             expect(filename.startsWith(CuiFileService.UNCLASSIFIED_PREFIX)).toBe(false);
             expect(filename.startsWith(CuiFileService.CLASSIFIED_PREFIX)).toBe(false);
+            expect(readWrittenJson(filename)).toEqual(LISTED_PACKAGES);
+        });
+
+        it("Should only prefix the listing when the content is unclassified", async () => {
+            mockAxiosGetWithStatus(COVER_URL, 204, "");
+
+            await listPackages();
+
+            const filename = loggedFileName();
+            expect(filename.startsWith(CuiFileService.UNCLASSIFIED_PREFIX)).toBe(true);
             expect(readWrittenJson(filename)).toEqual(LISTED_PACKAGES);
         });
 

--- a/tests/commands/studio/list-cui-marking.spec.ts
+++ b/tests/commands/studio/list-cui-marking.spec.ts
@@ -73,18 +73,7 @@ describe("CUI marking of Studio listings", () => {
             await listSpaces();
 
             const filename = loggedFileName();
-            expect(filename.startsWith(CuiFileService.UNCLASSIFIED_PREFIX)).toBe(false);
             expect(filename.startsWith(CuiFileService.CLASSIFIED_PREFIX)).toBe(false);
-            expect(readWrittenJson(filename)).toEqual(SPACES);
-        });
-
-        it("Should only prefix the listing when the content is unclassified", async () => {
-            mockAxiosGetWithStatus(COVER_URL, 204, "");
-
-            await listSpaces();
-
-            const filename = loggedFileName();
-            expect(filename.startsWith(CuiFileService.UNCLASSIFIED_PREFIX)).toBe(true);
             expect(readWrittenJson(filename)).toEqual(SPACES);
         });
 
@@ -120,18 +109,7 @@ describe("CUI marking of Studio listings", () => {
             await listPackages();
 
             const filename = loggedFileName();
-            expect(filename.startsWith(CuiFileService.UNCLASSIFIED_PREFIX)).toBe(false);
             expect(filename.startsWith(CuiFileService.CLASSIFIED_PREFIX)).toBe(false);
-            expect(readWrittenJson(filename)).toEqual(LISTED_PACKAGES);
-        });
-
-        it("Should only prefix the listing when the content is unclassified", async () => {
-            mockAxiosGetWithStatus(COVER_URL, 204, "");
-
-            await listPackages();
-
-            const filename = loggedFileName();
-            expect(filename.startsWith(CuiFileService.UNCLASSIFIED_PREFIX)).toBe(true);
             expect(readWrittenJson(filename)).toEqual(LISTED_PACKAGES);
         });
 

--- a/tests/core/utils/cui-file-service.spec.ts
+++ b/tests/core/utils/cui-file-service.spec.ts
@@ -13,8 +13,7 @@ describe("CuiFileService", () => {
 
     let cuiFileService: CuiFileService;
 
-    const coverResponse = (categories: Array<{ code: string; name: string }>) => ({
-        resolvedCuiMarking: { categories },
+    const coverResponse = () => ({
         coverPage: {
             pdfContent: PDF_BYTES.toString("base64"),
             encoding: "base64",
@@ -37,15 +36,6 @@ describe("CuiFileService", () => {
             expect(readFile("report.json").toString()).toEqual(PAYLOAD);
         });
 
-        it("Should keep the original filename when the team has CUI disabled", async () => {
-            mockAxiosGetWithStatus(COVER_URL, 204, "");
-
-            const filename = await cuiFileService.writeToFileWithGivenName(PAYLOAD, "no-marking.json");
-
-            expect(filename).toEqual("no-marking.json");
-            expect(readFile("no-marking.json").toString()).toEqual(PAYLOAD);
-        });
-
         it("Should fail on an unexpected backend error", async () => {
             mockAxiosGetError(COVER_URL, 500, { message: "boom" });
 
@@ -63,7 +53,7 @@ describe("CuiFileService", () => {
 
     describe("when the content is unclassified", () => {
         it("Should only prefix the filename and write no cover sheet", async () => {
-            mockAxiosGetWithStatus(COVER_URL, 200, coverResponse([]));
+            mockAxiosGetWithStatus(COVER_URL, 204, "");
 
             const filename = await cuiFileService.writeToFileWithGivenName(PAYLOAD, "packages.json");
 
@@ -75,7 +65,7 @@ describe("CuiFileService", () => {
 
     describe("when the content is classified", () => {
         it("Should wrap the payload and the decoded cover sheet into a CUI archive", async () => {
-            mockAxiosGetWithStatus(COVER_URL, 200, coverResponse([{ code: "PRVCY", name: "Privacy" }]));
+            mockAxiosGetWithStatus(COVER_URL, 200, coverResponse());
 
             const filename = await cuiFileService.writeToFileWithGivenName(PAYLOAD, "packages.json");
 
@@ -89,7 +79,7 @@ describe("CuiFileService", () => {
         });
 
         it("Should fail when the cover page uses an unsupported encoding", async () => {
-            const response = coverResponse([{ code: "PRVCY", name: "Privacy" }]);
+            const response = coverResponse();
             response.coverPage.encoding = "hex";
             mockAxiosGetWithStatus(COVER_URL, 200, response);
 
@@ -98,9 +88,7 @@ describe("CuiFileService", () => {
         });
 
         it("Should fail when the marking applies but no cover page was returned", async () => {
-            mockAxiosGetWithStatus(COVER_URL, 200, {
-                resolvedCuiMarking: { categories: [{ code: "PRVCY", name: "Privacy" }] },
-            });
+            mockAxiosGetWithStatus(COVER_URL, 200, { teamId: "team-1" });
 
             await expect(cuiFileService.writeToFileWithGivenName(PAYLOAD, "packages.json"))
                 .rejects.toThrow("CUI marking applies but the response contained no cover page.");
@@ -119,7 +107,7 @@ describe("CuiFileService", () => {
             new AdmZip(readFile(filename)).getEntries().map(entry => entry.entryName).sort();
 
         it("Should keep the archive untouched when no marking applies", async () => {
-            mockAxiosGetWithStatus(COVER_URL, 204, "");
+            mockAxiosGetError(COVER_URL, 403, { errorCode: "feature-disabled" });
             const exportZip = buildExportZip();
 
             const filename = await cuiFileService.writeZipToFileWithGivenName(exportZip, "export.zip");
@@ -129,7 +117,7 @@ describe("CuiFileService", () => {
         });
 
         it("Should only prefix the archive when the content is unclassified", async () => {
-            mockAxiosGetWithStatus(COVER_URL, 200, coverResponse([]));
+            mockAxiosGetWithStatus(COVER_URL, 204, "");
             const exportZip = buildExportZip();
 
             const filename = await cuiFileService.writeZipToFileWithGivenName(exportZip, "export.zip");
@@ -139,7 +127,7 @@ describe("CuiFileService", () => {
         });
 
         it("Should add the cover sheet into the given archive instead of nesting it", async () => {
-            mockAxiosGetWithStatus(COVER_URL, 200, coverResponse([{ code: "PRVCY", name: "Privacy" }]));
+            mockAxiosGetWithStatus(COVER_URL, 200, coverResponse());
 
             const filename = await cuiFileService.writeZipToFileWithGivenName(buildExportZip(), "export.zip");
 
@@ -156,9 +144,7 @@ describe("CuiFileService", () => {
         });
 
         it("Should fail when the marking applies but no cover page was returned", async () => {
-            mockAxiosGetWithStatus(COVER_URL, 200, {
-                resolvedCuiMarking: { categories: [{ code: "PRVCY", name: "Privacy" }] },
-            });
+            mockAxiosGetWithStatus(COVER_URL, 200, { teamId: "team-1" });
 
             await expect(cuiFileService.writeZipToFileWithGivenName(buildExportZip(), "export.zip"))
                 .rejects.toThrow("CUI marking applies but the response contained no cover page.");
@@ -175,7 +161,7 @@ describe("CuiFileService", () => {
         const exists = (...segments: string[]): boolean => existsSync(resolve(process.cwd(), ...segments));
 
         it("Should keep the original directory name when no marking applies", async () => {
-            mockAxiosGetWithStatus(COVER_URL, 204, "");
+            mockAxiosGetError(COVER_URL, 403, { errorCode: "feature-disabled" });
 
             const directoryName = await cuiFileService.writeDirectoryWithGivenName(writeTree, "unmarked-export");
 
@@ -185,7 +171,7 @@ describe("CuiFileService", () => {
         });
 
         it("Should only prefix the directory when the content is unclassified", async () => {
-            mockAxiosGetWithStatus(COVER_URL, 200, coverResponse([]));
+            mockAxiosGetWithStatus(COVER_URL, 204, "");
 
             const directoryName = await cuiFileService.writeDirectoryWithGivenName(writeTree, "plain-export");
 
@@ -196,7 +182,7 @@ describe("CuiFileService", () => {
         });
 
         it("Should prefix the directory and write the cover sheet into it", async () => {
-            mockAxiosGetWithStatus(COVER_URL, 200, coverResponse([{ code: "PRVCY", name: "Privacy" }]));
+            mockAxiosGetWithStatus(COVER_URL, 200, coverResponse());
 
             const directoryName = await cuiFileService.writeDirectoryWithGivenName(writeTree, "classified-export");
 
@@ -209,9 +195,7 @@ describe("CuiFileService", () => {
         });
 
         it("Should fail without writing anything when no cover page was returned", async () => {
-            mockAxiosGetWithStatus(COVER_URL, 200, {
-                resolvedCuiMarking: { categories: [{ code: "PRVCY", name: "Privacy" }] },
-            });
+            mockAxiosGetWithStatus(COVER_URL, 200, { teamId: "team-1" });
 
             await expect(cuiFileService.writeDirectoryWithGivenName(writeTree, "broken-export"))
                 .rejects.toThrow("CUI marking applies but the response contained no cover page.");

--- a/tests/core/utils/cui-file-service.spec.ts
+++ b/tests/core/utils/cui-file-service.spec.ts
@@ -35,7 +35,9 @@ describe("CuiFileService", () => {
             expect(filename).toEqual("report.json");
             expect(readFile("report.json").toString()).toEqual(PAYLOAD);
         });
+    });
 
+    describe("when the cover response cannot be used", () => {
         it("Should fail on an unexpected backend error", async () => {
             mockAxiosGetError(COVER_URL, 500, { message: "boom" });
 
@@ -49,17 +51,12 @@ describe("CuiFileService", () => {
             await expect(cuiFileService.writeToFileWithGivenName(PAYLOAD, "empty-cover.json")).rejects.toThrow(FatalError);
             expect(() => accessSync(resolve(process.cwd(), "empty-cover.json"))).toThrow();
         });
-    });
 
-    describe("when the content is unclassified", () => {
-        it("Should only prefix the filename and write no cover sheet", async () => {
+        it("Should fail when the backend answers with no content", async () => {
             mockAxiosGetWithStatus(COVER_URL, 204, "");
 
-            const filename = await cuiFileService.writeToFileWithGivenName(PAYLOAD, "packages.json");
-
-            expect(filename).toEqual("Unclassified - packages.json");
-            expect(readFile(filename).toString()).toEqual(PAYLOAD);
-            expect(() => accessSync(resolve(process.cwd(), CuiFileService.COVER_SHEET_FILE_NAME))).toThrow();
+            await expect(cuiFileService.writeToFileWithGivenName(PAYLOAD, "no-content.json")).rejects.toThrow(FatalError);
+            expect(() => accessSync(resolve(process.cwd(), "no-content.json"))).toThrow();
         });
     });
 
@@ -116,16 +113,6 @@ describe("CuiFileService", () => {
             expect(readFile(filename).equals(exportZip)).toBe(true);
         });
 
-        it("Should only prefix the archive when the content is unclassified", async () => {
-            mockAxiosGetWithStatus(COVER_URL, 204, "");
-            const exportZip = buildExportZip();
-
-            const filename = await cuiFileService.writeZipToFileWithGivenName(exportZip, "export.zip");
-
-            expect(filename).toEqual("Unclassified - export.zip");
-            expect(readFile(filename).equals(exportZip)).toBe(true);
-        });
-
         it("Should add the cover sheet into the given archive instead of nesting it", async () => {
             mockAxiosGetWithStatus(COVER_URL, 200, coverResponse());
 
@@ -168,17 +155,6 @@ describe("CuiFileService", () => {
             expect(directoryName).toEqual("unmarked-export");
             expect(exists(directoryName, "package.json")).toBe(true);
             expect(exists(directoryName, CuiFileService.COVER_SHEET_FILE_NAME)).toBe(false);
-        });
-
-        it("Should only prefix the directory when the content is unclassified", async () => {
-            mockAxiosGetWithStatus(COVER_URL, 204, "");
-
-            const directoryName = await cuiFileService.writeDirectoryWithGivenName(writeTree, "plain-export");
-
-            expect(directoryName).toEqual("Unclassified - plain-export");
-            expect(exists(directoryName, "nodes", "node-1.json")).toBe(true);
-            expect(exists(directoryName, CuiFileService.COVER_SHEET_FILE_NAME)).toBe(false);
-            expect(exists("plain-export")).toBe(false);
         });
 
         it("Should prefix the directory and write the cover sheet into it", async () => {

--- a/tests/utls/http-requests-mock.ts
+++ b/tests/utls/http-requests-mock.ts
@@ -45,9 +45,9 @@ const mockAxios = () : void => {
             }
         }
         // CUI marking is probed on every user-facing write. Unless a test opts in,
-        // answer 204 so the CLI keeps the original filename.
+        // answer 403 so the CLI keeps the original filename.
         if (requestUrl.endsWith(CUI_PDF_COVER_PATH)) {
-            return Promise.resolve({ status: 204, data: "" });
+            return Promise.resolve({ status: 403, data: "" });
         }
         fail("API call not mocked.")
     });


### PR DESCRIPTION
#### Description

Stacked on #413. Addresses changes from [here](https://github.com/celonis/cloud-team/pull/5693) 

The CUI cover call now decides the outcome by status code only. `resolvedCuiMarking.categories` is no longer read anywhere, and there is no unclassified artifact: marked content is always classified. The CLI recognises 403 and 200, and treats everything else, including 204, as a failure.

| Cover response | Outcome | Example (`list packages --json`) |
|---|---|---|
| **403** — feature flag disabled | Unmarked, unchanged | `packages.json` |
| **200** | Classified + PDF cover | `CUI - packages.zip` containing `packages.json` and `CUI_Cover_Sheet.pdf` |
| **204**, any other status, transport failure, or a 200 without a usable cover page | Command errors, nothing written | — |

What changed against the previous behaviour:

| Cover response | Before | After |
|---|---|---|
| **403** | Unmarked | Unmarked (unchanged) |
| **204** | Unmarked | **Command errors** |
| **200** | Unclassified without categories, classified with them | **Always classified + PDF cover** |

`CuiApi` returns a `disabled` / `classified` decision instead of a nullable cover body, and `CuiFileService` switches on it. `isClassified`, every category check, and the `Unclassified - ` prefix are gone. Failures fail closed: the command errors and no artifact is left behind.

`docs/cui-marking.md` is updated to match.

#### Relevant links

- Jira: [SP-1173](https://celonis.atlassian.net/browse/SP-1173)
- https://github.com/celonis/cloud-team/pull/5693

#### Checklist

- [x] I have self-reviewed this PR
- [x] I have tested the change and proved that it works in different scenarios
- [x] I have updated docs if needed

[SP-1173]: https://celonis.atlassian.net/browse/SP-1173?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Behavior change for teams that previously got unmarked output on 204 or `Unclassified -` on 200 without categories; marking is compliance-sensitive but scope is limited to export/write paths with broad test coverage.
> 
> **Overview**
> CUI disk marking now follows **only** the cover API HTTP status, aligned with backend changes. **`403`** still means no marking; **`200`** always produces classified output (`CUI - …` plus `CUI_Cover_Sheet.pdf`). **`204`**, other statuses, transport errors, and **`200`** without a usable cover page **fail closed**—the command errors and writes nothing.
> 
> The CLI drops **`Unclassified - …`** artifacts and no longer reads **`resolvedCuiMarking.categories`**. **`CuiApi.getCuiMarking()`** returns a **`DISABLED` / `CLASSIFIED`** decision; **`CuiFileService`** branches on that. **`docs/cui-marking.md`** and tests are updated (including default CUI mock **`403`** instead of **`204`**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49ee9f466634791c808b2fbfa15a2d4a77cafcb6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->