### PR TITLE
SP-2583: Update team ownership to Astro

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,25 +1,25 @@
-*                                                 @celonis/studio-platform
+*                                                 @celonis/astro
 
-/*                                                @celonis/studio-platform
-/src                                              @celonis/studio-platform
-/src/core                                         @celonis/studio-platform
-/src/commands/configuration-management/           @celonis/astro @celonis/studio-platform
-/tests/commands/configuration-management/         @celonis/astro @celonis/studio-platform
-/src/commands/t2tc/                               @celonis/studio-platform
-/tests/commands/t2tc/                             @celonis/studio-platform
-/src/commands/profile/                            @celonis/studio-platform
-/src/commands/asset-registry/                     @celonis/astro @celonis/studio-platform
-/tests/commands/asset-registry/                   @celonis/astro @celonis/studio-platform
-/src/commands/deployment/                         @celonis/astro @celonis/studio-platform
-/tests/commands/deployment/                       @celonis/astro @celonis/studio-platform
+/*                                                @celonis/astro
+/src                                              @celonis/astro
+/src/core                                         @celonis/astro
+/src/commands/configuration-management/           @celonis/astro
+/tests/commands/configuration-management/         @celonis/astro
+/src/commands/t2tc/                               @celonis/astro
+/tests/commands/t2tc/                             @celonis/astro
+/src/commands/profile/                            @celonis/astro
+/src/commands/asset-registry/                     @celonis/astro
+/tests/commands/asset-registry/                   @celonis/astro
+/src/commands/deployment/                         @celonis/astro
+/tests/commands/deployment/                       @celonis/astro
 /src/commands/action-flows/                       @celonis/process-automation
 /tests/commands/action-flows/                     @celonis/process-automation
-/src/commands/bookmarks/                          @celonis/studio-platform
-/tests/commands/bookmarks/                        @celonis/studio-platform
+/src/commands/bookmarks/                          @celonis/astro
+/tests/commands/bookmarks/                        @celonis/astro
 /src/commands/analysis/                           @celonis/process-analytics
 /src/commands/cpm4/                               @celonis/cpm4
 /src/commands/data-pipeline/                      @Dusan-r @IvanGandacov @EktaCelonis @gorasoCelonis
-/src/commands/studio/                             @celonis/astro @celonis/studio-platform
-/tests/commands/studio/                           @celonis/astro @celonis/studio-platform
-/package.json                                     @celonis/studio-platform @aocelo @siavash-celonis
-/yarn.lock                                        @celonis/studio-platform @aocelo @siavash-celonis
+/src/commands/studio/                             @celonis/astro
+/tests/commands/studio/                           @celonis/astro
+/package.json                                     @celonis/astro @aocelo @siavash-celonis
+/yarn.lock                                        @celonis/astro @aocelo @siavash-celonis


### PR DESCRIPTION
#### Description

Routes Content CLI CODEOWNERS entries from the former Navi and Studio Platform teams to Astro so reviews reach the current owner. This does not change CLI behavior.

#### Relevant links

- Jira: [SP-2583 — Migrate Studio Platform ownership metadata to Astro and Cosmonova](https://celonis.atlassian.net/browse/SP-2583)

#### Checklist

- [x] I have self-reviewed this PR
- [ ] I have tested the change and proved that it works in different scenarios — not applicable to CODEOWNERS-only changes
- [x] I have updated docs if needed — no documentation changes are needed
